### PR TITLE
replaced sharderKeys with mpkKeys: #146

### DIFF
--- a/code/go/0chain.net/chaincore/block/magic_block_entity.go
+++ b/code/go/0chain.net/chaincore/block/magic_block_entity.go
@@ -82,7 +82,7 @@ func (mb *MagicBlock) GetHashBytes() []byte {
 		mpkKeys = append(mpkKeys, k)
 	}
 	sort.Strings(mpkKeys)
-	for _, v := range sharderKeys {
+	for _, v := range mpkKeys {
 		data = append(data, []byte(v)...)
 	}
 	data = append(data, []byte(strconv.Itoa(mb.T))...)


### PR DESCRIPTION
The GetHashBytes() method of MagicBlock struct seems not to use mpkKeys to prepare data for generating correct hash. Instead it uses sharderKeys twice, which doesn't look like the intention of the author.
Following is the reported issue: https://github.com/0chain/0chain/issues/146