### PR TITLE
ChangeCollectorI add mutex

### DIFF
--- a/code/go/0chain.net/core/util/mpt_node_change.go
+++ b/code/go/0chain.net/core/util/mpt_node_change.go
@@ -49,9 +49,7 @@ func (cc *ChangeCollector) AddChange(oldNode Node, newNode Node) {
 	cc.mutex.Lock()
 	defer cc.mutex.Unlock()
 	nhash := newNode.GetHash()
-	if _, ok := cc.Deletes[nhash]; ok {
-		delete(cc.Deletes, nhash)
-	}
+	delete(cc.Deletes, nhash)
 	if oldNode == nil {
 		change := &NodeChange{}
 		change.New = newNode
@@ -63,7 +61,7 @@ func (cc *ChangeCollector) AddChange(oldNode Node, newNode Node) {
 	if ok {
 		delete(cc.Changes, ohash)
 		if prevChange.Old != nil {
-			if bytes.Compare(newNode.GetHashBytes(), prevChange.Old.GetHashBytes()) == 0 {
+			if bytes.Equal(newNode.GetHashBytes(), prevChange.Old.GetHashBytes()) {
 				return
 			}
 		}
@@ -166,7 +164,7 @@ func (cc *ChangeCollector) PrintChanges(w io.Writer) {
 //Validate - validate if this change collector is valid
 func (cc *ChangeCollector) Validate() error {
 	cc.mutex.RLock()
-	cc.mutex.RUnlock()
+	defer cc.mutex.RUnlock()
 	for key := range cc.Changes {
 		if _, ok := cc.Deletes[key]; ok {
 			return errors.New("key present in both add and delete")


### PR DESCRIPTION
Issue https://github.com/0chain/0chain/issues/270. Add mutex protection to ChangeCollector. Tested in PR https://github.com/0chain/0chain/pull/268.

Fix lint issues
```
core/util/mpt_node_change.go:52:2: S1033: unnecessary guard around call to delete (gosimple)
if _, ok := cc.Deletes[nhash]; ok {

core/util/mpt_node_change.go:66:7: S1004: should use bytes.Equal(newNode.GetHashBytes(), prevChange.Old.GetHashBytes()) instead (gosimple)
if bytes.Compare(newNode.GetHashBytes(), prevChange.Old.GetHashBytes()) == 0 {
```