### PR TITLE
New smart contract factroy

### DIFF
--- a/code/go/0chain.net/chaincore/chain/state_handler_test.go
+++ b/code/go/0chain.net/chaincore/chain/state_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"0chain.net/chaincore/block"
 	"0chain.net/chaincore/chain"
 	"0chain.net/chaincore/config"
+	"0chain.net/chaincore/scfactory"
 	"0chain.net/chaincore/state"
 	"0chain.net/core/common"
 	"0chain.net/core/datastore"
@@ -29,6 +30,7 @@ import (
 )
 
 func init() {
+	scfactory.SetUpSmartContractFactory()
 	config.SetupDefaultConfig()
 	viper.Set("development.smart_contract.faucet", true)
 	viper.Set("development.smart_contract.interest", true)

--- a/code/go/0chain.net/chaincore/scfactory/scfactory.go
+++ b/code/go/0chain.net/chaincore/scfactory/scfactory.go
@@ -1,0 +1,10 @@
+package scfactory
+
+import (
+	"0chain.net/chaincore/smartcontract"
+	"0chain.net/smartcontract/setupsc"
+)
+
+func SetUpSmartContractFactory() {
+	smartcontract.SmartContractFactory = setupsc.NewSmartContractFactory()
+}

--- a/code/go/0chain.net/chaincore/scfactory/scfactory_test.go
+++ b/code/go/0chain.net/chaincore/scfactory/scfactory_test.go
@@ -21,7 +21,6 @@ import (
 func init() {
 	metrics.DefaultRegistry = metrics.NewRegistry()
 	config.SmartContractConfig = viper.New()
-	setupsc.SetupSmartContracts()
 	viper.Set("development.smart_contract.faucet", true)
 	viper.Set("development.smart_contract.storage", true)
 	viper.Set("development.smart_contract.zrc20", true)

--- a/code/go/0chain.net/chaincore/smartcontract/handler.go
+++ b/code/go/0chain.net/chaincore/smartcontract/handler.go
@@ -20,6 +20,8 @@ import (
 //ContractMap - stores the map of valid smart contracts mapping from its address to its interface implementation
 var ContractMap = map[string]sci.SmartContractInterface{}
 
+var SmartContractFactory sci.SmartContractFactoryI
+
 //ExecuteRestAPI - executes the rest api on the smart contract
 func ExecuteRestAPI(ctx context.Context, scAdress string, restpath string, params url.Values, balances c_state.StateContextI) (interface{}, error) {
 	_, sc := getSmartContract(scAdress)
@@ -50,7 +52,7 @@ func ExecuteStats(ctx context.Context, scAdress string, params url.Values, w htt
 func getSmartContract(scAddress string) (sci.SmartContractInterface, *sci.SmartContract) {
 	contracti, ok := ContractMap[scAddress]
 	if ok {
-		return contracti.MakeCopy()
+		return SmartContractFactory.NewSmartContract(contracti.GetName())
 	}
 	return nil, nil
 }

--- a/code/go/0chain.net/chaincore/smartcontract/handler_test.go
+++ b/code/go/0chain.net/chaincore/smartcontract/handler_test.go
@@ -1,0 +1,103 @@
+package smartcontract_test
+
+import (
+	"0chain.net/chaincore/config"
+	. "0chain.net/chaincore/smartcontract"
+	"0chain.net/smartcontract/faucetsc"
+	"0chain.net/smartcontract/interestpoolsc"
+	"0chain.net/smartcontract/minersc"
+	"0chain.net/smartcontract/multisigsc"
+	"0chain.net/smartcontract/setupsc"
+	"0chain.net/smartcontract/storagesc"
+	"0chain.net/smartcontract/vestingsc"
+	"0chain.net/smartcontract/zrc20sc"
+	"fmt"
+	"github.com/rcrowley/go-metrics"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func init() {
+	metrics.DefaultRegistry = metrics.NewRegistry()
+	config.SmartContractConfig = viper.New()
+	setupsc.SetupSmartContracts()
+	viper.Set("development.smart_contract.faucet", true)
+	viper.Set("development.smart_contract.storage", true)
+	viper.Set("development.smart_contract.zrc20", true)
+	viper.Set("development.smart_contract.interest", true)
+	viper.Set("development.smart_contract.multisig", true)
+	viper.Set("development.smart_contract.miner", true)
+	viper.Set("development.smart_contract.vesting", true)
+	setupsc.SetupSmartContracts()
+}
+
+func TestGetSmartContract(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		address    string
+		restpoints int
+		null       bool
+	}{
+		{
+			name:       "faucet",
+			address:    faucetsc.ADDRESS,
+			restpoints: 4,
+		},
+		{
+			name:       "storage",
+			address:    storagesc.ADDRESS,
+			restpoints: 16,
+		},
+		{
+			name:       "zrc20",
+			address:    zrc20sc.ADDRESS,
+			restpoints: 0,
+		},
+		{
+			name:       "interest",
+			address:    interestpoolsc.ADDRESS,
+			restpoints: 2,
+		},
+		{
+			name:       "multisig",
+			address:    multisigsc.Address,
+			restpoints: 0,
+		},
+		{
+			name:       "miner",
+			address:    minersc.ADDRESS,
+			restpoints: 13,
+		},
+		{
+			name:       "vesting",
+			address:    vestingsc.ADDRESS,
+			restpoints: 3,
+		},
+		{
+			name:    "Nil_OK",
+			address: "not an address",
+			null:    true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := GetSmartContract(tt.address)
+			if !tt.null == (got == nil) {
+				require.True(t, true)
+			}
+			require.True(t, tt.null == (got == nil))
+			if got == nil {
+				return
+			}
+			fmt.Println("name", got.GetName(), "address", got.GetAddress(), "rest points", len(got.GetRestPoints()))
+			require.EqualValues(t, tt.name, got.GetName())
+			require.EqualValues(t, tt.address, got.GetAddress())
+			require.EqualValues(t, tt.restpoints, len(got.GetRestPoints()))
+		})
+	}
+}

--- a/code/go/0chain.net/chaincore/smartcontractinterface/interface.go
+++ b/code/go/0chain.net/chaincore/smartcontractinterface/interface.go
@@ -37,6 +37,7 @@ type SmartContractInterface interface {
 	GetName() string
 	GetAddress() string
 	InitSC()
+	MakeCopy() (SmartContractInterface, *SmartContract)
 }
 
 /*BCContextI interface for smart contracts to access blockchain.

--- a/code/go/0chain.net/chaincore/smartcontractinterface/interface.go
+++ b/code/go/0chain.net/chaincore/smartcontractinterface/interface.go
@@ -37,7 +37,10 @@ type SmartContractInterface interface {
 	GetName() string
 	GetAddress() string
 	InitSC()
-	MakeCopy() (SmartContractInterface, *SmartContract)
+}
+
+type SmartContractFactoryI interface {
+	NewSmartContract(string) (SmartContractInterface, *SmartContract)
 }
 
 /*BCContextI interface for smart contracts to access blockchain.

--- a/code/go/0chain.net/miner/miner/main.go
+++ b/code/go/0chain.net/miner/miner/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"0chain.net/chaincore/scfactory"
 	"bufio"
 	"context"
 	"errors"
@@ -80,6 +81,7 @@ func main() {
 	reader.Close()
 
 	node.Self.SetSignatureScheme(signatureScheme)
+	scfactory.SetUpSmartContractFactory()
 
 	miner.SetupMinerChain(serverChain)
 	mc := miner.GetMinerChain()

--- a/code/go/0chain.net/sharder/sharder/main.go
+++ b/code/go/0chain.net/sharder/sharder/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"0chain.net/chaincore/scfactory"
 	"bufio"
 	"context"
 	"errors"
@@ -142,6 +143,7 @@ func main() {
 	chain.SetServerChain(serverChain)
 	chain.SetNetworkRelayTime(viper.GetDuration("network.relay_time") * time.Millisecond)
 	node.ReadConfig()
+	scfactory.SetUpSmartContractFactory()
 
 	if *initialStatesFile == "" {
 		*initialStatesFile = viper.GetString("network.initial_states")

--- a/code/go/0chain.net/smartcontract/faucetsc/sc.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/sc.go
@@ -27,7 +27,7 @@ type FaucetSmartContract struct {
 	*smartcontractinterface.SmartContract
 }
 
-func (fc *FaucetSmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+func NewFaucetSmartContract() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
 	var fcCopy = &FaucetSmartContract{
 		smartcontractinterface.NewSC(ADDRESS),
 	}

--- a/code/go/0chain.net/smartcontract/faucetsc/sc.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/sc.go
@@ -1,6 +1,7 @@
 package faucetsc
 
 import (
+	"0chain.net/chaincore/smartcontract"
 	"fmt"
 
 	c_state "0chain.net/chaincore/chain/state"
@@ -24,6 +25,14 @@ const (
 
 type FaucetSmartContract struct {
 	*smartcontractinterface.SmartContract
+}
+
+func (fc *FaucetSmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+	var fcCopy = &FaucetSmartContract{
+		smartcontractinterface.NewSC(ADDRESS),
+	}
+	fcCopy.SetSC(fcCopy.SmartContract, &smartcontract.BCContext{})
+	return fcCopy, fcCopy.SmartContract
 }
 
 func (fc *FaucetSmartContract) InitSC() {}

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
@@ -28,7 +28,7 @@ type InterestPoolSmartContract struct {
 	*smartcontractinterface.SmartContract
 }
 
-func (ipsc *InterestPoolSmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+func NewInterestPoolSmartContract() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
 	var ipscCopy = &InterestPoolSmartContract{
 		smartcontractinterface.NewSC(ADDRESS),
 	}

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
@@ -1,6 +1,7 @@
 package interestpoolsc
 
 import (
+	"0chain.net/chaincore/smartcontract"
 	"fmt"
 	"time"
 
@@ -25,6 +26,14 @@ const (
 
 type InterestPoolSmartContract struct {
 	*smartcontractinterface.SmartContract
+}
+
+func (ipsc *InterestPoolSmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+	var ipscCopy = &InterestPoolSmartContract{
+		smartcontractinterface.NewSC(ADDRESS),
+	}
+	ipscCopy.SetSC(ipscCopy.SmartContract, &smartcontract.BCContext{})
+	return ipscCopy, ipscCopy.SmartContract
 }
 
 func (ipsc *InterestPoolSmartContract) InitSC() {}

--- a/code/go/0chain.net/smartcontract/minersc/minersc.go
+++ b/code/go/0chain.net/smartcontract/minersc/minersc.go
@@ -7,10 +7,7 @@ import (
 )
 
 func (msc *MinerSmartContract) InitSC() {
-
-	if msc.smartContractFunctions == nil {
-		msc.smartContractFunctions = make(map[string]smartContractFunction)
-	}
+	msc.InitSmartContractFunctions()
 
 	phaseFuncs[Start] = msc.createDKGMinersForContribute
 	phaseFuncs[Contribute] = msc.widdleDKGMinersForShare
@@ -30,7 +27,12 @@ func (msc *MinerSmartContract) InitSC() {
 	moveFunctions[Share] = msc.moveToShareOrPublish
 	moveFunctions[Publish] = msc.moveToWait
 	moveFunctions[Wait] = msc.moveToStart
+}
 
+func (msc *MinerSmartContract) InitSmartContractFunctions() {
+	if msc.smartContractFunctions == nil {
+		msc.smartContractFunctions = make(map[string]smartContractFunction)
+	}
 	msc.smartContractFunctions["add_miner"] = msc.AddMiner
 	msc.smartContractFunctions["add_sharder"] = msc.AddSharder
 

--- a/code/go/0chain.net/smartcontract/minersc/sc.go
+++ b/code/go/0chain.net/smartcontract/minersc/sc.go
@@ -57,7 +57,7 @@ type MinerSmartContract struct {
 	smartContractFunctions map[string]smartContractFunction
 }
 
-func (msc *MinerSmartContract) MakeCopy() (sci.SmartContractInterface, *sci.SmartContract) {
+func NewMinerSmartContract() (sci.SmartContractInterface, *sci.SmartContract) {
 	var mscCopy = &MinerSmartContract{
 		SmartContract: sci.NewSC(ADDRESS),
 		bcContext:     &smartcontract.BCContext{},

--- a/code/go/0chain.net/smartcontract/minersc/sc.go
+++ b/code/go/0chain.net/smartcontract/minersc/sc.go
@@ -1,6 +1,7 @@
 package minersc
 
 import (
+	"0chain.net/chaincore/smartcontract"
 	"errors"
 	"fmt"
 	"net/url"
@@ -54,6 +55,16 @@ type MinerSmartContract struct {
 
 	mutexMinerMPK          sync.RWMutex
 	smartContractFunctions map[string]smartContractFunction
+}
+
+func (msc *MinerSmartContract) MakeCopy() (sci.SmartContractInterface, *sci.SmartContract) {
+	var mscCopy = &MinerSmartContract{
+		SmartContract: sci.NewSC(ADDRESS),
+		bcContext:     &smartcontract.BCContext{},
+	}
+	mscCopy.InitSmartContractFunctions()
+	mscCopy.SetSC(mscCopy.SmartContract, mscCopy.bcContext)
+	return mscCopy, mscCopy.SmartContract
 }
 
 func (msc *MinerSmartContract) GetName() string {

--- a/code/go/0chain.net/smartcontract/multisigsc/sc.go
+++ b/code/go/0chain.net/smartcontract/multisigsc/sc.go
@@ -1,6 +1,7 @@
 package multisigsc
 
 import (
+	"0chain.net/chaincore/smartcontract"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -25,6 +26,14 @@ const (
 
 type MultiSigSmartContract struct {
 	*smartcontractinterface.SmartContract
+}
+
+func (ms *MultiSigSmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+	var msCopy = &MultiSigSmartContract{
+		SmartContract: smartcontractinterface.NewSC(Address),
+	}
+	msCopy.SetSC(msCopy.SmartContract, &smartcontract.BCContext{})
+	return msCopy, msCopy.SmartContract
 }
 
 func (ms *MultiSigSmartContract) InitSC() {}

--- a/code/go/0chain.net/smartcontract/multisigsc/sc.go
+++ b/code/go/0chain.net/smartcontract/multisigsc/sc.go
@@ -28,7 +28,7 @@ type MultiSigSmartContract struct {
 	*smartcontractinterface.SmartContract
 }
 
-func (ms *MultiSigSmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+func NewMultiSigSmartContract() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
 	var msCopy = &MultiSigSmartContract{
 		SmartContract: smartcontractinterface.NewSC(Address),
 	}

--- a/code/go/0chain.net/smartcontract/setupsc/setupsc.go
+++ b/code/go/0chain.net/smartcontract/setupsc/setupsc.go
@@ -16,6 +16,18 @@ import (
 	"0chain.net/smartcontract/zrc20sc"
 )
 
+type SCName string
+
+const (
+	Faucet   SCName = "faucet"
+	Storage  SCName = "storage"
+	Zrc20    SCName = "zrc20"
+	Interest SCName = "interest"
+	Multisig SCName = "multisig"
+	Miner    SCName = "miner"
+	Vesting  SCName = "vesting"
+)
+
 var scs = []sci.SmartContractInterface{
 	&faucetsc.FaucetSmartContract{}, &storagesc.StorageSmartContract{},
 	&zrc20sc.ZRC20SmartContract{}, &interestpoolsc.InterestPoolSmartContract{},
@@ -31,5 +43,33 @@ func SetupSmartContracts() {
 			sc.InitSC()
 			smartcontract.ContractMap[sc.GetAddress()] = sc
 		}
+	}
+}
+
+type smartContractFactorys struct {
+}
+
+func NewSmartContractFactory() sci.SmartContractFactoryI {
+	return &smartContractFactorys{}
+}
+
+func (scf smartContractFactorys) NewSmartContract(name string) (sci.SmartContractInterface, *sci.SmartContract) {
+	switch SCName(name) {
+	case Faucet:
+		return faucetsc.NewFaucetSmartContract()
+	case Storage:
+		return storagesc.NewStorageSmartContract()
+	case Zrc20:
+		return zrc20sc.NewZRC20SmartContract()
+	case Interest:
+		return interestpoolsc.NewInterestPoolSmartContract()
+	case Multisig:
+		return multisigsc.NewMultiSigSmartContract()
+	case Miner:
+		return minersc.NewMinerSmartContract()
+	case Vesting:
+		return vestingsc.NewVestingSmartContract()
+	default:
+		return nil, nil
 	}
 }

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -26,7 +26,7 @@ type StorageSmartContract struct {
 	*sci.SmartContract
 }
 
-func (ssc *StorageSmartContract) MakeCopy() (sci.SmartContractInterface, *sci.SmartContract) {
+func NewStorageSmartContract() (sci.SmartContractInterface, *sci.SmartContract) {
 	var sscCopy = &StorageSmartContract{
 		SmartContract: sci.NewSC(ADDRESS),
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/chaincore/smartcontract"
 	"fmt"
 
 	chainstate "0chain.net/chaincore/chain/state"
@@ -23,6 +24,14 @@ const (
 
 type StorageSmartContract struct {
 	*sci.SmartContract
+}
+
+func (ssc *StorageSmartContract) MakeCopy() (sci.SmartContractInterface, *sci.SmartContract) {
+	var sscCopy = &StorageSmartContract{
+		SmartContract: sci.NewSC(ADDRESS),
+	}
+	sscCopy.SetSC(sscCopy.SmartContract, &smartcontract.BCContext{})
+	return sscCopy, sscCopy.SmartContract
 }
 
 func (ssc *StorageSmartContract) InitSC() {}

--- a/code/go/0chain.net/smartcontract/vestingsc/sc.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/sc.go
@@ -1,6 +1,7 @@
 package vestingsc
 
 import (
+	"0chain.net/chaincore/smartcontract"
 	"fmt"
 
 	chainstate "0chain.net/chaincore/chain/state"
@@ -18,6 +19,14 @@ type RestPoints = map[string]smartcontractinterface.SmartContractRestHandler
 
 type VestingSmartContract struct {
 	*smartcontractinterface.SmartContract
+}
+
+func (vsc *VestingSmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+	var vscCopy = &VestingSmartContract{
+		smartcontractinterface.NewSC(ADDRESS),
+	}
+	vscCopy.SetSC(vscCopy.SmartContract, &smartcontract.BCContext{})
+	return vscCopy, vscCopy.SmartContract
 }
 
 func (vsc *VestingSmartContract) InitSC() {}

--- a/code/go/0chain.net/smartcontract/vestingsc/sc.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/sc.go
@@ -21,7 +21,7 @@ type VestingSmartContract struct {
 	*smartcontractinterface.SmartContract
 }
 
-func (vsc *VestingSmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+func NewVestingSmartContract() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
 	var vscCopy = &VestingSmartContract{
 		smartcontractinterface.NewSC(ADDRESS),
 	}

--- a/code/go/0chain.net/smartcontract/zrc20sc/sc.go
+++ b/code/go/0chain.net/smartcontract/zrc20sc/sc.go
@@ -23,7 +23,7 @@ type ZRC20SmartContract struct {
 	*smartcontractinterface.SmartContract
 }
 
-func (zrc *ZRC20SmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+func NewZRC20SmartContract() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
 	var zrcCopy = &ZRC20SmartContract{
 		smartcontractinterface.NewSC(ADDRESS),
 	}

--- a/code/go/0chain.net/smartcontract/zrc20sc/sc.go
+++ b/code/go/0chain.net/smartcontract/zrc20sc/sc.go
@@ -1,6 +1,7 @@
 package zrc20sc
 
 import (
+	"0chain.net/chaincore/smartcontract"
 	"fmt"
 
 	c_state "0chain.net/chaincore/chain/state"
@@ -20,6 +21,14 @@ const (
 
 type ZRC20SmartContract struct {
 	*smartcontractinterface.SmartContract
+}
+
+func (zrc *ZRC20SmartContract) MakeCopy() (smartcontractinterface.SmartContractInterface, *smartcontractinterface.SmartContract) {
+	var zrcCopy = &ZRC20SmartContract{
+		smartcontractinterface.NewSC(ADDRESS),
+	}
+	zrcCopy.SetSC(zrcCopy.SmartContract, &smartcontract.BCContext{})
+	return zrcCopy, zrcCopy.SmartContract
 }
 
 func (zrc *ZRC20SmartContract) InitSC() {}


### PR DESCRIPTION
This resolves issue https://github.com/0chain/0chain/issues/260

Currently, there is only one smart contract object for each of the smart contracts. Each time a new smart contract is requested, its contents are copied onto itself. This copying is not properly protected against concurrent access.

This PR creates a different instance of a smart contract each time one is called. A new smart contract factory object is built to create them. This extra effort of a factory interface is needed to prevent against import cycles.