### PR TITLE
Minersc payFes: fix sharder delegate reward and view change interest

### DIFF
--- a/code/go/0chain.net/smartcontract/minersc/READEME.md
+++ b/code/go/0chain.net/smartcontract/minersc/READEME.md
@@ -113,7 +113,8 @@ min/max_stake out of this SC boundary.
 #### Interest rate.
 
 Interest rate is % (value in [0; 1) range) that used to calculate interests of
-stake holders. The interests payed every view change.
+stake holders. The interest is payed periodically, on rounds that are a multiple of
+the `sc.yaml minersc.reward_round_frequency` settings.
 
 The formula
 ```
@@ -255,12 +256,12 @@ of all offline nodes returning tokens back.
     ```
     for run in {1..10}; do ./zwallet faucet --methodName pour --input “{Pay day}”; done
     ```
-    This takes a while.
+   This takes a while.
 4. Determine ID of the wallet
     ```
     cat ~/.zcn/wallet.json
     ```
-    The "client_id" field is the wallet ID.
+   The "client_id" field is the wallet ID.
 5. Check out Miner SC configurations to determine min_stake and max_sake of SC.
 6. Configure 5th miner (file `docker.local/config/0chain.yaml`)
     ```
@@ -271,16 +272,16 @@ of all offline nodes returning tokens back.
     max_stake: 10.0
     ```
 7. Start the 5th miner and wait some time to let the miner register in Miner SC.
-    Export the miner 5 ID to use in the commands
+   Export the miner 5 ID to use in the commands
     ```
     export MINER5=53add50ff9501014df2cbd698c673f85e5785281cebba8772a64a6e74057d328
     ```
-    Wait view change to let the 5th miner join blockchain.
+   Wait view change to let the 5th miner join blockchain.
 8. Stake 10 tokens for the 5th miner
     ```
     ./zwallet mn-lock --id $MINER5 --tokens 10.0
     ```
-    end export returned pool id
+   end export returned pool id
     ```
     export POOL=<the returned pool ID>
     ```

--- a/code/go/0chain.net/smartcontract/minersc/fees.go
+++ b/code/go/0chain.net/smartcontract/minersc/fees.go
@@ -1,13 +1,11 @@
 package minersc
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 
 	"0chain.net/chaincore/block"
 	cstate "0chain.net/chaincore/chain/state"
-	"0chain.net/chaincore/config"
 	"0chain.net/chaincore/node"
 	sci "0chain.net/chaincore/smartcontractinterface"
 	"0chain.net/chaincore/state"
@@ -18,10 +16,6 @@ import (
 	. "0chain.net/core/logging"
 	"github.com/rcrowley/go-metrics"
 	"go.uber.org/zap"
-)
-
-var (
-	ErrExecutionStatsNotFound = errors.New("SmartContractExecutionStats stat not found")
 )
 
 func (msc *MinerSmartContract) activatePending(mn *MinerNode) {
@@ -96,7 +90,7 @@ func (msc *MinerSmartContract) deletePoolFromUserNode(delegateID, nodeID,
 }
 
 func (msc *MinerSmartContract) emptyPool(mn *MinerNode,
-	pool *sci.DelegatePool, round int64, balances cstate.StateContextI) (
+	pool *sci.DelegatePool, _ int64, balances cstate.StateContextI) (
 	resp string, err error) {
 
 	mn.TotalStaked -= int64(pool.Balance)
@@ -306,7 +300,7 @@ func (msc *MinerSmartContract) adjustViewChange(gn *GlobalNode,
 }
 
 func (msc *MinerSmartContract) payFees(t *transaction.Transaction,
-	inputData []byte, gn *GlobalNode, balances cstate.StateContextI) (
+	_ []byte, gn *GlobalNode, balances cstate.StateContextI) (
 	resp string, err error) {
 
 	var pn *PhaseNode
@@ -393,13 +387,13 @@ func (msc *MinerSmartContract) payFees(t *transaction.Transaction,
 	)
 
 	if mn.numActiveDelegates() == 0 {
-		iresp, err = msc.payMiner(charger+restr, chargef+restf, mn, block, gn, balances)
+		iresp, err = msc.payNode(charger+restr, chargef+restf, mn, gn, balances)
 		if err != nil {
 			return "", err
 		}
 		resp += iresp
 	} else {
-		iresp, err = msc.payMiner(charger, chargef, mn, block, gn, balances)
+		iresp, err = msc.payNode(charger, chargef, mn, gn, balances)
 		if err != nil {
 			return "", err
 		}
@@ -416,7 +410,7 @@ func (msc *MinerSmartContract) payFees(t *transaction.Transaction,
 		resp += iresp
 	}
 	// pay and mint rest for block sharders
-	iresp, err = msc.paySharders(sharderf, sharderr, block, gn, balances)
+	iresp, err = msc.payShardersAndDelegates(sharderf, sharderr, block, gn, balances)
 	if err != nil {
 		return "", err
 	}
@@ -428,22 +422,15 @@ func (msc *MinerSmartContract) payFees(t *transaction.Transaction,
 			"saving generator node: %v", err)
 	}
 
-	// view change stuff, Either run on view change or round reward frequency
-	if config.DevConfiguration.ViewChange {
-		if block.Round == gn.ViewChange {
-			var mb = balances.GetBlock().MagicBlock
-			err = msc.viewChangePoolsWork(gn, mb, block.Round, balances)
-			if err != nil {
-				return "", err
-			}
-		}
-	} else if gn.RewardRoundFrequency != 0 && block.Round%gn.RewardRoundFrequency == 0 {
+	if gn.RewardRoundFrequency != 0 && block.Round%gn.RewardRoundFrequency == 0 {
 		var mb = balances.GetLastestFinalizedMagicBlock().MagicBlock
 		if mb != nil {
 			err = msc.viewChangePoolsWork(gn, mb, block.Round, balances)
 			if err != nil {
 				return "", err
 			}
+		} else {
+			return "", common.NewError("pay fees", "cannot find latest magic bock")
 		}
 	}
 
@@ -590,7 +577,7 @@ func (msc *MinerSmartContract) getBlockSharders(block *block.Block,
 }
 
 // pay fees and mint sharders
-func (msc *MinerSmartContract) paySharders(fee, mint state.Balance,
+func (msc *MinerSmartContract) payShardersAndDelegates(fee, mint state.Balance,
 	block *block.Block, gn *GlobalNode, balances cstate.StateContextI) (
 	resp string, err error) {
 
@@ -607,23 +594,40 @@ func (msc *MinerSmartContract) paySharders(fee, mint state.Balance,
 
 	// part for every sharder
 	for _, sh := range sharders {
-
 		var sresp string
-		sresp, err = msc.payStakeHolders(partf, sh, true, balances)
-		if err != nil {
-			return "", common.NewErrorf("pay_fees/pay_sharders",
-				"paying block sharder fees: %v", err)
+		if sh.numActiveDelegates() > 0 {
+			var delegateBr = state.Balance(float64(partm) * (1 - sh.ServiceCharge))
+			var delegateFees = state.Balance(float64(partf) * (1 - sh.ServiceCharge))
+			var sharderBR = state.Balance(float64(partm) * sh.ServiceCharge)
+			var sharderFees = state.Balance(float64(partf) * sh.ServiceCharge)
+
+			sresp, err = msc.payNode(sharderBR, sharderFees, sh, gn, balances)
+			if err != nil {
+				return "", err
+			}
+			resp += sresp
+
+			sresp, err = msc.payStakeHolders(delegateFees, sh, true, balances)
+			if err != nil {
+				return "", common.NewErrorf("pay_fees/pay_sharders",
+					"paying block sharder fees: %v", err)
+			}
+
+			resp += sresp
+
+			sresp, err = msc.mintStakeHolders(delegateBr, sh, gn, true, balances)
+			if err != nil {
+				return "", common.NewErrorf("pay_fees/mint_sharders",
+					"minting block sharder reward: %v", err)
+			}
+			resp += sresp
+		} else {
+			sresp, err = msc.payNode(partm, partf, sh, gn, balances)
+			if err != nil {
+				return "", err
+			}
+			resp += sresp
 		}
-
-		resp += sresp
-
-		sresp, err = msc.mintStakeHolders(partm, sh, gn, true, balances)
-		if err != nil {
-			return "", common.NewErrorf("pay_fees/mint_sharders",
-				"minting block sharder reward: %v", err)
-		}
-
-		resp += sresp
 
 		if err = sh.save(balances); err != nil {
 			return "", common.NewErrorf("pay_fees/pay_sharders",
@@ -634,13 +638,12 @@ func (msc *MinerSmartContract) paySharders(fee, mint state.Balance,
 	return
 }
 
-// pay miner's charge
-func (msc *MinerSmartContract) payMiner(reward, fee state.Balance, mn *MinerNode,
-	block *block.Block, gn *GlobalNode, balances cstate.StateContextI) (
+func (msc *MinerSmartContract) payNode(reward, fee state.Balance, mn *MinerNode,
+	gn *GlobalNode, balances cstate.StateContextI) (
 	resp string, err error) {
 
 	if reward != 0 {
-		Logger.Info("pay miner service charge",
+		Logger.Info("pay "+mn.NodeType.String()+" service charge",
 			zap.Any("delegate_wallet", mn.DelegateWallet),
 			zap.Any("service_charge_reward", reward))
 
@@ -653,7 +656,7 @@ func (msc *MinerSmartContract) payMiner(reward, fee state.Balance, mn *MinerNode
 		resp += string(mint.Encode())
 	}
 	if fee != 0 {
-		Logger.Info("pay miner service charge",
+		Logger.Info("pay "+mn.NodeType.String()+" service charge",
 			zap.Any("delegate_wallet", mn.DelegateWallet),
 			zap.Any("service_charge_fee", fee))
 


### PR DESCRIPTION
Fix a couple of issues in fees.go.

* The service change for sharder delegates was wrong. The service charge was not being removed. This was also fixed in PR https://github.com/0chain/0chain/pull/117 but that came with extensive refactoring. This aims to change as little as possible.
* Interest payments not being paid. Now interest payments are paid every multiple of `sc.minersc.reward_round_frequency`, this is the same irrespective of the `view_change setting`. There is an alternative approach of paying interest when `0chian.view_change = true` which will mostly work out the same.

Resolves issue indicated by unit test PR https://github.com/0chain/0chain/pull/137 which cannot be merged until this PR is merged.