### PR TITLE
Fix remaining issues for getting lfmb from sharders

### DIFF
--- a/code/go/0chain.net/chaincore/chain/worker.go
+++ b/code/go/0chain.net/chaincore/chain/worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	"0chain.net/chaincore/block"
@@ -555,27 +554,14 @@ type MagicBlockSaver interface {
 func (sc *Chain) UpdateLatesMagicBlockFromShardersOn(ctx context.Context,
 	mb *block.MagicBlock) (err error) {
 
-	var mbs = sc.GetLatestFinalizedMagicBlockFromShardersOn(ctx, mb)
-	if len(mbs) == 0 {
+	magicBlock := sc.GetLatestFinalizedMagicBlockFromShardersOn(ctx, mb)
+	if magicBlock == nil {
 		Logger.Warn("no new finalized magic block from sharders given",
 			zap.Strings("URLs", mb.Sharders.N2NURLs()))
 		return nil
 	}
 
-	if len(mbs) > 1 {
-		sort.Slice(mbs, func(i, j int) bool {
-			if mbs[i].StartingRound == mbs[j].StartingRound {
-				return mbs[i].Round > mbs[j].Round
-			}
-
-			return mbs[i].StartingRound > mbs[j].StartingRound
-		})
-	}
-
-	var (
-		magicBlock = mbs[0]
-		cmb        = sc.GetCurrentMagicBlock()
-	)
+	cmb := sc.GetCurrentMagicBlock()
 
 	Logger.Info("get current magic block from sharders",
 		zap.Any("number", magicBlock.MagicBlockNumber),

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -1491,8 +1491,6 @@ func (mc *Chain) ensureLatestFinalizedBlocks(ctx context.Context) (
 
 	defer mc.SetupLatestAndPreviousMagicBlocks(ctx)
 
-	// LFB
-
 	if updated, err = mc.ensureLatestFinalizedBlock(ctx); err != nil {
 		return
 	}
@@ -1500,24 +1498,15 @@ func (mc *Chain) ensureLatestFinalizedBlocks(ctx context.Context) (
 	// LFMB. The LFMB can be already update by LFMD worker (which uses 0DNS)
 	// and here we just set correct DKG.
 
-	var (
-		lfmb = mc.GetLatestFinalizedMagicBlock()
-		list = mc.GetLatestFinalizedMagicBlockFromShardersOn(ctx,
-			lfmb.MagicBlock)
+	lfmb := mc.GetLatestFinalizedMagicBlock()
+	rcvd := mc.GetLatestFinalizedMagicBlockFromShardersOn(ctx,
+		lfmb.MagicBlock)
 
-		rcvd *block.Block
-	)
-
-	mc.ensureDKG(ctx, lfmb)
-
-	if len(list) == 0 {
+	if rcvd == nil {
 		return
 	}
 
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].StartingRound > list[j].StartingRound
-	})
-	rcvd = list[0]
+	mc.ensureDKG(ctx, lfmb)
 
 	if lfmb != nil && rcvd.MagicBlockNumber <= lfmb.MagicBlockNumber {
 		return

--- a/code/go/0chain.net/miner/protocol_view_change.go
+++ b/code/go/0chain.net/miner/protocol_view_change.go
@@ -672,8 +672,7 @@ func (mc *Chain) Wait(ctx context.Context, lfb *block.Block,
 	vcdkg.N = magicBlock.N
 
 	// save DKG and MB
-
-	if err = StoreDKG(ctx, vcdkg); err != nil {
+	if err = StoreDKGSummary(ctx, vcdkg.GetDKGSummary()); err != nil {
 		return nil, common.NewErrorf("vc_wait", "saving DKG summary: %v", err)
 	}
 
@@ -738,11 +737,6 @@ func LoadMagicBlock(ctx context.Context, id string) (mb *block.MagicBlock,
 }
 
 // DKG save / load
-
-// StoreDKG in DB.
-func StoreDKG(ctx context.Context, dkg *bls.DKG) error {
-	return StoreDKGSummary(ctx, dkg.GetDKGSummary())
-}
 
 // StoreDKGSummary in DB.
 func StoreDKGSummary(ctx context.Context, summary *bls.DKGSummary) (err error) {


### PR DESCRIPTION
Get latest finalized magic block from shaders and return the block with highest magic block starting round, or block with highest round if they have the same MB starting round. Previously, it returns the the list of latest finalized magic block acquired from sharders, and do the sorting outside the function. This makes the sorting algorithm spread everywhere when the GetLastFinalizedMagicBlockFromSharder is called, and can cause unexpected issue if the sorting algorithm needs update.