### PR TITLE
Fix closure issue with mpt_nodedb_test.go

### DIFF
--- a/code/go/0chain.net/core/util/mpt_nodedb_test.go
+++ b/code/go/0chain.net/core/util/mpt_nodedb_test.go
@@ -461,6 +461,7 @@ func TestLevelNodeDB_Current_Prev_Rebase(t *testing.T) {
 	}
 
 	for i := 0; i < parallel; i++ {
+		i := i
 		t.Run("parallel access", func(t *testing.T) {
 			t.Parallel()
 
@@ -727,6 +728,8 @@ func TestNodeDB_parallel(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%T", ndb), func(t *testing.T) {
 			for i := 0; i < parallel; i++ {
+				i := i
+				ndb := ndb
 				t.Run("parallel access", func(t *testing.T) {
 					t.Parallel()
 					for j := 0; j < len(kvs); j++ {


### PR DESCRIPTION
[Using t.Parallel inside a t.Run can cause closer issues](https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721#how-to-solve-this).