### PR TITLE
Fix bash in scripts

### DIFF
--- a/docker.local/bin/build.miners.sh
+++ b/docker.local/bin/build.miners.sh
@@ -9,7 +9,7 @@ DOCKERDIR="$ROOT/docker.local/build.miner"
 DOCKERFILE="$DOCKERDIR/Dockerfile"
 DOCKERCOMPOSE="$DOCKERDIR/docker-compose.yml"
 
-if [[ "$@" == *"--dev"* ]]
+if [[ "$*" == *"--dev"* ]]
 then
     echo -e "\nDevelopment mode: building miner locally\n"
 

--- a/docker.local/bin/start.b0miner.sh
+++ b/docker.local/bin/start.b0miner.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 PWD=`pwd`
 MINER_DIR=`basename $PWD`
 MINER_ID=`echo $MINER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
-if [[ "$@" == *"--debug"* ]]
+if [[ "$*" == *"--debug"* ]]
 then
     echo Starting miner$MINER_ID in debug mode ...
 

--- a/docker.local/bin/start.b0sharder.sh
+++ b/docker.local/bin/start.b0sharder.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 PWD=`pwd`
 SHARDER_DIR=`basename $PWD`
 SHARDER_ID=`echo $SHARDER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
-if [[ "$@" == *"--debug"* ]]
+if [[ "$*" == *"--debug"* ]]
 then
     echo Starting sharder$SHARDER_ID in debug mode ...
 

--- a/docker.local/bin/unit_test.sh
+++ b/docker.local/bin/unit_test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # Allocate interactive TTY to allow Ctrl-C.
@@ -10,7 +10,7 @@ IMAGE=""
 GENERAL_IMAGE="zchain_unit_test"
 SC_IMAGE="zchain_sc_unit_test"
 
-if [[ "$@" == *"--ci"* ]]
+if [[ "$*" == *"--ci"* ]]
 then
     # We need non-interactive mode for CI
     INTERACTIVE=""
@@ -21,7 +21,7 @@ then
 else
     PACKAGE="$1"
 
-    if [[ "$@" == *"--sc"* ]]
+    if [[ "$*" == *"--sc"* ]]
     then
         IMAGE="$SC_IMAGE"
         echo "Building SC test image"

--- a/docker.local/bin/unit_test.sh
+++ b/docker.local/bin/unit_test.sh
@@ -13,8 +13,6 @@ if [[ "$1" == *"--ci"* ]]
 then
     # We need non-interactive mode for CI
     INTERACTIVE=""
-    echo piers intereative
-
     echo "Building both general and SC test images"
     docker build -f docker.local/build.sc_unit_test/Dockerfile . -t zchain_sc_unit_test
     docker build -f docker.local/build.unit_test/Dockerfile . -t zchain_unit_test
@@ -34,7 +32,7 @@ else
 fi
 
 GO_TEST="go test -v -cover -tags bn256"
-echo piers pacage $PACKAGE
+
 if [[ -n "$PACKAGE" ]]; then
     # Run tests from a single package.
     # assume that $PACKAGE looks something like: 0chain.net/chaincore/threshold/bls

--- a/docker.local/bin/unit_test.sh
+++ b/docker.local/bin/unit_test.sh
@@ -6,27 +6,27 @@ INTERACTIVE="-it"
 PACKAGE=""
 IMAGE=""
 
-
 GENERAL_IMAGE="zchain_unit_test"
 SC_IMAGE="zchain_sc_unit_test"
 
-if [[ "$*" == *"--ci"* ]]
+if [[ "$1" == *"--ci"* ]]
 then
     # We need non-interactive mode for CI
     INTERACTIVE=""
+    echo piers intereative
 
     echo "Building both general and SC test images"
     docker build -f docker.local/build.sc_unit_test/Dockerfile . -t zchain_sc_unit_test
     docker build -f docker.local/build.unit_test/Dockerfile . -t zchain_unit_test
 else
-    PACKAGE="$1"
-
-    if [[ "$*" == *"--sc"* ]]
+    if [[ "$1" == *"--sc"* ]]
     then
+        PACKAGE="$2"
         IMAGE="$SC_IMAGE"
         echo "Building SC test image"
         docker build -f docker.local/build.sc_unit_test/Dockerfile . -t $IMAGE
     else
+        PACKAGE="$1"
         IMAGE="$GENERAL_IMAGE"
         echo "Building general test image"
         docker build -f docker.local/build.unit_test/Dockerfile . -t $IMAGE
@@ -34,16 +34,15 @@ else
 fi
 
 GO_TEST="go test -v -cover -tags bn256"
-
+echo piers pacage $PACKAGE
 if [[ -n "$PACKAGE" ]]; then
     # Run tests from a single package.
-
     # assume that $PACKAGE looks something like: 0chain.net/chaincore/threshold/bls
     echo "Running unit tests from $PACKAGE:"
     docker run $INTERACTIVE $IMAGE sh -c "cd $PACKAGE; $GO_TEST"
 else
     # Run all tests.
-
+    echo no package run all tests
     # avoid expanding outside of Docker container
     cd_mod='cd 0chain.net/$mod'
     all_in_mod='0chain.net/$mod/...'
@@ -66,8 +65,6 @@ else
     "
 
     echo "Running smart contract unit tests:"
-    docker run $INTERACTIVE $SC_IMAGE sh -c "\
-        cd 0chain.net/smartcontract/minersc; $GO_TEST; \ cd -;
-        cd 0chain.net/smartcontract/storagesc; $GO_TEST \ cd -;
-    "
+    docker run $INTERACTIVE $SC_IMAGE sh -c "cd 0chain.net/smartcontract/storagesc; $GO_TEST;"
+    docker run $INTERACTIVE $SC_IMAGE sh -c "cd 0chain.net/smartcontract/minersc; $GO_TEST;"
 fi

--- a/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/bin/build.miners.sh
+++ b/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/bin/build.miners.sh
@@ -9,7 +9,7 @@ DOCKERDIR="$ROOT/docker.local/build.miner"
 DOCKERFILE="$DOCKERDIR/Dockerfile"
 DOCKERCOMPOSE="$DOCKERDIR/docker-compose.yml"
 
-if [[ "$@" == *"--dev"* ]]
+if [[ "$*" == *"--dev"* ]]
 then
     echo -e "\nDevelopment mode: building miner locally\n"
 

--- a/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/bin/start.b0miner.sh
+++ b/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/bin/start.b0miner.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 PWD=`pwd`
 MINER_DIR=`basename $PWD`
 MINER_ID=`echo $MINER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
-if [[ "$@" == *"--debug"* ]]
+if [[ "$*" == *"--debug"* ]]
 then
     echo Starting miner$MINER_ID in debug mode ...
 

--- a/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/bin/start.b0sharder.sh
+++ b/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/bin/start.b0sharder.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 PWD=`pwd`
 SHARDER_DIR=`basename $PWD`
 SHARDER_ID=`echo $SHARDER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
-if [[ "$@" == *"--debug"* ]]
+if [[ "$*" == *"--debug"* ]]
 then
     echo Starting sharder$SHARDER_ID in debug mode ...
 

--- a/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/bin/unit_test.sh
+++ b/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/bin/unit_test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # Allocate interactive TTY to allow Ctrl-C.


### PR DESCRIPTION
Changed shell scripts that make use of `[[ ]]` to use `bash` as they don't work in `sh`. 

Modified scripts as suggested by [SC2199](https://github.com/koalaman/shellcheck/wiki/SC2199) to not use `$@` in `[[`.

Fixed `unit_test.sh`, which was not working as intended.

Resolves issue https://github.com/0chain/0chain/issues/176