### PR TITLE
state_context.go fix for smartcontgract/storatec

### DIFF
--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -227,25 +227,34 @@ func (sc *StateContext) GetSignatureScheme() encryption.SignatureScheme {
 }
 
 func (sc *StateContext) GetTrieNode(key datastore.Key) (util.Serializable, error) {
-	if encryption.IsHash(key) {
+
+	key_hash := encryption.Hash(key)
+
+	if !encryption.IsHash(key_hash) {
 		return nil, common.NewError("failed to get trie node", "key is too short")
 	}
-	return sc.state.GetNodeValue(util.Path(encryption.Hash(key)))
+	return sc.state.GetNodeValue(util.Path(key_hash))
 }
 
 func (sc *StateContext) InsertTrieNode(key datastore.Key, node util.Serializable) (datastore.Key, error) {
-	if encryption.IsHash(key) {
+	
+	key_hash := encryption.Hash(key)
+	
+	if !encryption.IsHash(key_hash) {
 		return "", common.NewError("failed to get trie node", "key is too short")
 	}
-	byteKey, err := sc.state.Insert(util.Path(encryption.Hash(key)), node)
+	byteKey, err := sc.state.Insert(util.Path(key_hash), node)
 	return datastore.Key(byteKey), err
 }
 
 func (sc *StateContext) DeleteTrieNode(key datastore.Key) (datastore.Key, error) {
-	if encryption.IsHash(key) {
+
+	key_hash := encryption.Hash(key)
+
+	if !encryption.IsHash(key_hash) {
 		return "", common.NewError("failed to get trie node", "key is too short")
 	}
-	byteKey, err := sc.state.Delete(util.Path(encryption.Hash(key)))
+	byteKey, err := sc.state.Delete(util.Path(key_hash))
 	return datastore.Key(byteKey), err
 }
 

--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -231,7 +231,7 @@ func (sc *StateContext) GetTrieNode(key datastore.Key) (util.Serializable, error
 	key_hash := encryption.Hash(key)
 
 	if !encryption.IsHash(key_hash) {
-		return nil, common.NewError("failed to get trie node", "key is too short")
+		return nil, common.NewError("Failed to GetTrieNode", "key must be a hexadecimal hash")
 	}
 	return sc.state.GetNodeValue(util.Path(key_hash))
 }
@@ -241,7 +241,7 @@ func (sc *StateContext) InsertTrieNode(key datastore.Key, node util.Serializable
 	key_hash := encryption.Hash(key)
 	
 	if !encryption.IsHash(key_hash) {
-		return "", common.NewError("failed to get trie node", "key is too short")
+		return "", common.NewError("Failed to InsertTrieNode", "key must be a hexadecimal hash")
 	}
 	byteKey, err := sc.state.Insert(util.Path(key_hash), node)
 	return datastore.Key(byteKey), err
@@ -252,7 +252,7 @@ func (sc *StateContext) DeleteTrieNode(key datastore.Key) (datastore.Key, error)
 	key_hash := encryption.Hash(key)
 
 	if !encryption.IsHash(key_hash) {
-		return "", common.NewError("failed to get trie node", "key is too short")
+		return "", common.NewError("failed to DeleteTrieNode", "key must be a hexadecimal hash")
 	}
 	byteKey, err := sc.state.Delete(util.Path(key_hash))
 	return datastore.Key(byteKey), err

--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -5,7 +5,6 @@ import (
 	"0chain.net/chaincore/config"
 	"0chain.net/chaincore/state"
 	"0chain.net/chaincore/transaction"
-	"0chain.net/core/common"
 	"0chain.net/core/datastore"
 	"0chain.net/core/encryption"
 	"0chain.net/core/util"
@@ -227,33 +226,18 @@ func (sc *StateContext) GetSignatureScheme() encryption.SignatureScheme {
 }
 
 func (sc *StateContext) GetTrieNode(key datastore.Key) (util.Serializable, error) {
-
 	key_hash := encryption.Hash(key)
-
-	if !encryption.IsHash(key_hash) {
-		return nil, common.NewError("Failed to GetTrieNode", "key must be a hexadecimal hash")
-	}
 	return sc.state.GetNodeValue(util.Path(key_hash))
 }
 
 func (sc *StateContext) InsertTrieNode(key datastore.Key, node util.Serializable) (datastore.Key, error) {
-	
 	key_hash := encryption.Hash(key)
-	
-	if !encryption.IsHash(key_hash) {
-		return "", common.NewError("Failed to InsertTrieNode", "key must be a hexadecimal hash")
-	}
 	byteKey, err := sc.state.Insert(util.Path(key_hash), node)
 	return datastore.Key(byteKey), err
 }
 
 func (sc *StateContext) DeleteTrieNode(key datastore.Key) (datastore.Key, error) {
-
 	key_hash := encryption.Hash(key)
-
-	if !encryption.IsHash(key_hash) {
-		return "", common.NewError("failed to DeleteTrieNode", "key must be a hexadecimal hash")
-	}
 	byteKey, err := sc.state.Delete(util.Path(key_hash))
 	return datastore.Key(byteKey), err
 }


### PR DESCRIPTION
This fixes  an incompatibility between the GetKey functions in the file:
https://github.com/0chain/0chain/blob/master/code/go/0chain.net/smartcontract/storagesc/models.go

and the IsHash function:
https://github.com/0chain/0chain/blob/378cc81404ca6e4dfab81eab2a432d174aaaf074/code/go/0chain.net/core/encryption/hash.go#L22

IsHash wants HASH_LENGTH = 32
But GetKey functions add an arbitrary number of bytes to the HASH_LENGTH.

```
func (sn *StorageAllocation) GetKey(globalKey string) datastore.Key {
	return datastore.Key(globalKey + sn.ID)
}
```

Regression tests were made:
create allocation
upload file to allocation.
./zbox listallocations
