### PR TITLE
Fix sharder panic when nodes list contains nil value

### DIFF
--- a/code/go/0chain.net/chaincore/chain/protocol_view_change.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change.go
@@ -180,6 +180,10 @@ func (mc *Chain) isRegisteredEx(getStatePath func(n *node.Node) string,
 	}
 
 	for _, miner := range allNodesList.Nodes {
+		if miner == nil {
+			continue
+		}
+
 		if miner.ID == selfNodeKey {
 			return true
 		}


### PR DESCRIPTION
Sharders will panic in `isRegisteredEx` method when there are nil value in the nodes list acquired from network. 