### PR TITLE
Fixed initial state panic for non genesis miners.

### DIFF
--- a/code/go/0chain.net/miner/miner/main.go
+++ b/code/go/0chain.net/miner/miner/main.go
@@ -98,10 +98,7 @@ func main() {
 	}
 
 	initStates := state.NewInitStates()
-	err = initStates.Read(*initialStatesFile)
-	if err != nil {
-		Logger.Panic("Failed to read initialStates", zap.Any("Error", err))
-	}
+	initStateErr := initStates.Read(*initialStatesFile)
 
 	// if there's no magic_block_file commandline flag, use configured then
 	if *magicBlockFile == "" {
@@ -146,6 +143,10 @@ func main() {
 		node.Self.Underlying().N2NHost = n2nHostName
 		node.Self.Underlying().Port = portNum
 		node.Self.Underlying().Path = path
+	} else {
+		if initStateErr != nil {
+			Logger.Panic("Failed to read initialStates", zap.Any("Error", initStateErr))
+		}
 	}
 
 	if node.Self.Underlying().GetKey() == "" {

--- a/code/go/0chain.net/sharder/sharder/main.go
+++ b/code/go/0chain.net/sharder/sharder/main.go
@@ -145,10 +145,7 @@ func main() {
 	}
 
 	initStates := state.NewInitStates()
-	err = initStates.Read(*initialStatesFile)
-	if err != nil {
-		Logger.Panic("Failed to read initialStates", zap.Any("Error", err))
-	}
+	initStateErr := initStates.Read(*initialStatesFile)
 
 	// if there's no magic_block_file commandline flag, use configured then
 	if *magicBlockFile == "" {
@@ -197,6 +194,10 @@ func main() {
 		selfNode.Port = portNum
 		selfNode.Type = node.NodeTypeSharder
 		selfNode.Path = path
+	} else {
+		if initStateErr != nil {
+			Logger.Panic("Failed to read initialStates", zap.Any("Error", initStateErr))
+		}
 	}
 	if selfNode.Type != node.NodeTypeSharder {
 		Logger.Panic("node not configured as sharder")


### PR DESCRIPTION
## Premise
Right now the code panics if the initial_state.yaml isn't there. However, miners and sharpers joining the network have no need for the file to exist. The changes move the panic so only genesis miners will panic without the file.

## Changes
- When reading the initial state from the file the initStateErr is used for the error rather than err.
- The initStateErr is used only if the node is in the genesis and causes a panic.