### PR TITLE
Unit tests: Expose race issues.

### DIFF
--- a/code/go/0chain.net/chaincore/chain/state_handler_test.go
+++ b/code/go/0chain.net/chaincore/chain/state_handler_test.go
@@ -1707,11 +1707,1614 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 			},
 			wantStatus: http.StatusInternalServerError,
 		},
+		{
+			name:  "Faucet_/personalPeriodicLimit_Empty_Global_Node_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", faucetsc.ADDRESS, "/personalPeriodicLimit")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Faucet_/personalPeriodicLimit_Decoding_Global_Node_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(faucetsc.ADDRESS + faucetsc.ADDRESS)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", faucetsc.ADDRESS, "/personalPeriodicLimit")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Faucet_/personalPeriodicLimit_Empty_User_Node_404",
+			chain: func() *chain.Chain {
+				gn := &faucetsc.GlobalNode{ID: faucetsc.ADDRESS}
+				blob, err := json.Marshal(gn)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gv := util.SecureSerializableValue{Buffer: blob}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(gn.ID + gn.ID)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", faucetsc.ADDRESS, "/personalPeriodicLimit")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Faucet_/personalPeriodicLimit_Decoding_User_Node_Err_500",
+			chain: func() *chain.Chain {
+				gn := &faucetsc.GlobalNode{ID: faucetsc.ADDRESS}
+				blob, err := json.Marshal(gn)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gv := util.SecureSerializableValue{Buffer: blob}
+				gk := encryption.Hash(faucetsc.ADDRESS + faucetsc.ADDRESS)
+
+				uv := util.SecureSerializableValue{Buffer: []byte("}{")}
+				uk := encryption.Hash(faucetsc.ADDRESS + clientID)
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				if _, err := lfb.ClientState.Insert(util.Path(gk), &gv); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := lfb.ClientState.Insert(util.Path(uk), &uv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", faucetsc.ADDRESS, "/personalPeriodicLimit")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("client_id", clientID)
+					u.RawQuery = q.Encode()
+
+					return httptest.NewRequest(http.MethodGet, u.String(), nil)
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Faucet_/globalPerodicLimit_Empty_Global_Node_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", faucetsc.ADDRESS, "/globalPerodicLimit")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Faucet_/globalPerodicLimit_Decoding_Global_Node_Err_500",
+			chain: func() *chain.Chain {
+				v := util.SecureSerializableValue{Buffer: []byte("}{")}
+				k := encryption.Hash(faucetsc.ADDRESS + faucetsc.ADDRESS)
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &v); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", faucetsc.ADDRESS, "/globalPerodicLimit")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Faucet_/pourAmount_Empty_Global_Node_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", faucetsc.ADDRESS, "/pourAmount")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Faucet_/pourAmount_Decoding_Global_Node_500",
+			chain: func() *chain.Chain {
+				v := util.SecureSerializableValue{Buffer: []byte("}{")}
+				k := encryption.Hash(faucetsc.ADDRESS + faucetsc.ADDRESS)
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &v); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", faucetsc.ADDRESS, "/pourAmount")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Interestpool_/getPoolsStats_Empty_User_Nodes_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", interestpoolsc.ADDRESS, "/getPoolsStats")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:  "Minersc_/getNodepool_Decode_Miner_From_Params_Err_400",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getNodepool")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:  "Minersc_/getNodepool_Miner_Does_Not_Exist_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getNodepool")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("n2n_host", "n2n host")
+					q.Set("id", "id")
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Minersc_/getUserPools_No_User_Node_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.ADDRESS + clientID)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getUserPools")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("client_id", clientID)
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Minersc_/getSharderList_Decoding_User_Node_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.AllShardersKey)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getSharderList")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Minersc_/nodePoolStat_Decoding_User_Node_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.ADDRESS)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/nodePoolStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Minersc_/configs_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.GlobalNodeKey)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/configs")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Minersc_/getMinerList_DEcoding_User_Node_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.AllMinersKey)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getMinerList")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Minersc_/getSharderKeepList_Decoding_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.ShardersKeepKey)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getSharderKeepList")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Minersc_/getDkgList_Decoding_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.DKGMinersKey)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getDkgList")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Minersc_/nodeStat_Decoding_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.ADDRESS + clientID)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/nodeStat")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("id", clientID)
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Minersc_/getUserPools_Fail_Retrieving_Miners_Node_404",
+			chain: func() *chain.Chain {
+				un := minersc.UserNode{
+					ID: clientID,
+					Pools: map[datastore.Key][]datastore.Key{
+						"key": {},
+					},
+				}
+				blob, err := json.Marshal(un)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gv := util.SecureSerializableValue{Buffer: blob}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.ADDRESS + clientID)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getUserPools")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("client_id", clientID)
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Minersc_/getUserPools_Decoding_Miners_Node_Err_500",
+			chain: func() *chain.Chain {
+				minerID := "miner id"
+
+				un := minersc.UserNode{
+					ID: clientID,
+					Pools: map[datastore.Key][]datastore.Key{
+						minerID: {},
+					},
+				}
+				blob, err := json.Marshal(un)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gv := util.SecureSerializableValue{Buffer: blob}
+				gk := encryption.Hash(minersc.ADDRESS + clientID)
+
+				mv := util.SecureSerializableValue{Buffer: []byte("}{")}
+				mk := encryption.Hash(minersc.ADDRESS + minerID)
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				if _, err := lfb.ClientState.Insert(util.Path(gk), &gv); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := lfb.ClientState.Insert(util.Path(mk), &mv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getUserPools")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("client_id", clientID)
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Minersc_/getMpksList_Empty_Miners_Mpks_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getMpksList")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Minersc_/getMpksList_Decoding_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.MinersMPKKey)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getMpksList")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Minersc_/getGroupShareOrSigns_Empty_SOS_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getGroupShareOrSigns")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Minersc_/getGroupShareOrSigns_Decoding_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.GroupShareOrSignsKey)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getGroupShareOrSigns")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Minersc_/getMagicBlock_Empty_Magic_Block_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getMagicBlock")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Minersc_/getMagicBlock_Decoding_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.MagicBlockKey)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/getMagicBlock")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Minersc_/nodePoolStat_Not_Found_404",
+			chain: func() *chain.Chain {
+				mn := minersc.NewMinerNode()
+				blob, err := json.Marshal(mn)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				gv := util.SecureSerializableValue{Buffer: blob}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(minersc.ADDRESS + clientID)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", minersc.ADDRESS, "/nodePoolStat")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("id", clientID)
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Storagesc_/getConfig_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + ":configurations")
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getConfig")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("id", clientID)
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Storagesc_/getConfig_500",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getConfig")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Storagesc_/latestreadmarker_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + encryption.Hash(":"))
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/latestreadmarker")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Storagesc_/allocation_No_Allocation_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/allocation")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Storagesc_/allocation_Decoding_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/allocation")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Storagesc_/allocations_Get_List_Err_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/allocations")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Storagesc_/allocation_min_lock_500",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/allocation_min_lock")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Storagesc_/allocation_min_lock_Invalid_Config_Err_500",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					type newAllocationRequest struct {
+						DataShards                 int                  `json:"data_shards"`
+						ParityShards               int                  `json:"parity_shards"`
+						Size                       int64                `json:"size"`
+						Expiration                 common.Timestamp     `json:"expiration_date"`
+						Owner                      string               `json:"owner_id"`
+						OwnerPublicKey             string               `json:"owner_public_key"`
+						PreferredBlobbers          []string             `json:"preferred_blobbers"`
+						ReadPriceRange             storagesc.PriceRange `json:"read_price_range"`
+						WritePriceRange            storagesc.PriceRange `json:"write_price_range"`
+						MaxChallengeCompletionTime time.Duration        `json:"max_challenge_completion_time"`
+					}
+					allocReq := &newAllocationRequest{}
+					blob, err := json.Marshal(allocReq)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/allocation_min_lock")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("allocation_data", string(blob))
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Storagesc_/allocation_min_lock_Invalid_Config_500",
+			chain: func() *chain.Chain {
+				sn := storageNodes{
+					Nodes: []*storagesc.StorageNode{
+						{},
+					},
+				}
+				blob, err := json.Marshal(sn)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gv := util.SecureSerializableValue{Buffer: blob}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ALL_BLOBBERS_KEY)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					type newAllocationRequest struct {
+						DataShards                 int                  `json:"data_shards"`
+						ParityShards               int                  `json:"parity_shards"`
+						Size                       int64                `json:"size"`
+						Expiration                 common.Timestamp     `json:"expiration_date"`
+						Owner                      string               `json:"owner_id"`
+						OwnerPublicKey             string               `json:"owner_public_key"`
+						PreferredBlobbers          []string             `json:"preferred_blobbers"`
+						ReadPriceRange             storagesc.PriceRange `json:"read_price_range"`
+						WritePriceRange            storagesc.PriceRange `json:"write_price_range"`
+						MaxChallengeCompletionTime time.Duration        `json:"max_challenge_completion_time"`
+					}
+					allocReq := &newAllocationRequest{
+						Size:           2048,
+						Expiration:     common.Timestamp(time.Now().Add(time.Hour).Unix()),
+						DataShards:     1,
+						OwnerPublicKey: "owners public key",
+						Owner:          "owner",
+					}
+					blob, err := json.Marshal(allocReq)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/allocation_min_lock")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("allocation_data", string(blob))
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusInternalServerError,
+		},
+		{
+			name:  "Storagesc_/openchallenges_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/openchallenges")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name: "Storagesc_/openchallenges_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + ":blobberchallenge:")
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/openchallenges")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Storagesc_/getchallenge_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getchallenge")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name: "Storagesc_/getchallenge_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + ":blobberchallenge:")
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getchallenge")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "Storagesc_/getblobbers_500",
+			chain: func() *chain.Chain {
+				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ALL_BLOBBERS_KEY)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getblobbers")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusInternalServerError,
+		},
+		{
+			name:  "Storagesc_/getBlobber_400",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getBlobber")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusBadRequest,
+		},
+		{
+			name:  "Storagesc_/getBlobber_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getBlobber")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("blobber_id", "blobber_id")
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name:  "Storagesc_/getReadPoolStat_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getReadPoolStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name:  "Storagesc_/getReadPoolAllocBlobberStat_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getReadPoolAllocBlobberStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name:  "Storagesc_/getWritePoolStat_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getWritePoolStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name:  "Storagesc_/getWritePoolAllocBlobberStat_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getWritePoolAllocBlobberStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name:  "Storagesc_/getStakePoolStat_No_Config_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getStakePoolStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name: "Storagesc_/getStakePoolStat_No_Blobber_404",
+			chain: func() *chain.Chain {
+				blob, err := json.Marshal(&scConfig{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				gv := util.SecureSerializableValue{Buffer: blob}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + ":configurations")
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getStakePoolStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name: "Storagesc_/getStakePoolStat_No_Stake_Pool_404",
+			chain: func() *chain.Chain {
+				blob, err := json.Marshal(&scConfig{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				v := util.SecureSerializableValue{Buffer: blob}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + ":configurations")
+				if _, err := lfb.ClientState.Insert(util.Path(k), &v); err != nil {
+					t.Fatal(err)
+				}
+
+				bl := storagesc.StorageNode{}
+				blob, err = json.Marshal(bl)
+				if err != nil {
+					t.Fatal(err)
+				}
+				v2 := util.SecureSerializableValue{Buffer: blob}
+				k2 := encryption.Hash(storagesc.ADDRESS + blobberID)
+				if _, err := lfb.ClientState.Insert(util.Path(k2), &v2); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getStakePoolStat")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("blobber_id", blobberID)
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name:  "Storagesc_/getUserStakePoolStat_No_Config_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getUserStakePoolStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name: "Storagesc_/getUserStakePoolStat_No_User_Stake_Pool_404",
+			chain: func() *chain.Chain {
+				conf := &scConfig{
+					StakePool: &stakePoolConfig{},
+				}
+				blob, err := json.Marshal(conf)
+				if err != nil {
+					t.Fatal(err)
+				}
+				gv := util.SecureSerializableValue{Buffer: blob}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + ":configurations")
+				if _, err := lfb.ClientState.Insert(util.Path(k), &gv); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getUserStakePoolStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name: "Storagesc_/getUserStakePoolStat_No_Stake_Pool_404",
+			chain: func() *chain.Chain {
+				conf := &scConfig{
+					StakePool: &stakePoolConfig{},
+				}
+				blob, err := json.Marshal(conf)
+				if err != nil {
+					t.Fatal(err)
+				}
+				v := util.SecureSerializableValue{Buffer: blob}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + ":configurations")
+				if _, err := lfb.ClientState.Insert(util.Path(k), &v); err != nil {
+					t.Fatal(err)
+				}
+
+				sp := &userStakePools{
+					Pools: map[datastore.Key][]datastore.Key{
+						"key": {"key"},
+					},
+				}
+				blob, err = json.Marshal(sp)
+				if err != nil {
+					t.Fatal(err)
+				}
+				v2 := util.SecureSerializableValue{Buffer: blob}
+				k2 := encryption.Hash(storagesc.ADDRESS + ":stakepool:userpools:")
+				if _, err := lfb.ClientState.Insert(util.Path(k2), &v2); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getUserStakePoolStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name:  "Storagesc_/getChallengePoolStat_400",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getChallengePoolStat")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusBadRequest,
+		},
+		{
+			name: "Storagesc_/getChallengePoolStat_de_Allocation_500",
+			chain: func() *chain.Chain {
+				v := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + allocationID)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &v); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getChallengePoolStat")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("allocation_id", allocationID)
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusInternalServerError,
+		},
+		{
+			name: "Storagesc_/getChallengePoolStat_No_Challenge_Pool_404",
+			chain: func() *chain.Chain {
+				sa := &storagesc.StorageAllocation{}
+				blob, err := json.Marshal(sa)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				v := util.SecureSerializableValue{Buffer: blob}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(storagesc.ADDRESS + allocationID)
+				if _, err := lfb.ClientState.Insert(util.Path(k), &v); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", storagesc.ADDRESS, "/getChallengePoolStat")
+					u, err := url.Parse(tar)
+					if err != nil {
+						t.Fatal(err)
+					}
+					q := u.Query()
+					q.Set("allocation_id", allocationID)
+					u.RawQuery = q.Encode()
+
+					req := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+					return req
+				}(),
+			},
+			setValidConfig: true,
+			wantStatus:     http.StatusNotFound,
+		},
+		{
+			name:  "Vestingsc_/getConfig_500",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", vestingsc.ADDRESS, "/getConfig")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:  "Vestingsc_/getPoolInfo_404",
+			chain: serverChain,
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", vestingsc.ADDRESS, "/getPoolInfo")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "Vestingsc_/getClientPools_500",
+			chain: func() *chain.Chain {
+				v := util.SecureSerializableValue{Buffer: []byte("}{")}
+
+				lfb := block.NewBlock("", 1)
+				lfb.ClientState = util.NewMerklePatriciaTrie(util.NewMemoryNodeDB(), 1)
+				k := encryption.Hash(vestingsc.ADDRESS + ":clientvestingpools:")
+				if _, err := lfb.ClientState.Insert(util.Path(k), &v); err != nil {
+					t.Fatal(err)
+				}
+
+				ch := chain.NewChainFromConfig()
+				ch.LatestFinalizedBlock = lfb
+
+				return ch
+			}(),
+			args: args{
+				w: httptest.NewRecorder(),
+				r: func() *http.Request {
+					tar := fmt.Sprintf("%v%v%v", "/v1/screst/", vestingsc.ADDRESS, "/getClientPools")
+					req := httptest.NewRequest(http.MethodGet, tar, nil)
+
+					return req
+				}(),
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name,
 			func(t *testing.T) {
+				t.Parallel()
 				if test.setValidConfig {
 					config.SmartContractConfig.Set("smart_contracts.storagesc.max_challenge_completion_time", 1000)
 					config.SmartContractConfig.Set("smart_contracts.vestingsc.min_duration", time.Second*5)

--- a/code/go/0chain.net/core/memorystore/connection_test.go
+++ b/code/go/0chain.net/core/memorystore/connection_test.go
@@ -227,6 +227,7 @@ func TestAddPool(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			AddPool(tt.args.dbid, tt.args.pool)

--- a/code/go/0chain.net/core/memorystore/connection_test.go
+++ b/code/go/0chain.net/core/memorystore/connection_test.go
@@ -89,9 +89,38 @@ func TestNewPool(t *testing.T) {
 			},
 			wantDialCheck: true,
 		},
+		{
+			name: "Test_NewPool_OK",
+			args: args{port: 8080},
+			want: &redis.Pool{
+				MaxIdle:   80,
+				MaxActive: 1000,
+			},
+		},
+		{
+			name: "Test_NewPool_Panic",
+			args: args{port: 8080},
+			want: &redis.Pool{
+				MaxIdle:   80,
+				MaxActive: 1000,
+			},
+			wantPanic:     true,
+			wantDialCheck: true,
+		},
+		{
+			name: "Test_NewPool_Dial_Check_OK",
+			args: args{port: portInt},
+			want: &redis.Pool{
+				MaxIdle:   80,
+				MaxActive: 1000,
+			},
+			wantDialCheck: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			defer func() {
 				got := recover()
 				if (got != nil) != tt.wantPanic {
@@ -135,9 +164,19 @@ func TestNewPool_Docker(t *testing.T) {
 				MaxActive: 1000, // max number of connections
 			},
 		},
+		{
+			name: "Test_NewPool_OK",
+			args: args{host: "host"},
+			want: &redis.Pool{
+				MaxIdle:   80,
+				MaxActive: 1000, // max number of connections
+			},
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := NewPool(tt.args.host, tt.args.port)
 			got.Dial = nil
 			if !reflect.DeepEqual(got, tt.want) {
@@ -173,9 +212,23 @@ func TestAddPool(t *testing.T) {
 				return p
 			}(),
 		},
+		{
+			name: "Test_AddPool_OK",
+			args: args{dbid: dbid, pool: pool},
+			want: func() map[string]*dbpool {
+				p := make(map[string]*dbpool)
+				for key, value := range pools {
+					p[key] = value
+				}
+
+				p[dbid] = &dbpool{ID: dbid, CtxKey: getConnectionCtxKey(dbid), Pool: pool}
+				return p
+			}(),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			AddPool(tt.args.dbid, tt.args.pool)
 			if !reflect.DeepEqual(pools, tt.want) {
 				t.Errorf("AddPool() got = %v, want = %v", pools, tt.want)
@@ -210,9 +263,22 @@ func TestGetConnectionCount(t *testing.T) {
 			args:      args{entityMetadata: &datastore.EntityMetadataImpl{DB: "unknown"}},
 			wantPanic: true,
 		},
+		{
+			name:  "Test_GetConnectionCount_OK",
+			args:  args{entityMetadata: &datastore.EntityMetadataImpl{DB: dbid}},
+			want:  pool.ActiveCount(),
+			want1: pool.IdleCount(),
+		},
+		{
+			name:      "Test_GetConnectionCount_Panic",
+			args:      args{entityMetadata: &datastore.EntityMetadataImpl{DB: "unknown"}},
+			wantPanic: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			defer func() {
 				got := recover()
 				if (got != nil) != tt.wantPanic {
@@ -245,6 +311,16 @@ func Test_getdbpool(t *testing.T) {
 		want      *dbpool
 		wantPanic bool
 	}{
+		{
+			name: "Test_getdbpool_OK",
+			args: args{entityMetadata: &datastore.EntityMetadataImpl{DB: dbid}},
+			want: &dbpool{ID: dbid, CtxKey: getConnectionCtxKey(dbid), Pool: pool},
+		},
+		{
+			name:      "Test_getdbpool_Panic",
+			args:      args{entityMetadata: &datastore.EntityMetadataImpl{DB: "unknown"}},
+			wantPanic: true,
+		},
 		{
 			name: "Test_getdbpool_OK",
 			args: args{entityMetadata: &datastore.EntityMetadataImpl{DB: dbid}},
@@ -288,9 +364,15 @@ func TestGetConnection(t *testing.T) {
 			name: "Test_GetConnection_OK",
 			want: DefaultPool,
 		},
+		{
+			name: "Test_GetConnection_OK",
+			want: DefaultPool,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := GetConnection(); !reflect.DeepEqual(got.Pool, tt.want) {
 				t.Errorf("GetConnection() = %v, want %v", got, tt.want)
 			}
@@ -311,9 +393,15 @@ func TestGetInfo(t *testing.T) {
 			name:      "Test_GetInfo_Panic",
 			wantPanic: true,
 		},
+		{
+			name:      "Test_GetInfo_Panic",
+			wantPanic: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			defer func() {
 				got := recover()
 				if (got != nil) != tt.wantPanic {
@@ -352,9 +440,21 @@ func TestGetEntityConnection(t *testing.T) {
 			args: args{entityMetadata: &datastore.EntityMetadataImpl{DB: ""}},
 			want: DefaultPool,
 		},
+		{
+			name: "Test_GetEntityConnection_OK",
+			args: args{entityMetadata: &datastore.EntityMetadataImpl{DB: dbid}},
+			want: DefaultPool,
+		},
+		{
+			name: "Test_GetEntityConnection_Empty_dbid_OK",
+			args: args{entityMetadata: &datastore.EntityMetadataImpl{DB: ""}},
+			want: DefaultPool,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := GetEntityConnection(tt.args.entityMetadata); !reflect.DeepEqual(got.Pool, tt.want) {
 				t.Errorf("GetEntityConnection() = %v, want %v", got, tt.want)
 			}
@@ -391,9 +491,26 @@ func TestWithConnection(t *testing.T) {
 			args: args{ctx: context.WithValue(context.TODO(), CONNECTION, make(connections))},
 			want: DefaultPool,
 		},
+		{
+			name: "Test_WithConnection_Nil_Connection_In_Ctx_OK",
+			args: args{ctx: context.TODO()},
+			want: DefaultPool,
+		},
+		{
+			name:      "Test_WithConnection_Panic",
+			args:      args{ctx: context.WithValue(context.TODO(), CONNECTION, 123)},
+			wantPanic: true,
+		},
+		{
+			name: "Test_WithConnection_Nil_Connection_In_Ctx_OK",
+			args: args{ctx: context.WithValue(context.TODO(), CONNECTION, make(connections))},
+			want: DefaultPool,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			defer func() {
 				got := recover()
 				if (got != nil) != tt.wantPanic {
@@ -451,9 +568,31 @@ func TestGetCon(t *testing.T) {
 			args: args{ctx: context.WithValue(context.TODO(), CONNECTION, make(connections))},
 			want: DefaultPool,
 		},
+		{
+			name: "Test_GetCon_Nil_Ctx_OK",
+			args: args{ctx: nil},
+			want: DefaultPool,
+		},
+		{
+			name: "Test_GetCon_Nil_Connection_Value_In_Ctx_OK",
+			args: args{ctx: context.TODO()},
+			want: DefaultPool,
+		},
+		{
+			name:      "Test_GetCon_Panic",
+			args:      args{ctx: context.WithValue(context.TODO(), CONNECTION, 123)},
+			wantPanic: true,
+		},
+		{
+			name: "Test_GetCon_OK",
+			args: args{ctx: context.WithValue(context.TODO(), CONNECTION, make(connections))},
+			want: DefaultPool,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			defer func() {
 				got := recover()
 				if (got != nil) != tt.wantPanic {
@@ -514,9 +653,32 @@ func TestWithEntityConnection(t *testing.T) {
 			ctxKey: getConnectionCtxKey(anotherDbid),
 			want:   anotherPool,
 		},
+		{
+			name:   "Test_WithEntityConnection_DefaultPool_OK",
+			args:   args{ctx: context.TODO(), entityMetadata: &datastore.EntityMetadataImpl{DB: dbid}},
+			ctxKey: CONNECTION,
+			want:   DefaultPool,
+		},
+		{
+			name:   "Test_WithEntityConnection_Nil_Connection_Value_In_Ctx_OK",
+			args:   args{ctx: context.TODO(), entityMetadata: &datastore.EntityMetadataImpl{DB: anotherDbid}},
+			ctxKey: getConnectionCtxKey(anotherDbid),
+			want:   anotherPool,
+		},
+		{
+			name: "Test_WithEntityConnection_OK",
+			args: args{
+				ctx:            context.WithValue(context.TODO(), CONNECTION, make(connections)),
+				entityMetadata: &datastore.EntityMetadataImpl{DB: anotherDbid},
+			},
+			ctxKey: getConnectionCtxKey(anotherDbid),
+			want:   anotherPool,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			defer func() {
 				got := recover()
 				if (got != nil) != tt.wantPanic {
@@ -590,9 +752,37 @@ func TestGetEntityCon(t *testing.T) {
 			},
 			want: anotherPool,
 		},
+		{
+			name: "TestGetEntityCon_Nil_Context_OK",
+			args: args{entityMetadata: &datastore.EntityMetadataImpl{DB: dbid}},
+			want: DefaultPool,
+		},
+		{
+			name: "TestGetEntityCon_Default_Pool_OK",
+			args: args{ctx: context.TODO(), entityMetadata: &datastore.EntityMetadataImpl{DB: dbid}},
+			want: DefaultPool,
+		},
+		{
+			name: "TestGetEntityCon_Nil_Connection_In_Ctx_OK",
+			args: args{
+				ctx:            context.TODO(),
+				entityMetadata: &datastore.EntityMetadataImpl{DB: anotherDbid},
+			},
+			want: nil,
+		},
+		{
+			name: "TestGetEntityCon_OK",
+			args: args{
+				ctx:            context.WithValue(context.TODO(), CONNECTION, make(connections)),
+				entityMetadata: &datastore.EntityMetadataImpl{DB: anotherDbid},
+			},
+			want: anotherPool,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := GetEntityCon(tt.args.ctx, tt.args.entityMetadata)
 			if got == nil && tt.want == nil {
 				return
@@ -642,9 +832,19 @@ func TestClose(t *testing.T) {
 			name: "Test_Close_OK2",
 			args: args{ctx: context.WithValue(context.TODO(), CONNECTION, cMap)},
 		},
+		{
+			name: "Test_Close_OK",
+			args: args{ctx: context.TODO()},
+		},
+		{
+			name: "Test_Close_OK2",
+			args: args{ctx: context.WithValue(context.TODO(), CONNECTION, cMap)},
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			Close(tt.args.ctx)
 		})
 	}
@@ -661,6 +861,9 @@ func TestInitDefaultPool(t *testing.T) {
 		name string
 		args args
 	}{
+		{
+			name: "Test_InitDefaultPool_OK",
+		},
 		{
 			name: "Test_InitDefaultPool_OK",
 		},
@@ -686,6 +889,15 @@ func Test_getConnectionCtxKey(t *testing.T) {
 		args args
 		want common.ContextKey
 	}{
+		{
+			name: "Test_getConnectionCtxKey_Empty_Dbid_OK",
+			args: args{dbid: ""},
+			want: CONNECTION,
+		},
+		{
+			args: args{dbid: "dbid"},
+			want: common.ContextKey(fmt.Sprintf("%v%v", CONNECTION, "dbid")),
+		},
 		{
 			name: "Test_getConnectionCtxKey_Empty_Dbid_OK",
 			args: args{dbid: ""},

--- a/code/go/0chain.net/core/memorystore/store_test.go
+++ b/code/go/0chain.net/core/memorystore/store_test.go
@@ -81,9 +81,23 @@ func TestStore_Read(t *testing.T) {
 			want:    b,
 			wantErr: true,
 		},
+		{
+			name:    "Test_Store_Read_OK",
+			args:    args{ctx: nil, key: b.GetKey(), entity: block.Provider()},
+			want:    b,
+			wantErr: false,
+		},
+		{
+			name:    "Test_Store_Read_Nil_Data_ERR",
+			args:    args{ctx: nil, entity: block.Provider()},
+			want:    b,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.Read(tt.args.ctx, tt.args.key, tt.args.entity); (err != nil) != tt.wantErr {
 				t.Errorf("Read() error = %v, wantErr %v", err, tt.wantErr)
@@ -123,9 +137,16 @@ func TestStore_Read_Closed_Conn_ERR(t *testing.T) {
 			args:    args{ctx: nil, key: b.GetKey(), entity: block.Provider()},
 			wantErr: true,
 		},
+		{
+			name:    "Test_Store_Read_Closed_Conn_ERR",
+			args:    args{ctx: nil, key: b.GetKey(), entity: block.Provider()},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.Read(tt.args.ctx, tt.args.key, tt.args.entity); (err != nil) != tt.wantErr {
 				t.Errorf("Read() error = %v, wantErr %v", err, tt.wantErr)
@@ -180,9 +201,31 @@ func TestStore_Write(t *testing.T) {
 			args:    args{ctx: nil, entity: &txn2},
 			wantErr: false,
 		},
+		{
+			name:    "Test_Store_Write_Block_OK",
+			args:    args{ctx: nil, entity: b},
+			wantErr: false,
+		},
+		{
+			name:    "Test_Store_Write_Txn_OK",
+			args:    args{ctx: nil, entity: &transaction.Transaction{}},
+			wantErr: false,
+		},
+		{
+			name:    "Test_Store_Write_Txn_Non_Empty_Score_OK",
+			args:    args{ctx: nil, entity: &txn},
+			wantErr: false,
+		},
+		{
+			name:    "Test_Store_Write_Txn_Non_Empty_Score_And_Score_OK",
+			args:    args{ctx: nil, entity: &txn2},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.Write(tt.args.ctx, tt.args.entity); (err != nil) != tt.wantErr {
 				t.Errorf("Write() error = %v, wantErr %v", err, tt.wantErr)
@@ -215,9 +258,16 @@ func TestStore_Write_Closed_Conn_ERR(t *testing.T) {
 			args:    args{ctx: nil, entity: b},
 			wantErr: true,
 		},
+		{
+			name:    "Test_Store_Write_Closed_Conn_OK",
+			args:    args{ctx: nil, entity: b},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.Write(tt.args.ctx, tt.args.entity); (err != nil) != tt.wantErr {
 				t.Errorf("Write() error = %v, wantErr %v", err, tt.wantErr)
@@ -252,9 +302,16 @@ func TestStore_InsertIfNE(t *testing.T) {
 			args:    args{entity: b},
 			wantErr: true,
 		},
+		{
+			name:    "Test_Store_InsertIfNE_ERR",
+			args:    args{entity: b},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.InsertIfNE(tt.args.ctx, tt.args.entity); (err != nil) != tt.wantErr {
 				t.Errorf("InsertIfNE() error = %v, wantErr %v", err, tt.wantErr)
@@ -285,9 +342,21 @@ func TestStore_Delete(t *testing.T) {
 			args:    args{entity: block.NewBlock("", 1)},
 			wantErr: false,
 		},
+		{
+			name:    "Test_Store_Delete_Txn_OK",
+			args:    args{entity: &transaction.Transaction{}},
+			wantErr: false,
+		},
+		{
+			name:    "Test_Store_Delete_Block_OK",
+			args:    args{entity: block.NewBlock("", 1)},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.Delete(tt.args.ctx, tt.args.entity); (err != nil) != tt.wantErr {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
@@ -317,9 +386,16 @@ func TestStore_Delete_Closed_Conn_ERR(t *testing.T) {
 			args:    args{entity: &transaction.Transaction{}},
 			wantErr: true,
 		},
+		{
+			name:    "Test_Store_Delete_Closed_Conn_ERR",
+			args:    args{entity: &transaction.Transaction{}},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.Delete(tt.args.ctx, tt.args.entity); (err != nil) != tt.wantErr {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
@@ -391,9 +467,46 @@ func TestStore_MultiRead(t *testing.T) {
 				entityMetadata: round.Provider().GetEntityMetadata(),
 			},
 		},
+		{
+			name: "Test_Store_MultiRead_OK",
+			args: args{
+				entityMetadata: round.Provider().GetEntityMetadata(),
+				keys: []datastore.Key{
+					r.GetKey(),
+					r2.GetKey(),
+				},
+				entities: []datastore.Entity{
+					round.Provider(),
+					round.Provider(),
+				},
+			},
+		},
+		{
+			name: "Test_Store_MultiRead_Size>256_OK",
+			args: args{
+				entityMetadata: round.Provider().GetEntityMetadata(),
+				keys:           make([]datastore.Key, 257),
+				entities: func() []datastore.Entity {
+					en := make([]datastore.Entity, 257)
+					for ind := range en {
+						en[ind] = round.Provider()
+					}
+
+					return en
+				}(),
+			},
+		},
+		{
+			name: "Test_Store_MultiRead_Zero_Size_OK",
+			args: args{
+				entityMetadata: round.Provider().GetEntityMetadata(),
+			},
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiRead(tt.args.ctx, tt.args.entityMetadata, tt.args.keys, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiRead() error = %v, wantErr %v", err, tt.wantErr)
@@ -456,14 +569,46 @@ func TestStore_MultiRead_Closed_Conn_ERR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Test_Store_MultiRead_Closed_Conn_ERR",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				keys: []datastore.Key{
+					txn.GetKey(),
+				},
+				entities: []datastore.Entity{
+					transaction.Provider(),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test_Store_MultiRead_Size>256_ERR",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				keys:           make([]datastore.Key, 257),
+				entities: func() []datastore.Entity {
+					en := make([]datastore.Entity, 257)
+					for ind := range en {
+						en[ind] = transaction.Provider()
+					}
+
+					return en
+				}(),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiRead(tt.args.ctx, tt.args.entityMetadata, tt.args.keys, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiRead() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+
 	}
 }
 
@@ -519,10 +664,40 @@ func TestStore_MultiWrite(t *testing.T) {
 					return en
 				}(),
 			},
+		}, {
+			name: "Test_Store_MultiWrite_OK",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				keys: []datastore.Key{
+					txn.GetKey(),
+					txn2.GetKey(),
+				},
+				entities: []datastore.Entity{
+					&txn,
+					&txn2,
+				},
+			},
+		},
+		{
+			name: "Test_Store_MultiWrite_Size>256_OK",
+			args: args{
+				entityMetadata: round.Provider().GetEntityMetadata(),
+				keys:           make([]datastore.Key, 257),
+				entities: func() []datastore.Entity {
+					en := make([]datastore.Entity, 257)
+					for ind := range en {
+						en[ind] = round.Provider()
+					}
+
+					return en
+				}(),
+			},
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiWrite(tt.args.ctx, tt.args.entityMetadata, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiWrite() error = %v, wantErr %v", err, tt.wantErr)
@@ -569,9 +744,27 @@ func TestStore_MultiWrite_Closed_Conn_ERR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Test_Store_MultiWrite_Closed_Conn_ERR",
+			args: args{
+				entityMetadata: round.Provider().GetEntityMetadata(),
+				keys:           make([]datastore.Key, 257),
+				entities: func() []datastore.Entity {
+					en := make([]datastore.Entity, 257)
+					for ind := range en {
+						en[ind] = round.Provider()
+					}
+
+					return en
+				}(),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiWrite(tt.args.ctx, tt.args.entityMetadata, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiWrite() error = %v, wantErr %v", err, tt.wantErr)
@@ -628,9 +821,36 @@ func TestStore_MultiDelete(t *testing.T) {
 				}(),
 			},
 		},
+		{
+			name: "Test_Store_MultiDelete_OK",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				entities: []datastore.Entity{
+					&txn,
+					&txn2,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test_Store_MultiDelete_Size>256_OK",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				entities: func() []datastore.Entity {
+					en := make([]datastore.Entity, 257)
+					for ind := range en {
+						en[ind] = transaction.Provider()
+					}
+
+					return en
+				}(),
+			},
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiDelete(tt.args.ctx, tt.args.entityMetadata, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiDelete() error = %v, wantErr %v", err, tt.wantErr)
@@ -673,9 +893,26 @@ func TestStore_MultiDelete_Closed_Conn_ERR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Test_Store_MultiDelete_Closed_Conn_ERR",
+			args: args{
+				entityMetadata: block.Provider().GetEntityMetadata(),
+				entities: func() []datastore.Entity {
+					en := make([]datastore.Entity, 257)
+					for ind := range en {
+						en[ind] = block.Provider()
+					}
+
+					return en
+				}(),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiDelete(tt.args.ctx, tt.args.entityMetadata, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiDelete() error = %v, wantErr %v", err, tt.wantErr)
@@ -741,7 +978,60 @@ func TestStore_MultiAddToCollection(t *testing.T) {
 		{
 			name: "Test_Store_MultiAddToCollection_Size>256_OK",
 			args: func() args {
-				entities := make([]datastore.Entity, 257)
+				entities := make([]datastore.Entity, 128)
+				for ind := range entities {
+					txn := transaction.Transaction{}
+					txn.CollectionMemberField.EntityCollection = &datastore.EntityCollection{}
+					txn.CollectionMemberField.EntityCollection.CollectionDuration = time.Millisecond
+					txn.SetKey(fmt.Sprintf("key:%v", ind))
+					sp := memorystore.GetStorageProvider()
+					if err := sp.Write(nil, &txn); err != nil {
+						t.Fatal(err)
+					}
+					entities[ind] = &txn
+				}
+
+				return args{
+					entityMetadata: transaction.Provider().GetEntityMetadata(),
+					entities:       entities,
+				}
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "Test_Store_MultiAddToCollection_Zero_Size_OK",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				entities:       make([]datastore.Entity, 0),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test_Store_MultiAddToCollection_Not_Collection_Entity_ERR",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				entities: []datastore.Entity{
+					&txn,
+					&round.Round{},
+				},
+			},
+			wantErr: true,
+		}, {
+			name: "Test_Store_MultiAddToCollection_OK",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				entities: []datastore.Entity{
+					&txn,
+					&txn2,
+					&txn3,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test_Store_MultiAddToCollection_Size>256_OK",
+			args: func() args {
+				entities := make([]datastore.Entity, 128)
 				for ind := range entities {
 					txn := transaction.Transaction{}
 					txn.CollectionMemberField.EntityCollection = &datastore.EntityCollection{}
@@ -782,7 +1072,9 @@ func TestStore_MultiAddToCollection(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiAddToCollection(tt.args.ctx, tt.args.entityMetadata, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiAddToCollection() error = %v, wantErr %v", err, tt.wantErr)
@@ -827,9 +1119,30 @@ func TestStore_MultiAddToCollection_Closed_Conn_ERR(t *testing.T) {
 			}(),
 			wantErr: true,
 		},
+		{
+			name: "Test_Store_MultiAddToCollection_Size>256_OK",
+			args: func() args {
+				entities := make([]datastore.Entity, 257)
+				for ind := range entities {
+					txn := transaction.Transaction{}
+					txn.CollectionMemberField.EntityCollection = &datastore.EntityCollection{}
+					txn.CollectionMemberField.EntityCollection.CollectionDuration = time.Millisecond
+					txn.SetKey(fmt.Sprintf("key:%v", ind))
+					entities[ind] = &txn
+				}
+
+				return args{
+					entityMetadata: transaction.Provider().GetEntityMetadata(),
+					entities:       entities,
+				}
+			}(),
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiAddToCollection(tt.args.ctx, tt.args.entityMetadata, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiAddToCollection() error = %v, wantErr %v", err, tt.wantErr)
@@ -894,7 +1207,59 @@ func TestStore_MultiDeleteFromCollection(t *testing.T) {
 		{
 			name: "Test_Store_MultiDeleteFromCollection_Size>256_OK",
 			args: func() args {
-				entities := make([]datastore.Entity, 257)
+				entities := make([]datastore.Entity, 128)
+				for ind := range entities {
+					txn := transaction.Transaction{}
+					txn.CollectionMemberField.EntityCollection = &datastore.EntityCollection{}
+					txn.CollectionMemberField.EntityCollection.CollectionDuration = time.Millisecond
+					txn.SetKey(fmt.Sprintf("key:%v", ind))
+					sp := memorystore.GetStorageProvider()
+					if err := sp.Write(nil, &txn); err != nil {
+						t.Fatal(err)
+					}
+					entities[ind] = &txn
+				}
+
+				return args{
+					entityMetadata: transaction.Provider().GetEntityMetadata(),
+					entities:       entities,
+				}
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "Test_Store_MultiDeleteFromCollection_OK",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				entities: []datastore.Entity{
+					&txn,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test_Store_MultiDeleteFromCollection_ERR",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				entities: []datastore.Entity{
+					&txn,
+					round.Provider(),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Test_Store_MultiDeleteFromCollection_Zero_Size_OK",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				entities:       []datastore.Entity{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test_Store_MultiDeleteFromCollection_Size>256_OK",
+			args: func() args {
+				entities := make([]datastore.Entity, 128)
 				for ind := range entities {
 					txn := transaction.Transaction{}
 					txn.CollectionMemberField.EntityCollection = &datastore.EntityCollection{}
@@ -916,7 +1281,9 @@ func TestStore_MultiDeleteFromCollection(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiDeleteFromCollection(tt.args.ctx, tt.args.entityMetadata, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiDeleteFromCollection() error = %v, wantErr %v", err, tt.wantErr)
@@ -961,9 +1328,30 @@ func TestStore_MultiDeleteFromCollection_Closed_Conn_ERR(t *testing.T) {
 			}(),
 			wantErr: true,
 		},
+		{
+			name: "Test_Store_MultiDeleteFromCollection_Closed_Conn_ERR",
+			args: func() args {
+				entities := make([]datastore.Entity, 257)
+				for ind := range entities {
+					txn := transaction.Transaction{}
+					txn.CollectionMemberField.EntityCollection = &datastore.EntityCollection{}
+					txn.CollectionMemberField.EntityCollection.CollectionDuration = time.Millisecond
+					txn.SetKey(fmt.Sprintf("key:%v", ind))
+					entities[ind] = &txn
+				}
+
+				return args{
+					entityMetadata: transaction.Provider().GetEntityMetadata(),
+					entities:       entities,
+				}
+			}(),
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.MultiDeleteFromCollection(tt.args.ctx, tt.args.entityMetadata, tt.args.entities); (err != nil) != tt.wantErr {
 				t.Errorf("MultiDeleteFromCollection() error = %v, wantErr %v", err, tt.wantErr)
@@ -1000,9 +1388,19 @@ func TestStore_GetCollectionSize(t *testing.T) {
 			},
 			want: 1,
 		},
+		{
+			name: "Test_Store_GetCollectionSize_OK",
+			args: args{
+				entityMetadata: txn.GetEntityMetadata(),
+				collectionName: txn.GetCollectionName(),
+			},
+			want: 1,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if got := ms.GetCollectionSize(tt.args.ctx, tt.args.entityMetadata, tt.args.collectionName); got != tt.want {
 				t.Errorf("GetCollectionSize() = %v, want %v", got, tt.want)
@@ -1038,9 +1436,19 @@ func TestStore_GetCollectionSiz_Closed_Conn(t *testing.T) {
 			},
 			want: -1,
 		},
+		{
+			name: "Test_Store_GetCollectionSize_OK",
+			args: args{
+				entityMetadata: transaction.Provider().GetEntityMetadata(),
+				collectionName: txn.GetCollectionName(),
+			},
+			want: -1,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if got := ms.GetCollectionSize(tt.args.ctx, tt.args.entityMetadata, tt.args.collectionName); got != tt.want {
 				t.Errorf("GetCollectionSize() = %v, want %v", got, tt.want)
@@ -1074,9 +1482,16 @@ func TestStore_AddToCollection(t *testing.T) {
 			args:    args{ce: &txn},
 			wantErr: true,
 		},
+		{
+			name:    "TestStore_AddToCollection_Closed_Conn_ERR",
+			args:    args{ce: &txn},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.AddToCollection(tt.args.ctx, tt.args.ce); (err != nil) != tt.wantErr {
 				t.Errorf("AddToCollection() error = %v, wantErr %v", err, tt.wantErr)
@@ -1110,9 +1525,16 @@ func TestStore_DeleteFromCollection(t *testing.T) {
 			args:    args{ce: &txn},
 			wantErr: true,
 		},
+		{
+			name:    "TestStore_DeleteFromCollection_Closed_Conn_ERR",
+			args:    args{ce: &txn},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ms := &memorystore.Store{}
 			if err := ms.DeleteFromCollection(tt.args.ctx, tt.args.ce); (err != nil) != tt.wantErr {
 				t.Errorf("DeleteFromCollection() error = %v, wantErr %v", err, tt.wantErr)

--- a/code/go/0chain.net/core/memorystore/worker_test.go
+++ b/code/go/0chain.net/core/memorystore/worker_test.go
@@ -43,6 +43,20 @@ func TestMemoryDBChunk_Add(t *testing.T) {
 				Length: 1,
 			},
 		},
+		{
+			name: "Test_MemoryDBChunk_Add_OK",
+			fields: fields{
+				Buffer: make([]datastore.Entity, 1),
+				Length: 0,
+			},
+			args: args{entity: r},
+			want: &memorystore.MemoryDBChunk{
+				Buffer: []datastore.Entity{
+					r,
+				},
+				Length: 1,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -92,6 +106,17 @@ func TestMemoryDBChunk_Get(t *testing.T) {
 			args: args{index: 0},
 			want: r,
 		},
+		{
+			name: "Test_MemoryDBChunk_Get_OK",
+			fields: fields{
+				Buffer: []datastore.Entity{
+					r,
+				},
+				Length: 1,
+			},
+			args: args{index: 0},
+			want: r,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -125,6 +150,19 @@ func TestMemoryDBChunk_Trim(t *testing.T) {
 		fields fields
 		want   *memorystore.MemoryDBChunk
 	}{
+		{
+			name: "Test_MemoryDBChunk_Trim_OK",
+			fields: fields{
+				Buffer: buff,
+				Length: 1,
+			},
+			want: &memorystore.MemoryDBChunk{
+				Buffer: []datastore.Entity{
+					r,
+				},
+				Length: 1,
+			},
+		},
 		{
 			name: "Test_MemoryDBChunk_Trim_OK",
 			fields: fields{
@@ -203,23 +241,46 @@ func TestMemoryDBChunkProcessor_Process(t *testing.T) {
 			name:      "Test_MemoryDBChunkProcessor_Process_OK",
 			wantPanic: true,
 		},
+		{
+			name: "Test_MemoryDBChunkProcessor_Process_OK",
+			fields: fields{
+				EntityMetadata: txn.GetEntityMetadata(),
+				ChunkChannel:   nil,
+			},
+			args: args{
+				ctx: context.TODO(),
+				chunk: &memorystore.MemoryDBChunk{
+					Buffer: []datastore.Entity{
+						&txn,
+					},
+				}},
+			wantPanic: false,
+		},
+		{
+			name:      "Test_MemoryDBChunkProcessor_Process_OK",
+			wantPanic: true,
+		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			defer func() {
-				got := recover()
-				if (got != nil) != tt.wantPanic {
-					t.Errorf("Process() want panic  = %v, but got = %v", tt.wantPanic, got)
+		for i := 0; i < 2; i++ {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				defer func() {
+					got := recover()
+					if (got != nil) != tt.wantPanic {
+						t.Errorf("Process() want panic  = %v, but got = %v", tt.wantPanic, got)
+					}
+				}()
+
+				mcp := &memorystore.MemoryDBChunkProcessor{
+					EntityMetadata: tt.fields.EntityMetadata,
+					ChunkChannel:   tt.fields.ChunkChannel,
 				}
-			}()
 
-			mcp := &memorystore.MemoryDBChunkProcessor{
-				EntityMetadata: tt.fields.EntityMetadata,
-				ChunkChannel:   tt.fields.ChunkChannel,
-			}
-
-			mcp.Process(tt.args.ctx, tt.args.chunk)
-		})
+				mcp.Process(tt.args.ctx, tt.args.chunk)
+			})
+		}
 	}
 }
 
@@ -250,9 +311,18 @@ func TestMemoryDBChunkProcessor_Run(t *testing.T) {
 			},
 			args: args{ctx: context.TODO()},
 		},
+		{
+			name: "Test_MemoryDBChunkProcessor_Run_OK",
+			fields: fields{
+				EntityMetadata: transaction.Provider().GetEntityMetadata(),
+			},
+			args: args{ctx: context.TODO()},
+		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			ch := make(chan datastore.Chunk)
 
 			mcp := &memorystore.MemoryDBChunkProcessor{


### PR DESCRIPTION
Modify existing unit test to expose race issues. All these tests are confirmed to produce race problems linked to issues:  https://github.com/0chain/0chain/issues/259, https://github.com/0chain/0chain/issues/260, https://github.com/0chain/0chain/issues/263, https://github.com/0chain/0chain/issues/265 and https://github.com/0chain/0chain/issues/195.

The tests were generated by duplicating each subtest case and then running all subtests in parallel. 

