### PR TITLE
refactored by moving locks to appropriate level and fixed race condit…

### DIFF
--- a/code/go/0chain.net/core/util/mpt_nodedb.go
+++ b/code/go/0chain.net/core/util/mpt_nodedb.go
@@ -137,7 +137,6 @@ func (mndb *MemoryNodeDB) DeleteNode(key Key) (err error) {
 func (mndb *MemoryNodeDB) MultiGetNode(keys []Key) (nodes []Node, err error) {
 	mndb.mutex.RLock()
 	defer mndb.mutex.RUnlock()
-	nodes = make([]Node, 0, len(keys))
 	for _, key := range keys {
 		node, nerr := mndb.getNode(key)
 		if nerr != nil {
@@ -454,7 +453,6 @@ func (lndb *LevelNodeDB) DeleteNode(key Key) error {
 func (lndb *LevelNodeDB) MultiGetNode(keys []Key) (nodes []Node, err error) {
 	lndb.mutex.RLock()
 	defer lndb.mutex.RUnlock()
-	nodes = make([]Node, 0, len(keys))
 	for _, key := range keys {
 		node, nerr := lndb.getNode(key)
 		if nerr != nil {


### PR DESCRIPTION
…ions in MemoryNodeDB methods: Iterate, Validate, ComputeRoot

As few exported methods in MemoryNodeDB didn't have locks while accessing map, it may lead to concurrent modification panics. Added appropriate locks at appropriate levels.