### PR TITLE
Features/allocation transfer 333

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -943,17 +943,14 @@ func (sc *StorageSmartContract) transferAllocation(t *transaction.Transaction,
 	alloc *StorageAllocation, tar *transferAllocationRequest,
 	balances chainstate.StateContextI,
 ) (resp string, err error) {
-	// get related write pool
-	var wp *writePool
-	if wp, err = sc.getWritePool(alloc.Owner, balances); err != nil {
-		return "", common.NewErrorf("allocation_transfer_failed",
-			"can't get write pool: %v", err)
+	// transfer write pool
+	err = sc.transferWritePool(t, alloc, tar.NewOwnerID, balances)
+	if err != nil {
+		return "", common.NewErrorf("allocation_transfer_failed", "%v", err)
 	}
 
-	// update read pool and allocation fields
-	// wp.transfer()
-
-	// enable if PayerID will be added to StorageAllocation one day
+	// set allocation fields
+	// enable if Payer will be added to StorageAllocation one day
 	// if alloc.Payer == alloc.OwnerID {
 	// 	alloc.Payer = tar.NewOwnerID
 	// }

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -202,6 +202,8 @@ func (sc *StorageSmartContract) Execute(t *transaction.Transaction,
 		resp, err = sc.newAllocationRequest(t, input, balances)
 	case "update_allocation_request":
 		resp, err = sc.updateAllocationRequest(t, input, balances)
+	case "transfer_allocation_request":
+		resp, err = sc.transferAllocationRequest(t, input, balances)
 	case "finalize_allocation":
 		resp, err = sc.finalizeAllocation(t, input, balances)
 	case "cancel_allocation":


### PR DESCRIPTION
Add method to transfer allocation from one owner to another.
The flow:
- update allocation owner's write pool to transfer non-used tokens from the related allocation pools
- update and save several allocation fields

PS. related to allocation challenge pools are owner-independent and remain unchanged