### PR TITLE
Timeout cap

### DIFF
--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -135,8 +135,7 @@ func (tc *timeoutCounter) checkCap() {
 	}
 }
 
-// SetTimeoutCount - sets the timeout count to given nu
-//mber if it is greater
+// SetTimeoutCount - sets the timeout count to given number if it is greater
 // than existing and returns true. Else false.
 func (tc *timeoutCounter) SetTimeoutCount(count int) (set bool) {
 	tc.mutex.Lock()

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -31,6 +31,8 @@ const (
 	RoundStateFinalized
 )
 
+const timeoutCap = 10 // todo: add to 0chainl.yaml later
+
 type timeoutCounter struct {
 	mutex sync.RWMutex // async safe
 
@@ -81,7 +83,6 @@ func (tc *timeoutCounter) AddTimeoutVote(num int, id string) {
 
 // IncrementTimeoutCount - increments timeout count.
 func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
-
 	if prrs == 0 {
 		return // no PRRS, no timeout incrementation
 	}
@@ -92,6 +93,11 @@ func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
 	if tc.votes == nil {
 		tc.resetVotes() // it creates the map
 		tc.count++
+		if tc.count > timeoutCap {
+			tc.count = timeoutCap
+		}
+		Logger.Info("IncrementTimeoutCount",
+			zap.Any("timeout count", tc.count))
 		return
 	}
 
@@ -124,6 +130,11 @@ func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
 	if tc.count == from {
 		tc.count++
 	}
+	if tc.count > timeoutCap {
+		tc.count = timeoutCap
+	}
+	Logger.Info("IncrementTimeoutCount",
+		zap.Any("timeout count", tc.count))
 }
 
 // SetTimeoutCount - sets the timeout count to given number if it is greater

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -3,6 +3,7 @@ package round
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/viper"
 	"math/rand"
 	"os"
 	"runtime/pprof"
@@ -30,8 +31,6 @@ const (
 	RoundStateFinalizing
 	RoundStateFinalized
 )
-
-const timeoutCap = 10 // todo: add to 0chainl.yaml later
 
 type timeoutCounter struct {
 	mutex sync.RWMutex // async safe
@@ -130,12 +129,14 @@ func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
 }
 
 func (tc *timeoutCounter) checkCap() {
-	if tc.count > timeoutCap {
+	timeoutCap := viper.GetInt("server_chain.round_timeouts.timeout_cap")
+	if timeoutCap > 0 && tc.count > timeoutCap {
 		tc.count = timeoutCap
 	}
 }
 
-// SetTimeoutCount - sets the timeout count to given number if it is greater
+// SetTimeoutCount - sets the timeout count to given nu
+//mber if it is greater
 // than existing and returns true. Else false.
 func (tc *timeoutCounter) SetTimeoutCount(count int) (set bool) {
 	tc.mutex.Lock()

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -93,11 +93,7 @@ func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
 	if tc.votes == nil {
 		tc.resetVotes() // it creates the map
 		tc.count++
-		if tc.count > timeoutCap {
-			tc.count = timeoutCap
-		}
-		Logger.Info("IncrementTimeoutCount",
-			zap.Any("timeout count", tc.count))
+		tc.checkCap()
 		return
 	}
 
@@ -130,11 +126,13 @@ func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
 	if tc.count == from {
 		tc.count++
 	}
+	tc.checkCap()
+}
+
+func (tc *timeoutCounter) checkCap() {
 	if tc.count > timeoutCap {
 		tc.count = timeoutCap
 	}
-	Logger.Info("IncrementTimeoutCount",
-		zap.Any("timeout count", tc.count))
 }
 
 // SetTimeoutCount - sets the timeout count to given number if it is greater

--- a/docker.local/config/0chain.yaml
+++ b/docker.local/config/0chain.yaml
@@ -70,6 +70,7 @@ server_chain:
     softto_mult: 3 #multiples of mean network time (mnt)  softto = max{softo_min, softto_mult * mnt}
     round_restart_mult: 2 #number of soft timeouts before round is restarted
     round_timeout_mult: 2 # increase timeout counter by this value
+    timeout_cap: 0 # 0 indicates no cap
   transaction:
     payload:
       max_size: 98304 # bytes


### PR DESCRIPTION
Adds a new constant in `0chain.yaml`; `server_chain.round_timeouts.timeout_cap`. 
This places a cap on the size of the timeout counter `timeoutCounter.count` created by `func (tc *timeoutCounter) IncrementTimeoutCount`
The default value of `0` indicates no cap and cause no change to the current code.

This PR addresses issue https://github.com/0chain/0chain/issues/86