### PR TITLE
Return empty list, if there is no challenges

### DIFF
--- a/code/go/0chain.net/chaincore/chain/state_handler_test.go
+++ b/code/go/0chain.net/chaincore/chain/state_handler_test.go
@@ -2752,7 +2752,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 			wantStatus:     http.StatusInternalServerError,
 		},
 		{
-			name:  "Storagesc_/openchallenges_200",
+			name:  "Storagesc_/openchallenges_404",
 			chain: serverChain,
 			args: args{
 				w: httptest.NewRecorder(),
@@ -2764,7 +2764,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 				}(),
 			},
 			setValidConfig: true,
-			wantStatus:     http.StatusOK,
+			wantStatus:     http.StatusNotFound,
 		},
 		{
 			name: "Storagesc_/openchallenges_404",

--- a/code/go/0chain.net/chaincore/chain/state_handler_test.go
+++ b/code/go/0chain.net/chaincore/chain/state_handler_test.go
@@ -1166,7 +1166,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 			wantStatus:     http.StatusNotFound,
 		},
 		{
-			name: "Storagesc_/openchallenges_500",
+			name: "Storagesc_/openchallenges_404",
 			chain: func() *chain.Chain {
 				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
 
@@ -1191,7 +1191,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 					return req
 				}(),
 			},
-			wantStatus: http.StatusInternalServerError,
+			wantStatus: http.StatusNotFound,
 		},
 		{
 			name:  "Storagesc_/getchallenge_404",
@@ -2752,7 +2752,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 			wantStatus:     http.StatusInternalServerError,
 		},
 		{
-			name:  "Storagesc_/openchallenges_404",
+			name:  "Storagesc_/openchallenges_200",
 			chain: serverChain,
 			args: args{
 				w: httptest.NewRecorder(),
@@ -2764,10 +2764,10 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 				}(),
 			},
 			setValidConfig: true,
-			wantStatus:     http.StatusNotFound,
+			wantStatus:     http.StatusOK,
 		},
 		{
-			name: "Storagesc_/openchallenges_500",
+			name: "Storagesc_/openchallenges_404",
 			chain: func() *chain.Chain {
 				gv := util.SecureSerializableValue{Buffer: []byte("}{")}
 
@@ -2792,7 +2792,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 					return req
 				}(),
 			},
-			wantStatus: http.StatusInternalServerError,
+			wantStatus: http.StatusNotFound,
 		},
 		{
 			name:  "Storagesc_/getchallenge_404",

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -209,12 +209,11 @@ func (ssc *StorageSmartContract) OpenChallengeHandler(ctx context.Context, param
 	blobberChallengeObj.Challenges = make([]*StorageChallenge, 0)
 
 	blobberChallengeBytes, err := balances.GetTrieNode(blobberChallengeObj.GetKey(ssc.ID))
-	if err != nil {
-		return "", smartcontract.NewErrNoResourceOrErrInternal(err, true, "error reading blobber challenge from DB")
-	}
-	err = blobberChallengeObj.Decode(blobberChallengeBytes.Encode())
-	if err != nil {
-		return nil, common.NewErrInternal("fail decoding blobber challenge", err.Error())
+	if err == nil {
+		err = blobberChallengeObj.Decode(blobberChallengeBytes.Encode())
+		if err != nil {
+			return nil, common.NewErrInternal("fail decoding blobber challenge", err.Error())
+		}
 	}
 
 	// for k, v := range blobberChallengeObj.ChallengeMap {
@@ -223,6 +222,8 @@ func (ssc *StorageSmartContract) OpenChallengeHandler(ctx context.Context, param
 	// 	}
 	// }
 
+	// return populate or empty list of challenges
+	// don't return error, if no challenges (expected by blobbers)
 	return &blobberChallengeObj, nil
 }
 


### PR DESCRIPTION
Blobbers start to try to fetch open challenges prior any challenge (incl. challenge pool) is created.
Sharders should return empty list, not error message, if there are no challenges/challenge pool yet.

<img width="798" alt="Screenshot 2021-06-21 at 06 20 53" src="https://user-images.githubusercontent.com/3892914/122706775-eec86e80-d258-11eb-8bcc-75ef3716e4ed.png">

PS. It could be extended later to return error for non-registered blobbers. When blobber is unknown. Even though it's not critical.