### PR TITLE
Features/generic allocation pool 323

### DIFF
--- a/code/go/0chain.net/chaincore/state/state.go
+++ b/code/go/0chain.net/chaincore/state/state.go
@@ -1,16 +1,26 @@
 package state
 
 import (
-	"0chain.net/core/encryption"
-	"0chain.net/core/logging"
-	"0chain.net/core/util"
+	"math"
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+
+	"0chain.net/core/encryption"
+	"0chain.net/core/logging"
+	"0chain.net/core/util"
 )
 
 //Balance - any quantity that is represented as an integer in the lowest denomination
 type Balance int64
+
+func (b Balance) Min(v Balance) Balance {
+	return Balance(math.Min(float64(b), float64(v)))
+}
+
+func (b Balance) Max(v Balance) Balance {
+	return Balance(math.Max(float64(b), float64(v)))
+}
 
 //State - state that needs consensus within the blockchain.
 type State struct {

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
@@ -138,8 +138,8 @@ func (bps *blobberPools) add(bp *blobberPool) (ok bool) {
 type allocationPool struct {
 	tokenpool.ZcnPool `json:"pool"`
 	ExpireAt          common.Timestamp `json:"expire_at"`     // inclusive
-	AllocationID      datastore.Key    `json:"allocation_id"` //
-	Blobbers          blobberPools     `json:"blobbers"`      //
+	AllocationID      datastore.Key    `json:"allocation_id"` // could be empty, for generic allocation pools
+	Blobbers          blobberPools     `json:"blobbers"`
 }
 
 //

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
@@ -142,6 +142,10 @@ type allocationPool struct {
 	Blobbers          blobberPools     `json:"blobbers"`
 }
 
+func (ap allocationPool) isGeneric() bool {
+	return ap.AllocationID == ""
+}
+
 //
 // allocation read/write pools (list)
 //
@@ -237,11 +241,20 @@ func (aps allocationPools) allocationCut(allocID string) (
 	return
 }
 
+// filter out allocation pools by specific blobber
 func (aps allocationPools) blobberCut(allocID, blobberID string,
-	now common.Timestamp) (cut []*allocationPool) {
-
+	now common.Timestamp,
+) (cut []*allocationPool) {
 	cut = aps.allocationCut(allocID)
 	cut = removeBlobberExpired(cut, blobberID, now)
+	sortExpireAt(cut)
+	return
+}
+
+// filter out generic allocaton pools
+func (aps allocationPools) genericCut(now common.Timestamp) (cut []*allocationPool) {
+	cut = aps.allocationCut("")
+	cut = removeExpired(cut, now)
 	sortExpireAt(cut)
 	return
 }


### PR DESCRIPTION
To implement such thing as "generic" allocation pool (specifically, "generic" read allocation pool). It's basically the same allocation pool entity, but not linked to specific allocation. So that it can be used to pay for reads from multiple allocations.

- enable funding with non-specified allocation id, creating so-called "generic" allocation pools
- upgrade spending to use generic allocations pools in conjunction with regular allocation pools