### PR TITLE
add PORTABLE=1 for rocksdb build

### DIFF
--- a/docker.local/build.base/Dockerfile.build_base
+++ b/docker.local/build.base/Dockerfile.build_base
@@ -7,7 +7,7 @@ RUN apk add coreutils linux-headers perl zlib-dev bzip2-dev lz4-dev snappy-dev z
     cd /tmp && \
     wget -O - https://github.com/facebook/rocksdb/archive/v5.18.3.tar.gz | tar xz && \
     cd /tmp/rocksdb* && \
-    make -j $(nproc) install-shared OPT=-g0 USE_RTTI=1 && \
+    PORTABLE=1 make -j $(nproc) install-shared OPT=-g0 USE_RTTI=1 && \
     rm -R /tmp/rocksdb* && \
     apk del coreutils linux-headers perl
 


### PR DESCRIPTION
The docker image of miner and sharder has been returning error `illegal instruction` randomly.

![image](https://user-images.githubusercontent.com/6071642/116351942-2b0cbf00-a814-11eb-987c-90ef25271d00.png)

This seems to be due to rocksdb compilation done in different CPU types and running in a different ones.

As per docs provided in rocksdb installation, it mentions adding PORTABLE=1 before your make commands

https://github.com/facebook/rocksdb/blob/master/INSTALL.md#compilation


