### PR TITLE
Add curator and transfer allocatin ownership

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1374,7 +1374,7 @@ func (sc *StorageSmartContract) finishAllocation(
 type transferAllocationInput struct {
 	AllocationId      string `json:"allocation_id"`
 	NewOwnerId        string `json:"new_owner_id"`
-	NewOwnerPublicKey string `json:"bew_owner_public_key"`
+	NewOwnerPublicKey string `json:"new_owner_public_key"`
 }
 
 func (aci *transferAllocationInput) decode(input []byte) error {
@@ -1418,6 +1418,7 @@ func (sc *StorageSmartContract) curatorTransferAllocation(
 			"saving new allocation: %v", err)
 	}
 
+	// txn.Hash is the id of the new token pool
 	return txn.Hash, nil
 }
 

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1461,7 +1461,10 @@ func (sc *StorageSmartContract) addCurator(
 	balances chainstate.StateContextI,
 ) (err error) {
 	var aci addCuratorInput
-	aci.decode(input)
+	if err = aci.decode(input); err != nil {
+		return common.NewError("add_curator_failed",
+			"error unmarshalling input: "+err.Error())
+	}
 
 	var alloc *StorageAllocation
 	alloc, err = sc.getAllocation(aci.AllocationId, balances)

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -348,7 +348,7 @@ func (sc *StorageSmartContract) newAllocationRequest(t *transaction.Transaction,
 	}
 
 	// create write pool and lock tokens
-	if err = sc.createWritePool(t, sa, false, balances); err != nil {
+	if err = sc.createWritePool(t, sa, balances); err != nil {
 		return "", common.NewError("allocation_creation_failed", err.Error())
 	}
 
@@ -694,7 +694,7 @@ func (sc *StorageSmartContract) extendAllocation(t *transaction.Transaction,
 			return "", common.NewError("allocation_extending_failed",
 				err.Error())
 		}
-		if _, err = wp.fill(t, alloc, until, false, balances); err != nil {
+		if _, err = wp.fill(t, alloc, until, balances); err != nil {
 			return "", common.NewErrorf("allocation_extending_failed",
 				"write pool filling: %v", err)
 		}
@@ -777,7 +777,7 @@ func (sc *StorageSmartContract) reduceAllocation(t *transaction.Transaction,
 			return "", common.NewErrorf("allocation_reducing_failed", "%v", err)
 		}
 		var until = alloc.Until()
-		if _, err = wp.fill(t, alloc, until, false, balances); err != nil {
+		if _, err = wp.fill(t, alloc, until, balances); err != nil {
 			return "", common.NewErrorf("allocation_reducing_failed", "%v", err)
 		}
 	}
@@ -1406,7 +1406,7 @@ func (sc *StorageSmartContract) curatorTransferAllocation(
 	alloc.OwnerPublicKey = tai.NewOwnerPublicKey
 
 	if !alloc.hasWritePool(sc, tai.NewOwnerId, balances) {
-		if err = sc.createWritePool(txn, alloc, true, balances); err != nil {
+		if err = sc.createEmptyWritePool(txn, alloc, balances); err != nil {
 			return "", common.NewError("curator_transfer_allocation_failed",
 				"error creating write pool: "+err.Error())
 		}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -277,7 +277,7 @@ func TestTransferAllocation(t *testing.T) {
 			t.Parallel()
 			args := setExpectations(t, test.name, test.parameters, test.want)
 
-			err := args.ssc.transferAllocationRequest(args.txn, args.input, args.balances)
+			err := args.ssc.curatorTransferAllocation(args.txn, args.input, args.balances)
 
 			require.EqualValues(t, test.want.err, err != nil)
 			if err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -1,7 +1,11 @@
 package storagesc
 
 import (
+	"0chain.net/chaincore/mocks"
+	sci "0chain.net/chaincore/smartcontractinterface"
+	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/mock"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +57,103 @@ func TestStorageSmartContract_getAllocation(t *testing.T) {
 	got, err = ssc.getAllocation(allocID, balances)
 	require.NoError(t, err)
 	assert.Equal(t, alloc.Encode(), got.Encode())
+}
+
+func TestAddCurator(t *testing.T) {
+	t.Parallel()
+	const (
+		mockClientId     = "mock client id"
+		mockCuratorId    = "mock curator id"
+		mockAllocationId = "mock allocation ids"
+	)
+	type args struct {
+		ssc      *StorageSmartContract
+		txn      *transaction.Transaction
+		input    []byte
+		balances chainState.StateContextI
+	}
+	type parameters struct {
+		clientId         string
+		info             addCuratorInput
+		existingCurators []string
+	}
+	type want struct {
+		err    bool
+		errMsg string
+	}
+	var setExpectations = func(t *testing.T, name string, p parameters, want want) args {
+		var balances = &mocks.StateContextI{}
+		var txn = &transaction.Transaction{
+			ClientID: p.clientId,
+		}
+		var ssc = &StorageSmartContract{
+			SmartContract: sci.NewSC(ADDRESS),
+		}
+		input, err := json.Marshal(p.info)
+		require.NoError(t, err)
+
+		var sa = StorageAllocation{
+			ID:    p.info.AllocationId,
+			Owner: p.clientId,
+		}
+		for _, curator := range p.existingCurators {
+			sa.Curators = append(sa.Curators, curator)
+		}
+		balances.On("GetTrieNode", sa.GetKey(ssc.ID)).Return(&sa, nil).Once()
+
+		balances.On(
+			"InsertTrieNode",
+			sa.GetKey(ssc.ID),
+			mock.MatchedBy(func(sa *StorageAllocation) bool {
+				if len(sa.Curators) < 1 {
+					return false
+				}
+				for i, curator := range p.existingCurators {
+					if curator != sa.Curators[i] {
+						return false
+					}
+				}
+				if p.info.CuratorId != sa.Curators[len(sa.Curators)-1] {
+					return false
+				}
+				return sa.ID == p.info.AllocationId && sa.Owner == p.clientId
+			})).Return("", nil).Once()
+
+		return args{ssc, txn, input, balances}
+	}
+
+	testCases := []struct {
+		name       string
+		parameters parameters
+		want       want
+	}{
+		{
+			name: "ok",
+			parameters: parameters{
+				clientId: mockClientId,
+				info: addCuratorInput{
+					CuratorId:    mockCuratorId,
+					AllocationId: mockAllocationId,
+				},
+			},
+		},
+	}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			args := setExpectations(t, test.name, test.parameters, test.want)
+
+			err := args.ssc.addCurator(args.txn, args.input, args.balances)
+
+			require.EqualValues(t, test.want.err, err != nil)
+			if err != nil {
+				require.EqualValues(t, test.want.errMsg, err.Error())
+				return
+			}
+			require.True(t, mock.AssertExpectationsForObjects(t, args.balances))
+		})
+	}
 }
 
 func isEqualStrings(a, b []string) (eq bool) {

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -277,13 +277,14 @@ func TestTransferAllocation(t *testing.T) {
 			t.Parallel()
 			args := setExpectations(t, test.name, test.parameters, test.want)
 
-			err := args.ssc.curatorTransferAllocation(args.txn, args.input, args.balances)
+			resp, err := args.ssc.curatorTransferAllocation(args.txn, args.input, args.balances)
 
 			require.EqualValues(t, test.want.err, err != nil)
 			if err != nil {
 				require.EqualValues(t, test.want.errMsg, err.Error())
 				return
 			}
+			require.EqualValues(t, args.txn.Hash, resp)
 			require.True(t, mock.AssertExpectationsForObjects(t, args.balances))
 		})
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/mock"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -20,14 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-//
-// use:
-//
-//      go test -cover -coverprofile=cover.out && go tool cover -html=cover.out -o=cover.html
-//
-// to test and generate coverage html page
-//
 
 func TestStorageSmartContract_getAllocation(t *testing.T) {
 	const allocID, clientID, clientPk = "alloc_hex", "client_hex", "pk"
@@ -64,7 +57,7 @@ func TestAddCurator(t *testing.T) {
 	const (
 		mockClientId     = "mock client id"
 		mockCuratorId    = "mock curator id"
-		mockAllocationId = "mock allocation ids"
+		mockAllocationId = "mock allocation id"
 	)
 	type args struct {
 		ssc      *StorageSmartContract
@@ -145,6 +138,146 @@ func TestAddCurator(t *testing.T) {
 			args := setExpectations(t, test.name, test.parameters, test.want)
 
 			err := args.ssc.addCurator(args.txn, args.input, args.balances)
+
+			require.EqualValues(t, test.want.err, err != nil)
+			if err != nil {
+				require.EqualValues(t, test.want.errMsg, err.Error())
+				return
+			}
+			require.True(t, mock.AssertExpectationsForObjects(t, args.balances))
+		})
+	}
+}
+
+func TestTransferAllocation(t *testing.T) {
+	t.Parallel()
+	const (
+		mockNewOwnerId        = "mock new owner id"
+		mockNewOwnerPublicKey = "mock new owner public key"
+		mockCuratorId         = "mock curator id"
+		mockAllocationId      = "mock allocation id"
+		mockNotAllocationId   = "mock not allocation id"
+	)
+	type args struct {
+		ssc      *StorageSmartContract
+		txn      *transaction.Transaction
+		input    []byte
+		balances chainState.StateContextI
+	}
+	type parameters struct {
+		curator                 string
+		info                    transferAllocationInput
+		existingCurators        []string
+		existingWPForAllocation bool
+		existingNoiseWPools     int
+	}
+	type want struct {
+		err    bool
+		errMsg string
+	}
+	var setExpectations = func(t *testing.T, name string, p parameters, want want) args {
+		var balances = &mocks.StateContextI{}
+		var txn = &transaction.Transaction{
+			ClientID: p.curator,
+		}
+		var ssc = &StorageSmartContract{
+			SmartContract: sci.NewSC(ADDRESS),
+		}
+		input, err := json.Marshal(p.info)
+		require.NoError(t, err)
+
+		var sa = StorageAllocation{
+			ID: p.info.AllocationId,
+		}
+		for _, curator := range p.existingCurators {
+			sa.Curators = append(sa.Curators, curator)
+		}
+		balances.On("GetTrieNode", sa.GetKey(ssc.ID)).Return(&sa, nil).Once()
+
+		var wp writePool
+		if p.existingWPForAllocation || p.existingNoiseWPools > 0 {
+			for i := 0; i < p.existingNoiseWPools; i++ {
+				wp.Pools.add(&allocationPool{AllocationID: mockNotAllocationId + strconv.Itoa(i)})
+			}
+			if p.existingWPForAllocation {
+				wp.Pools.add(&allocationPool{AllocationID: p.info.AllocationId})
+			}
+			balances.On("GetTrieNode", writePoolKey(ssc.ID, p.info.NewOwnerId)).Return(&wp, nil).Twice()
+		} else {
+			balances.On("GetTrieNode", writePoolKey(ssc.ID, p.info.NewOwnerId)).Return(
+				nil, util.ErrValueNotPresent).Twice()
+		}
+
+		balances.On(
+			"InsertTrieNode",
+			writePoolKey(ssc.ID, p.info.NewOwnerId),
+			mock.MatchedBy(func(wp *writePool) bool {
+				if p.existingNoiseWPools+1 != len(wp.Pools) {
+					return false
+				}
+				_, ok := wp.Pools.get(p.info.AllocationId)
+				return ok
+
+			})).Return("", nil).Once()
+
+		balances.On(
+			"InsertTrieNode",
+			sa.GetKey(ssc.ID),
+			mock.MatchedBy(func(sa *StorageAllocation) bool {
+				for i, curator := range p.existingCurators {
+					if sa.Curators[i] != curator {
+						return false
+					}
+				}
+				return sa.ID == p.info.AllocationId &&
+					sa.Owner == p.info.NewOwnerId &&
+					sa.OwnerPublicKey == p.info.NewOwnerPublicKey
+			})).Return("", nil).Once()
+
+		return args{ssc, txn, input, balances}
+	}
+
+	testCases := []struct {
+		name       string
+		parameters parameters
+		want       want
+	}{
+		{
+			name: "ok",
+			parameters: parameters{
+				curator: mockCuratorId,
+				info: transferAllocationInput{
+					AllocationId:      mockAllocationId,
+					NewOwnerId:        mockNewOwnerId,
+					NewOwnerPublicKey: mockNewOwnerPublicKey,
+				},
+				existingCurators:        []string{mockCuratorId, "another", "and another"},
+				existingNoiseWPools:     3,
+				existingWPForAllocation: false,
+			},
+		},
+		{
+			name: "ok",
+			parameters: parameters{
+				curator: mockCuratorId,
+				info: transferAllocationInput{
+					AllocationId:      mockAllocationId,
+					NewOwnerId:        mockNewOwnerId,
+					NewOwnerPublicKey: mockNewOwnerPublicKey,
+				},
+				existingCurators:        []string{mockCuratorId, "another", "and another"},
+				existingNoiseWPools:     0,
+				existingWPForAllocation: false,
+			},
+		},
+	}
+	for _, test := range testCases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			args := setExpectations(t, test.name, test.parameters, test.want)
+
+			err := args.ssc.transferAllocationRequest(args.txn, args.input, args.balances)
 
 			require.EqualValues(t, test.want.err, err != nil)
 			if err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -270,6 +270,22 @@ func TestTransferAllocation(t *testing.T) {
 				existingWPForAllocation: false,
 			},
 		},
+		{
+			name: "Err_not_curator",
+			parameters: parameters{
+				curator: mockCuratorId,
+				info: transferAllocationInput{
+					AllocationId:      mockAllocationId,
+					NewOwnerId:        mockNewOwnerId,
+					NewOwnerPublicKey: mockNewOwnerPublicKey,
+				},
+				existingCurators: []string{"not mock curator"},
+			},
+			want: want{
+				err:    true,
+				errMsg: "curator_transfer_allocation_failed: only curators can transfer allocations; mock curator id is not a curator",
+			},
+		},
 	}
 	for _, test := range testCases {
 		test := test

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -554,6 +554,8 @@ type StorageAllocation struct {
 	// TimeUnit configured in Storage SC when the allocation created. It can't
 	// be changed for this allocation anymore. Even using expire allocation.
 	TimeUnit time.Duration `json:"time_unit"`
+
+	Curators []string `json:"curators"`
 }
 
 // The restMinLockDemand returns number of tokens required as min_lock_demand;

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -209,6 +209,8 @@ func (sc *StorageSmartContract) Execute(t *transaction.Transaction,
 
 	case "add_curator":
 		resp, err = "", sc.addCurator(t, input, balances)
+	case "transfer_allocation_request":
+		resp, err = "", sc.transferAllocationRequest(t, input, balances)
 
 	// blobbers
 
@@ -245,13 +247,6 @@ func (sc *StorageSmartContract) Execute(t *transaction.Transaction,
 		resp, err = sc.stakePoolUnlock(t, input, balances)
 	case "stake_pool_pay_interests":
 		resp, err = sc.stakePoolPayInterests(t, input, balances)
-
-	// case "challenge_request":
-	// 	resp, err := sc.addChallenge(t, balances.GetBlock(), input, balances)
-	// 	if err != nil {
-	// 		return "", err
-	// 	}
-	// 	return resp, nil
 
 	case "generate_challenges":
 		challengesEnabled := config.SmartContractConfig.GetBool(

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -61,6 +61,9 @@ func (ssc *StorageSmartContract) setSC(sc *sci.SmartContract, bcContext sci.BCCo
 	ssc.SmartContractExecutionStats["update_allocation_request"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", ssc.ID, "update_allocation_request"), nil)
 	ssc.SmartContractExecutionStats["finalize_allocation"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", ssc.ID, "finalize_allocation"), nil)
 	ssc.SmartContractExecutionStats["cancel_allocation"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", ssc.ID, "cancel_allocation"), nil)
+
+	ssc.SmartContractExecutionStats["add_curator"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", ssc.ID, "add_curator"), nil)
+	ssc.SmartContractExecutionStats["curator_transfer_allocation"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", ssc.ID, "curator_transfer_allocation"), nil)
 	// challenge
 	ssc.SmartContract.RestHandlers["/openchallenges"] = ssc.OpenChallengeHandler
 	ssc.SmartContract.RestHandlers["/getchallenge"] = ssc.GetChallengeHandler
@@ -209,8 +212,8 @@ func (sc *StorageSmartContract) Execute(t *transaction.Transaction,
 
 	case "add_curator":
 		resp, err = "", sc.addCurator(t, input, balances)
-	case "transfer_allocation_request":
-		resp, err = "", sc.transferAllocationRequest(t, input, balances)
+	case "curator_transfer_allocation":
+		resp, err = "", sc.curatorTransferAllocation(t, input, balances)
 
 	// blobbers
 

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -207,6 +207,9 @@ func (sc *StorageSmartContract) Execute(t *transaction.Transaction,
 	case "cancel_allocation":
 		resp, err = sc.cancelAllocationRequest(t, input, balances)
 
+	case "add_curator":
+		resp, err = "", sc.addCurator(t, input, balances)
+
 	// blobbers
 
 	case "add_blobber":

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -213,7 +213,7 @@ func (sc *StorageSmartContract) Execute(t *transaction.Transaction,
 	case "add_curator":
 		resp, err = "", sc.addCurator(t, input, balances)
 	case "curator_transfer_allocation":
-		resp, err = "", sc.curatorTransferAllocation(t, input, balances)
+		resp, err = sc.curatorTransferAllocation(t, input, balances)
 
 	// blobbers
 

--- a/code/go/0chain.net/smartcontract/storagesc/writepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool.go
@@ -326,7 +326,7 @@ func (ssc *StorageSmartContract) createWritePool(
 
 	if force || t.Value > 0 {
 		var until = alloc.Until()
-		if _, err = wp.fill(t, alloc, until, true, balances); err != nil {
+		if _, err = wp.fill(t, alloc, until, force, balances); err != nil {
 			return
 		}
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/writepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool.go
@@ -254,6 +254,8 @@ func (wp *writePool) fill(
 		if err = balances.AddTransfer(transfer); err != nil {
 			return "", fmt.Errorf("adding transfer to write pool: %v", err)
 		}
+	} else {
+		ap.TokenPool.ID = t.Hash
 	}
 
 	ap.AllocationID = alloc.ID

--- a/code/go/0chain.net/smartcontract/storagesc/writepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool.go
@@ -242,14 +242,14 @@ func (wp *writePool) fill(t *transaction.Transaction, alloc *StorageAllocation,
 	// set fields
 	ap.AllocationID = alloc.ID
 	ap.ExpireAt = until
-	ap.Blobbers = allocationBlobbers(*alloc, t.Value)
+	ap.Blobbers = makeCopyAllocationBlobbers(*alloc, t.Value)
 
 	// add the allocation pool
 	wp.Pools.add(&ap)
 	return
 }
 
-func allocationBlobbers(alloc StorageAllocation, value int64) blobberPools {
+func makeCopyAllocationBlobbers(alloc StorageAllocation, value int64) blobberPools {
 	var bps blobberPools
 	var total float64
 	for _, b := range alloc.BlobberDetails {
@@ -320,7 +320,7 @@ func (ssc *StorageSmartContract) createEmptyWritePool(
 	var ap = allocationPool{
 		AllocationID: alloc.ID,
 		ExpireAt:     alloc.Until(),
-		Blobbers:     allocationBlobbers(*alloc, txn.Value),
+		Blobbers:     makeCopyAllocationBlobbers(*alloc, txn.Value),
 	}
 	ap.TokenPool.ID = txn.Hash
 	wp.Pools.add(&ap)

--- a/code/go/0chain.net/smartcontract/storagesc/writepool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool_test.go
@@ -182,7 +182,7 @@ func TestStorageSmartContract_writePoolLock(t *testing.T) {
 
 	tx.Hash = "new_write_pool_tx_hash"
 	tx.Value, balances.balances[client.id] = 40, 40 // set {
-	err = ssc.createWritePool(&tx, &alloc, false, balances)
+	err = ssc.createWritePool(&tx, &alloc, balances)
 	require.NoError(t, err)
 	tx.Hash = txHash
 	tx.Value, balances.balances[client.id] = 0, 0 // } reset

--- a/code/go/0chain.net/smartcontract/storagesc/writepool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool_test.go
@@ -182,7 +182,7 @@ func TestStorageSmartContract_writePoolLock(t *testing.T) {
 
 	tx.Hash = "new_write_pool_tx_hash"
 	tx.Value, balances.balances[client.id] = 40, 40 // set {
-	err = ssc.createWritePool(&tx, &alloc, balances)
+	err = ssc.createWritePool(&tx, &alloc, false, balances)
 	require.NoError(t, err)
 	tx.Hash = txHash
 	tx.Value, balances.balances[client.id] = 0, 0 // } reset


### PR DESCRIPTION
Part of issue https://github.com/0chain/0chain/issues/333

Adds a curator to a list of allocation's curators. A curator can transfer allocations owners.
Adds transaction for a curator to trasnfer ownership.

Requires changes to gosdk  https://github.com/0chain/gosdk/pull/121 and zboxcli https://github.com/0chain/zboxcli/pull/47.