### PR TITLE
Fix 0chain quickstart 0dns bls and mcl

### DIFF
--- a/quickstart/1s_2m_4b/base/paths.sh
+++ b/quickstart/1s_2m_4b/base/paths.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 
-export zChain_Root="/home/andriy/Documents/0Chain/0Chain/0Chain"
-export zDNS_Root="/home/andriy/Documents/0Chain/0Chain/0dns"
-export zBlober_Root="/home/andriy/Documents/0Chain/0Chain/blobber"
+export zChain_Root="/Users/andigo/Lab/0chain"
+export zDNS_Root="/Users/andigo/Lab/0chain.live/0dns"
+export zBlober_Root="/Users/andigo/Lab/0chain.live/blobber"
 
-export gosdk="/home/andriy/Documents/0Chain/0Chain/gosdk"
-export zCLI_Root="/home/andriy/Documents/0Chain/0Chain/zboxcli"
-export zWallet_Root="/home/andriy/Documents/0Chain/0Chain/zwalletcli"
+export gosdk="/Users/andigo/Lab/0chain.live/gosdk"
+export zCLI_Root="/Users/andigo/Lab/0chain.live/zboxcli"
+export zWallet_Root="/Users/andigo/Lab/0chain.live/zwalletcli"
 
 export zWorkflows_Base=`pwd`

--- a/quickstart/1s_2m_4b/base/paths.sh
+++ b/quickstart/1s_2m_4b/base/paths.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 
-export zChain_Root="/Users/andigo/Lab/0chain"
-export zDNS_Root="/Users/andigo/Lab/0chain.live/0dns"
-export zBlober_Root="/Users/andigo/Lab/0chain.live/blobber"
+export zChain_Root="/home/andriy/Documents/0Chain/0Chain/0Chain"
+export zDNS_Root="/home/andriy/Documents/0Chain/0Chain/0dns"
+export zBlober_Root="/home/andriy/Documents/0Chain/0Chain/blobber"
 
-export gosdk="/Users/andigo/Lab/0chain.live/gosdk"
-export zCLI_Root="/Users/andigo/Lab/0chain.live/zboxcli"
-export zWallet_Root="/Users/andigo/Lab/0chain.live/zwalletcli"
+export gosdk="/home/andriy/Documents/0Chain/0Chain/gosdk"
+export zCLI_Root="/home/andriy/Documents/0Chain/0Chain/zboxcli"
+export zWallet_Root="/home/andriy/Documents/0Chain/0Chain/zwalletcli"
 
 export zWorkflows_Base=`pwd`

--- a/quickstart/1s_2m_4b/config/1s_2m_4b/0dns/docker.local/Dockerfile
+++ b/quickstart/1s_2m_4b/config/1s_2m_4b/0dns/docker.local/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add gmp gmp-dev openssl-dev && \
     mv bls* bls && \
     make -C mcl -j $(nproc) lib/libmclbn256.so install && \
     cp mcl/lib/libmclbn256.so /usr/local/lib && \
-    make -C bls -j $(nproc) install && \
+    make MCL_DIR=../mcl -C bls -j $(nproc) install && \
     rm -R /tmp/mcl && \
     rm -R /tmp/bls
 

--- a/quickstart/1s_2m_4b/config/1s_2m_4b/blobber/docker.local/Dockerfile
+++ b/quickstart/1s_2m_4b/config/1s_2m_4b/blobber/docker.local/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add gmp gmp-dev openssl-dev && \
     mv bls* bls && \
     make -C mcl -j $(nproc) lib/libmclbn256.so install && \
     cp mcl/lib/libmclbn256.so /usr/local/lib && \
-    make -C bls -j $(nproc) install && \
+    make MCL_DIR=../mcl -C bls -j $(nproc) install && \
     rm -R /tmp/mcl && \
     rm -R /tmp/bls
 

--- a/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/build.base/Dockerfile.build_base
+++ b/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/build.base/Dockerfile.build_base
@@ -20,6 +20,6 @@ RUN apk add gmp gmp-dev openssl-dev && \
     mv bls* bls && \
     make -C mcl -j $(nproc) lib/libmclbn256.so install && \
     cp mcl/lib/libmclbn256.so /usr/local/lib && \
-    make -C bls -j $(nproc) install && \
+    make MCL_DIR=../mcl -C bls -j $(nproc) install && \
     rm -R /tmp/mcl && \
     rm -R /tmp/bls

--- a/quickstart/1s_2m_4b/config/reference/0dns/docker.local/Dockerfile
+++ b/quickstart/1s_2m_4b/config/reference/0dns/docker.local/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add gmp gmp-dev openssl-dev && \
     mv bls* bls && \
     make -C mcl -j $(nproc) lib/libmclbn256.so install && \
     cp mcl/lib/libmclbn256.so /usr/local/lib && \
-    make -C bls -j $(nproc) install && \
+    make MCL_DIR=../mcl -C bls -j $(nproc) install && \
     rm -R /tmp/mcl && \
     rm -R /tmp/bls
 

--- a/quickstart/1s_2m_4b/config/reference/blobber/docker.local/IntegrationTestsBlobberDockerfile
+++ b/quickstart/1s_2m_4b/config/reference/blobber/docker.local/IntegrationTestsBlobberDockerfile
@@ -11,7 +11,7 @@ RUN apk add gmp gmp-dev openssl-dev && \
     mv bls* bls && \
     make -C mcl -j $(nproc) lib/libmclbn256.so install && \
     cp mcl/lib/libmclbn256.so /usr/local/lib && \
-    make -C bls -j $(nproc) install && \
+    make MCL_DIR=../mcl -C bls -j $(nproc) install && \
     rm -R /tmp/mcl && \
     rm -R /tmp/bls
 


### PR DESCRIPTION
@andriykutsevol 
please, check.

why that changes? because when BSL is build, it's required to load some files from MCL repo. By default builder tries to search for the files at the nested path -  "./mcl/...". Meanwhile the docker script loads MCL and all its files at the same level, not nested to BSL, path. 

PS. why some older scripts, installing BSL/MCL tools, runs well. Because they preload the repose slightly different way. Specifically, BSL is fetched _with submodules_, in other words with MCL. And it is placed at "./mcl/..." path.
