### PR TITLE
Fix MPT unit tests errors

### DIFF
--- a/code/go/0chain.net/core/util/merkle_patricia_trie_2_test.go
+++ b/code/go/0chain.net/core/util/merkle_patricia_trie_2_test.go
@@ -66,7 +66,7 @@ func TestMerkleTreeSaveToDB(t *testing.T) {
 
 	printChanges(t, mpt2.GetChangeCollector())
 
-	var err = mpt2.SaveChanges(pndb, false)
+	var err = mpt2.SaveChanges(context.TODO(), pndb, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -112,7 +112,7 @@ func TestMerkeTreePruning(t *testing.T) {
 		roots = append(roots, mpt2.GetRoot())
 		t.Logf("root(%v) = %v: changes: %v\n", origin, ToHex(mpt2.GetRoot()),
 			len(mpt2.GetChangeCollector().GetChanges()))
-		var err = mpt2.SaveChanges(pndb, false)
+		var err = mpt2.SaveChanges(context.TODO(), pndb, false)
 		if err != nil {
 			t.Error(err)
 		}
@@ -193,7 +193,7 @@ func TestMerkeTreeGetChanges(t *testing.T) {
 			ToHex(mpt2.GetRoot()), len(mpt2.GetChangeCollector().GetChanges()),
 			len(mndb.Nodes))
 
-		if err := mpt2.SaveChanges(pndb, false); err != nil {
+		if err := mpt2.SaveChanges(context.TODO(), pndb, false); err != nil {
 			panic(err)
 		}
 

--- a/code/go/0chain.net/core/util/merkle_patricia_trie_3_test.go
+++ b/code/go/0chain.net/core/util/merkle_patricia_trie_3_test.go
@@ -108,7 +108,7 @@ func TestMPT_blockGenerationFlow(t *testing.T) {
 		priorDB = blockState.GetNodeDB()
 		priorHash = blockState.GetRoot()
 
-		require.NoError(t, blockState.SaveChanges(stateDB, false))
+		require.NoError(t, blockState.SaveChanges(context.TODO(), stateDB, false))
 		mpt.SetRoot(priorHash)
 
 		// //  5. prune state

--- a/code/go/0chain.net/smartcontract/storagesc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/balances_test.go
@@ -69,6 +69,7 @@ func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer) {
 func (tb *testBalances) GetSignedTransfers() []*state.SignedTransfer {
 	return nil
 }
+func (tb *testBalances) GetChainCurrentMagicBlock() *block.MagicBlock { return nil }
 func (tb *testBalances) DeleteTrieNode(key datastore.Key) (
 	datastore.Key, error) {
 

--- a/code/go/0chain.net/smartcontract/vestingsc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/balances_test.go
@@ -33,15 +33,16 @@ func (tb *testBalances) setBalance(key datastore.Key, b state.Balance) {
 }
 
 // stubs
-func (tb *testBalances) GetBlock() *block.Block                   { return nil }
-func (tb *testBalances) GetState() util.MerklePatriciaTrieI       { return nil }
-func (tb *testBalances) GetTransaction() *transaction.Transaction { return nil }
-func (tb *testBalances) GetBlockSharders(b *block.Block) []string { return nil }
-func (tb *testBalances) Validate() error                          { return nil }
-func (tb *testBalances) GetMints() []*state.Mint                  { return nil }
-func (tb *testBalances) SetStateContext(*state.State) error       { return nil }
-func (tb *testBalances) AddMint(*state.Mint) error                { return nil }
-func (tb *testBalances) GetTransfers() []*state.Transfer          { return nil }
+func (tb *testBalances) GetBlock() *block.Block                       { return nil }
+func (tb *testBalances) GetState() util.MerklePatriciaTrieI           { return nil }
+func (tb *testBalances) GetTransaction() *transaction.Transaction     { return nil }
+func (tb *testBalances) GetBlockSharders(b *block.Block) []string     { return nil }
+func (tb *testBalances) Validate() error                              { return nil }
+func (tb *testBalances) GetMints() []*state.Mint                      { return nil }
+func (tb *testBalances) SetStateContext(*state.State) error           { return nil }
+func (tb *testBalances) AddMint(*state.Mint) error                    { return nil }
+func (tb *testBalances) GetTransfers() []*state.Transfer              { return nil }
+func (tb *testBalances) GetChainCurrentMagicBlock() *block.MagicBlock { return nil }
 func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer) {
 
 }


### PR DESCRIPTION
Fix unit test errors that caused by the new added `context.Context` parameter.