### PR TITLE
Fixed deadlock with SetNodeInfo

### DIFF
--- a/code/go/0chain.net/chaincore/node/node.go
+++ b/code/go/0chain.net/chaincore/node/node.go
@@ -595,6 +595,9 @@ func (n *Node) getTime(uri string) float64 {
 
 func (n *Node) SetNodeInfo(oldNode *Node) {
 	// Copy timers and size to new map from oldNode
+	if n == oldNode {
+		return
+	}
 	oldNode.mutex.RLock()
 	timersByURI := make(map[string]metrics.Timer, len(oldNode.TimersByURI))
 	sizeByURI := make(map[string]metrics.Histogram, len(oldNode.SizeByURI))


### PR DESCRIPTION
## Premise
When the SetNodeInfo's nodes n and oldNode are the same pointer there is a deadlock because the SetNodeInfo holds node n's mutex and defers the release. However, in the SetNodeInfo it calls GetInfo on the oldNode and GetInfo waits for the mutex to be released by SetNodeInfo.

## Changes
- When SetNodeInfo is called it first checks if the pointers are the same, and if they are it returns right away.