### PR TITLE
Revert timeout counting argument

### DIFF
--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -3,6 +3,7 @@ package round
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/viper"
 	"math/rand"
 	"os"
 	"runtime/pprof"
@@ -90,7 +91,8 @@ func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
 }
 
 func (tc *timeoutCounter) checkCap() {
-	if tc.count > timeoutCap {
+	timeoutCap := viper.GetInt("server_chain.round_timeouts.timeout_cap")
+	if timeoutCap > 0 && tc.count > timeoutCap {
 		tc.count = timeoutCap
 	}
 }

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -31,6 +31,8 @@ const (
 	RoundStateFinalized
 )
 
+const timeoutCap = 10 // todo: add to 0chainl.yaml later
+
 type timeoutCounter struct {
 	mutex sync.RWMutex // async safe
 
@@ -81,7 +83,6 @@ func (tc *timeoutCounter) AddTimeoutVote(num int, id string) {
 
 // IncrementTimeoutCount - increments timeout count.
 func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
-
 	if prrs == 0 {
 		return // no PRRS, no timeout incrementation
 	}
@@ -92,6 +93,11 @@ func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
 	if tc.votes == nil {
 		tc.resetVotes() // it creates the map
 		tc.count++
+		if tc.count > timeoutCap {
+			tc.count = timeoutCap
+		}
+		Logger.Info("IncrementTimeoutCount",
+			zap.Any("timeout count", tc.count))
 		return
 	}
 
@@ -124,6 +130,11 @@ func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
 	if tc.count == from {
 		tc.count++
 	}
+	if tc.count > timeoutCap {
+		tc.count = timeoutCap
+	}
+	Logger.Info("IncrementTimeoutCount",
+		zap.Any("timeout count", tc.count))
 }
 
 // SetTimeoutCount - sets the timeout count to given number if it is greater

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -66,7 +66,7 @@ func (tc *timeoutCounter) AddTimeoutVote(vote int, id string) {
 }
 
 // IncrementTimeoutCount - increments timeout count.
-func (tc *timeoutCounter) IncrementTimeoutCount(prrs int64, miners *node.Pool) {
+func (tc *timeoutCounter) IncrementTimeoutCount() {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
 

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -93,8 +93,6 @@ func (tc *timeoutCounter) checkCap() {
 	if tc.count > timeoutCap {
 		tc.count = timeoutCap
 	}
-	Logger.Info("IncrementTimeoutCount",
-		zap.Any("timeout count", tc.count))
 }
 
 // SetTimeoutCount - sets the timeout count to given number if it is greater

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -1384,8 +1384,7 @@ func (mc *Chain) restartRound(ctx context.Context) {
 		// (previous round random seed required for it)
 		if xrhnb == nil {
 			xr.Restart()
-			xr.IncrementTimeoutCount(mc.getRoundRandomSeed(i-1),
-				mc.GetMiners(i))
+			xr.IncrementTimeoutCount()
 			mc.RedoVrfShare(ctx, xr)
 			return // the round has restarted <===================== [exit loop]
 		}

--- a/docker.local/config/0chain.yaml
+++ b/docker.local/config/0chain.yaml
@@ -70,6 +70,7 @@ server_chain:
     softto_mult: 3 #multiples of mean network time (mnt)  softto = max{softo_min, softto_mult * mnt}
     round_restart_mult: 2 #number of soft timeouts before round is restarted
     round_timeout_mult: 2 # increase timeout counter by this value
+    timeout_cap: 0 # 0 indicates no cap
   transaction:
     payload:
       max_size: 98304 # bytes


### PR DESCRIPTION
The reverts back to a previous algorithm of timeout counting.
It also provides a cap on the size of the timeout counter timeoutCounter.count created by func (tc *timeoutCounter) IncrementTimeoutCount.

It addresses issue https://github.com/0chain/0chain/issues/86 and is an alternative to PR https://github.com/0chain/0chain/pull/90

<details>
  <summary>Model of timeout argument</summary>
The key function is `Incr()`  

  ```go
package main
​
import (
	crand "crypto/rand"
	"fmt"
	"log"
	"math/rand"
	"os"
	"os/signal"
	"sync"
	"time"
)
​
var list []*Node
​
type Node struct {
	id string
​
	sync.Mutex
	count int
	skip  int
	voted map[string]struct{}
	votes map[int]int
}
​
func newNode(i int) (n *Node) {
	n = new(Node)
	n.id = fmt.Sprintf("%0d", i)
	n.resetVotes()
	return
}
​
func (n *Node) resetVotes() {
	n.voted = make(map[string]struct{})
	n.votes = make(map[int]int)
}
​
func (n *Node) isVoted(id string) (ok bool) {
	_, ok = n.voted[id]
	return
}
​
func (n *Node) AddVote(id string, vote int) {
	n.Lock()
	defer n.Unlock()
​
	if n.isVoted(id) {
		return
	}
​
	n.voted[id] = struct{}{}
	n.votes[vote]++
	return
}
​
func (n *Node) Incr() {
	n.Lock()
	defer n.Unlock()
​
	var mostVotes, mostTimeout int = 0, n.count
	for k, v := range n.votes {
		if v > mostVotes || (v == mostVotes && k > mostTimeout) {
			mostVotes = v
			mostTimeout = k
		}
	}
​
	n.resetVotes() // for next voting
​
	if mostTimeout > n.count {
		n.count = mostTimeout + 1 // increase by an external vote
		return
	}
​
	n.count++ // increment own
}
​
func (n *Node) Set(c int) {
	n.Lock()
	defer n.Unlock()
​
	n.count = c
}
​
func (n *Node) Get() int {
	n.Lock()
	defer n.Unlock()
​
	return n.count
}
​
func (n *Node) process() {
	var rnd = getRand()
	n.count = rnd.Intn(100) // start from random in [0; 100) range
	n.skip = n.count        // the same
​
	var delay = time.Millisecond * time.Duration(rnd.Intn(3000))
​
	fmt.Println("=>", n.id, "starts from", n.count, "with delay", delay.String())
​
	time.Sleep(delay) // start with a delay
	for {
		select {
		case <-time.After(3 * time.Second):
			// increment and redo VRFS
			n.Incr()
			for _, x := range list {
				if x.id == n.id {
					continue // skip self
				}
				x.AddVote(n.id, n.count)
			}
			// filter nodes with not the same count
			var got int
			for _, x := range list {
				if x.id == n.id {
					continue // skip self
				}
				if x.Get() != n.Get() {
					continue
				}
				got++
			}
			fmt.Printf("-> %s: got %d/%d (%d)\n", n.id, got+1, len(list), n.Get())
		}
​
	}
}
​
func waitSigInt() os.Signal {
	var sigc = make(chan os.Signal, 2)
	signal.Notify(sigc, os.Interrupt)
	return <-sigc
}
​
func getRand() *rand.Rand {
	var big, err = crand.Prime(crand.Reader, 64)
	if err != nil {
		log.Fatal(err)
	}
	// the seed is OK, but the math/rand gives
	// bad randomization regardless the seed
	var seed = big.Int64()
	return rand.New(rand.NewSource(seed))
}
​
func main() {
​
	const N = 100
	for i := 0; i < N; i++ {
		var nn = newNode(i)
		go nn.process()
		list = append(list, nn)
	}
​
	fmt.Println("got signal", waitSigInt(), "exiting...")
}
  ```

  </details>