### PR TITLE
Fix getting latest finalized magic block from sharders issue

### DIFF
--- a/code/go/0chain.net/miner/miner/main.go
+++ b/code/go/0chain.net/miner/miner/main.go
@@ -382,7 +382,7 @@ func GetLatestMagicBlockFromSharders(ctx context.Context, mc *miner.Chain) (
 	case lfmb.StartingRound == cmb.StartingRound:
 		// ok, initialize the magicBlock
 	default: // magicBlock > cmb.StartingRoound, verify chain
-		err = mc.VerifyChainHistory(common.GetRootContext(), lfmb, nil)
+		err = mc.VerifyChainHistoryAndRepair(common.GetRootContext(), lfmb, nil)
 		if err != nil {
 			return
 		}

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -1523,7 +1523,7 @@ func (mc *Chain) ensureLatestFinalizedBlocks(ctx context.Context) (
 		return
 	}
 
-	if err = mc.VerifyChainHistory(ctx, rcvd, nil); err != nil {
+	if err = mc.VerifyChainHistoryAndRepair(ctx, rcvd, nil); err != nil {
 		return false, err
 	}
 	if err = mc.UpdateMagicBlock(rcvd.MagicBlock); err != nil {


### PR DESCRIPTION
The issue exists in sorting the returned latest magic blocks from sharders. The blocks may all have the same magic block StartingRound, however, the block itself may on different round. If the sharders have not been initialized or catched up with the network, they may  not have the round info. If the block with 0 round number was picked as the latest finalized magic block from sharders, then issues would occur when verify chain history. And may cause BC stuck.

The fix is rewrite the sorting function, which should take the situation of when magic block starting round are all the same into consideration. And if so, we need to compare the block's Round number then. As long as we have at least one sharder with the correct latest finalized magic block, we should be fine. Otherwise, the BC must be stuck to avoid incorrect finalized magic block.