### PR TITLE
Fix round_test.go error

### DIFF
--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -572,7 +572,7 @@ func (c *Chain) AddNotarizedBlockToRound(r round.RoundI, b *block.Block) (*block
 			zap.Int64("Round", r.GetRoundNumber()),
 			zap.Int64("Round_rrs", r.GetRandomSeed()),
 			zap.Int64("Block_rrs", b.GetRoundRandomSeed()))
-		r.SetRandomSeedForNotarizedBlock(b.GetRoundRandomSeed(), c.GetMiners(r.GetRoundNumber()))
+		r.SetRandomSeedForNotarizedBlock(b.GetRoundRandomSeed(), c.GetMiners(r.GetRoundNumber()).Size())
 		r.SetTimeoutCount(b.RoundTimeoutCount)
 	}
 
@@ -951,7 +951,7 @@ func (c *Chain) SetRandomSeed(r round.RoundI, randomSeed int64) bool {
 	if r.HasRandomSeed() && randomSeed == r.GetRandomSeed() {
 		return false
 	}
-	r.SetRandomSeed(randomSeed, c.GetMiners(r.GetRoundNumber()))
+	r.SetRandomSeed(randomSeed, c.GetMiners(r.GetRoundNumber()).Size())
 	roundNumber := r.GetRoundNumber()
 	if roundNumber > c.CurrentRound {
 		c.CurrentRound = roundNumber

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -206,17 +206,17 @@ func (r *Round) GetRoundNumber() int64 {
 }
 
 //SetRandomSeed - set the random seed of the round
-func (r *Round) SetRandomSeedForNotarizedBlock(seed int64, miners *node.Pool) {
+func (r *Round) SetRandomSeedForNotarizedBlock(seed int64, minersNum int) {
 	r.setRandomSeed(seed)
 	//r.setState(RoundVRFComplete) RoundStateFinalizing??
 	r.setHasRandomSeed(true)
 	r.mutex.Lock()
-	r.computeMinerRanks(miners)
+	r.computeMinerRanks(minersNum)
 	r.mutex.Unlock()
 }
 
 //SetRandomSeed - set the random seed of the round
-func (r *Round) SetRandomSeed(seed int64, miners *node.Pool) {
+func (r *Round) SetRandomSeed(seed int64, minersNum int) {
 	if atomic.LoadUint32(&r.hasRandomSeed) == 1 {
 		return
 	}
@@ -225,7 +225,7 @@ func (r *Round) SetRandomSeed(seed int64, miners *node.Pool) {
 	r.setHasRandomSeed(true)
 
 	r.mutex.Lock()
-	r.computeMinerRanks(miners)
+	r.computeMinerRanks(minersNum)
 	r.mutex.Unlock()
 }
 
@@ -462,11 +462,15 @@ func SetupRoundSummaryDB() {
 }
 
 /*ComputeMinerRanks - Compute random order of n elements given the random seed of the round */
-func (r *Round) computeMinerRanks(miners *node.Pool) {
-	Logger.Info("waiting to compute miner ranks", zap.Any("num_miners", miners.Size()), zap.Any("round", r.Number))
+func (r *Round) computeMinerRanks(minersNum int) {
+	Logger.Info("waiting to compute miner ranks",
+		zap.Any("num_miners", minersNum),
+		zap.Any("round", r.Number))
 	seed := r.GetRandomSeed()
-	Logger.Info("compute miner ranks", zap.Any("num_miners", miners.Size()), zap.Any("round", r.Number))
-	r.minerPerm = rand.New(rand.NewSource(seed)).Perm(miners.Size())
+	Logger.Info("compute miner ranks",
+		zap.Any("num_miners", minersNum),
+		zap.Any("round", r.Number))
+	r.minerPerm = rand.New(rand.NewSource(seed)).Perm(minersNum)
 }
 
 func (r *Round) IsRanksComputed() bool {

--- a/code/go/0chain.net/chaincore/round/round.go
+++ b/code/go/0chain.net/chaincore/round/round.go
@@ -10,11 +10,11 @@ type RoundI interface {
 	GetRoundNumber() int64
 
 	GetRandomSeed() int64
-	SetRandomSeed(seed int64, miners *node.Pool)
+	SetRandomSeed(seed int64, minersNum int)
 	HasRandomSeed() bool
 	GetTimeoutCount() int
 	SetTimeoutCount(tc int) bool
-	SetRandomSeedForNotarizedBlock(seed int64, miners *node.Pool)
+	SetRandomSeedForNotarizedBlock(seed int64, minersNum int)
 
 	IsRanksComputed() bool
 	GetMinerRank(miner *node.Node) int

--- a/code/go/0chain.net/chaincore/round/round_test.go
+++ b/code/go/0chain.net/chaincore/round/round_test.go
@@ -6,11 +6,15 @@ import (
 	"testing"
 
 	"0chain.net/chaincore/node"
+	"0chain.net/core/logging"
 )
+
+func init() {
+	logging.InitLogging("testing")
+}
 
 func TestRoundStableRandomization(t *testing.T) {
 	r := Round{Number: 1234}
-	r.SetRandomSeed(2009)
 	pool := node.NewPool(node.NodeTypeMiner)
 	nd := &node.Node{Type: node.NodeTypeMiner, SetIndex: 0}
 	nd.SetID("0")
@@ -23,12 +27,13 @@ func TestRoundStableRandomization(t *testing.T) {
 	pool.AddNode(nd)
 	pool.ComputeProperties()
 	numElements := pool.Size()
+	r.SetRandomSeed(2009, numElements)
 	fmt.Printf("pool size %v\n", numElements)
-	r.ComputeMinerRanks(pool)
+
 	p1 := make([]int, numElements)
 	copy(p1, r.minerPerm)
 	p2 := make([]int, numElements)
-	r.ComputeMinerRanks(pool)
+	r.computeMinerRanks(pool.Size())
 	copy(p2, r.minerPerm)
 	if !reflect.DeepEqual(p1, p2) {
 		t.Errorf("Permutations are not the same: %v %v\n", p1, p2)


### PR DESCRIPTION
Change the second parameter of SedRandomSeed and SetRandomSeedForNotarizedBlock from *node.Pool to int,
what it needs is the pool's size.

Initialize the logging on round_test.go so that the calling of Logger would not panic.