### PR TITLE
Imporve Recover error message

### DIFF
--- a/code/go/0chain.net/core/common/mdw_recover.go
+++ b/code/go/0chain.net/core/common/mdw_recover.go
@@ -1,7 +1,7 @@
 package common
 
 import (
-	. "0chain.net/core/logging"
+	"0chain.net/core/logging"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -21,7 +21,12 @@ func Recover(handler ReqRespHandlerf) ReqRespHandlerf {
 	return func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
 			if err := recover(); err != nil {
-				Logger.Error("panic", zap.Any("error", err))
+				logging.Logger.Error("panic handling message",
+					zap.Any("error", err),
+					zap.String("remote address", r.RemoteAddr),
+					zap.String("method", r.Method),
+					zap.String("request uri", r.RequestURI),
+				)
 				w.Header().Set("Content-Type", "application/json")
 				data := make(map[string]interface{}, 2)
 				data["error"] = fmt.Sprintf("%v", err)


### PR DESCRIPTION
Messages to 0chain were causing a panic with no record of where the message comes from. Adds more information to the error message.