### PR TITLE
Non genesis miners panic when there is no description

### DIFF
--- a/code/go/0chain.net/miner/miner/main.go
+++ b/code/go/0chain.net/miner/miner/main.go
@@ -348,7 +348,7 @@ func readNonGenesisHostAndPort(keysFile *string) (string, string, int, string, s
 
 	result = scanner.Scan()
 	if result == false {
-		return h, n2nh, p, path, "", errors.New("error reading description")
+		return h, n2nh, p, path, "", nil
 	}
 
 	description := scanner.Text()


### PR DESCRIPTION
## Related tasks
- [Non genesis panic issue](https://github.com/0chain/0chain/issues/213)

## Premise
A non genesis miner will panic if there isn't a description. The description isn't needed like the host or port are so returning a nil as the error will allow miners to join the network.

## Changes
- readNonGenesisHostAndPort no longer returns an error if there is no description