### PR TITLE
disable broken pull request check

### DIFF
--- a/.github/workflows/push-to-gitlab.yml
+++ b/.github/workflows/push-to-gitlab.yml
@@ -1,6 +1,6 @@
 name: Push-to-GitLab
 
-on: [push, delete]
+on: #[push, delete]
 
 jobs:
   to_gitlab:


### PR DESCRIPTION
The push-to-GitLab check is broken. This PR disables it until it can be fixed.