### PR TITLE
Miner sharder dev build flag #149

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@
 awsnet
 docker.local/miner*
 docker.local/sharder*
-**/pkg

--- a/docker.local/bin/build.miners.sh
+++ b/docker.local/bin/build.miners.sh
@@ -9,32 +9,37 @@ DOCKERDIR="$ROOT/docker.local/build.miner"
 DOCKERFILE="$DOCKERDIR/Dockerfile"
 DOCKERCOMPOSE="$DOCKERDIR/docker-compose.yml"
 
+APP_DIR="$ROOT/code/go/0chain.net/miner/miner"
+
 if [[ "$@" == *"--dev"* ]]
 then
-    echo -e "\nDevelopment mode: building miner locally\n"
+    cd $APP_DIR
+    echo "Building: --dev mode: vendoring dependencies"
+    rm -rf vendor
+    go mod vendor
+    # libzstd: start: to rebuild inside container
+    dstdir="vendor/github.com/valyala"
+    rm -r $dstdir/*
+    srcdir="$GOPATH/pkg/mod/github.com/valyala"
+    cp -r "$srcdir/$(ls $srcdir | tail -n1)" $dstdir/gozstd
+    chmod -R +w vendor
+    # libzstd: end
+    cd $ROOT
+fi
 
-    cd "$ROOT/code/go/0chain.net/miner/miner"
-    go build -v -tags "bn256 development" \
-        -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
+docker build --build-arg GIT_COMMIT=$GIT_COMMIT -f $DOCKERFILE -t miner .
 
-    sed 's,%COPY%,COPY ./code,g' "$DOCKERFILE.template" > "$DOCKERFILE"
-
-    cd "$ROOT"
-    docker build --build-arg GIT_COMMIT=$GIT_COMMIT \
-        -f "$DOCKERFILE" . -t miner --build-arg DEV=yes
-else
-    echo -e "\nProduction mode: building miner in Docker\n"
-
-    sed 's,%COPY%,COPY --from=miner_build $APP_DIR,g' "$DOCKERFILE.template" > "$DOCKERFILE"
-
-    cd "$ROOT"
-    docker build --build-arg GIT_COMMIT=$GIT_COMMIT \
-        -f "$DOCKERFILE" . -t miner --build-arg DEV=no
+if [[ "$@" == *"--dev"* ]]
+then
+    echo "Build complete: cleaning vendored dependencies"
+    cd $APP_DIR
+    rm -rf vendor
+    cd $ROOT
 fi
 
 for i in $(seq 1 5);
 do
-    MINER=$i docker-compose -p miner$i -f "$DOCKERCOMPOSE" build --force-rm
+  MINER=$i docker-compose -p miner$i -f $DOCKERCOMPOSE build --force-rm
 done
 
-"$ROOT"/docker.local/bin/sync_clock.sh
+docker.local/bin/sync_clock.sh

--- a/docker.local/bin/build.sharders.sh
+++ b/docker.local/bin/build.sharders.sh
@@ -1,14 +1,45 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 GIT_COMMIT=$(git rev-list -1 HEAD)
 echo $GIT_COMMIT
 
-docker build --build-arg GIT_COMMIT=$GIT_COMMIT -f docker.local/build.sharder/Dockerfile . -t sharder
+ROOT="$(git rev-parse --show-toplevel)"
+DOCKERDIR="$ROOT/docker.local/build.sharder"
+DOCKERFILE="$DOCKERDIR/Dockerfile"
+DOCKERCOMPOSE="$DOCKERDIR/docker-compose.yml"
+
+APP_DIR="$ROOT/code/go/0chain.net/sharder/sharder"
+
+if [[ "$@" == *"--dev"* ]]
+then
+    cd $APP_DIR
+    echo "Building: --dev mode: vendoring dependencies"
+    rm -rf vendor
+    go mod vendor
+    # libzstd: start: to rebuild inside container
+    dstdir="vendor/github.com/valyala"
+    rm -r $dstdir/*
+    srcdir="$GOPATH/pkg/mod/github.com/valyala"
+    cp -r "$srcdir/$(ls $srcdir | tail -n1)" $dstdir/gozstd
+    chmod -R +w vendor
+    # libzstd: end
+    cd $ROOT
+fi
+
+docker build --build-arg GIT_COMMIT=$GIT_COMMIT -f $DOCKERFILE -t sharder .
+
+if [[ "$@" == *"--dev"* ]]
+then
+    echo "Build complete: cleaning vendored dependencies"
+    cd $APP_DIR
+    rm -rf vendor
+    cd $ROOT
+fi
 
 for i in $(seq 1 3);
 do
-  SHARDER=$i docker-compose -p sharder$i -f docker.local/build.sharder/docker-compose.yml build --force-rm
+  SHARDER=$i docker-compose -p sharder$i -f $DOCKERCOMPOSE build --force-rm
 done
 
 docker.local/bin/sync_clock.sh

--- a/docker.local/bin/start.b0miner.sh
+++ b/docker.local/bin/start.b0miner.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 PWD=`pwd`

--- a/docker.local/bin/start.b0sharder.sh
+++ b/docker.local/bin/start.b0sharder.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 PWD=`pwd`

--- a/docker.local/build.miner/Dockerfile
+++ b/docker.local/build.miner/Dockerfile
@@ -1,0 +1,35 @@
+# Compile the miner in an un-tagged image so the final, tagged image can be smaller:
+FROM zchain_build_base as miner_build
+ENV GO111MODULE=on
+
+# Add the source code:
+COPY code/go/0chain.net /0chain.net
+
+# Set workdir
+WORKDIR /0chain.net/miner/miner
+
+# Build libzstd:
+# FIXME: Change this after https://github.com/valyala/gozstd/issues/6 is fixed.
+# FIXME: Also, is there a way we can move this to zchain_build_base?
+
+RUN [[ -d vendor ]] || ( \
+    go mod download && \
+    go mod vendor -v && \
+    dir=github.com/valyala/gozstd && \
+    rm -r vendor/$dir && \
+    mv $GOPATH/pkg/mod/$dir* vendor/$dir )
+
+RUN cd vendor/github.com/valyala/gozstd* && \
+    chmod -R +w . && \
+    make clean libzstd.a
+
+# Build it:
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+RUN go build -mod vendor -v -tags bn256 -gcflags "all=-N -l" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
+
+# Copy the build artifact into a minimal runtime image:
+FROM zchain_run_base
+ENV APP_DIR=/0chain
+WORKDIR $APP_DIR
+COPY --from=miner_build /0chain.net/miner/miner/miner $APP_DIR/bin/

--- a/docker.local/build.sharder/Dockerfile
+++ b/docker.local/build.sharder/Dockerfile
@@ -1,37 +1,35 @@
 # Compile the sharder in an un-tagged image so the final, tagged image can be smaller:
 FROM zchain_build_base as sharder_build
-ENV SRC_DIR=/0chain
 ENV GO111MODULE=on
 
-# Download the dependencies:
-# Will be cached if we don't change mod/sum files
-COPY ./code/go/0chain.net/core/go.mod            ./code/go/0chain.net/core/go.sum            $SRC_DIR/go/0chain.net/core/
-COPY ./code/go/0chain.net/chaincore/go.mod       ./code/go/0chain.net/chaincore/go.sum       $SRC_DIR/go/0chain.net/chaincore/
-COPY ./code/go/0chain.net/smartcontract/go.mod   ./code/go/0chain.net/smartcontract/go.sum   $SRC_DIR/go/0chain.net/smartcontract/
-COPY ./code/go/0chain.net/conductor/go.mod       ./code/go/0chain.net/conductor/go.sum       $SRC_DIR/go/0chain.net/conductor/
-COPY ./code/go/0chain.net/sharder/go.mod         ./code/go/0chain.net/sharder/go.sum         $SRC_DIR/go/0chain.net/sharder/
-COPY ./code/go/0chain.net/sharder/sharder/go.mod ./code/go/0chain.net/sharder/sharder/go.sum $SRC_DIR/go/0chain.net/sharder/sharder/
-WORKDIR $SRC_DIR/go/0chain.net/sharder/sharder
-RUN go mod download
+# Add the source code:
+COPY code/go/0chain.net /0chain.net
+
+# Set workdir
+WORKDIR /0chain.net/sharder/sharder
 
 # Build libzstd:
 # FIXME: Change this after https://github.com/valyala/gozstd/issues/6 is fixed.
 # FIXME: Also, is there a way we can move this to zchain_build_base?
-RUN cd $GOPATH/pkg/mod/github.com/valyala/gozstd* && \
+
+RUN [[ -d vendor ]] || ( \
+    go mod download && \
+    go mod vendor -v && \
+    dir=github.com/valyala/gozstd && \
+    rm -r vendor/$dir && \
+    mv $GOPATH/pkg/mod/$dir* vendor/$dir )
+
+RUN cd vendor/github.com/valyala/gozstd* && \
     chmod -R +w . && \
     make clean libzstd.a
-
-# Add the source code:
-COPY ./code/go/0chain.net $SRC_DIR/go/0chain.net
 
 # Build it:
 ARG GIT_COMMIT
 ENV GIT_COMMIT=$GIT_COMMIT
-RUN go build -v -tags bn256 -gcflags "all=-N -l" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
-
+RUN go build -mod vendor -v -tags bn256 -gcflags "all=-N -l" -ldflags "-X 0chain.net/core/build.BuildTag=$GIT_COMMIT"
 
 # Copy the build artifact into a minimal runtime image:
 FROM zchain_run_base
 ENV APP_DIR=/0chain
 WORKDIR $APP_DIR
-COPY --from=sharder_build $APP_DIR/go/0chain.net/sharder/sharder/sharder $APP_DIR/bin/
+COPY --from=sharder_build /0chain.net/sharder/sharder/sharder $APP_DIR/bin/


### PR DESCRIPTION
This change references following issue: https://github.com/0chain/0chain/issues/149

As specified in above issue, dev build logic for miner has been moved inside container. This is done by vendoring dependencies and building inside the container using -vendor flag.

Note that, the .dockerignore file had **/pkg entry. One of the vendored dependencies (minio) needed the pkg directory that included credentials. Hence, **/pkg entry needed to be removed from .dockerignore. Ignoring such directory was probably done because of some necessity. Therefore, it needs some review.