### PR TITLE
Revert "Shell Checks"

### DIFF
--- a/docker.local/bin/build.miners-integration-tests.sh
+++ b/docker.local/bin/build.miners-integration-tests.sh
@@ -2,13 +2,13 @@
 set -e
 
 GIT_COMMIT=$(git rev-list -1 HEAD)
-echo "$GIT_COMMIT"
+echo $GIT_COMMIT
 
-docker build --build-arg GIT_COMMIT="$GIT_COMMIT" -f docker.local/build.miner/Dockerfile.integration_tests . -t miner
+docker build --build-arg GIT_COMMIT=$GIT_COMMIT -f docker.local/build.miner/Dockerfile.integration_tests . -t miner
 
 for i in $(seq 1 5);
 do
-  MINER=$i docker-compose -p miner"$i" -f docker.local/build.miner/docker-compose.yml build --force-rm
+  MINER=$i docker-compose -p miner$i -f docker.local/build.miner/docker-compose.yml build --force-rm
 done
 
 docker.local/bin/sync_clock.sh

--- a/docker.local/bin/build.sharders-integration-tests.sh
+++ b/docker.local/bin/build.sharders-integration-tests.sh
@@ -2,13 +2,13 @@
 set -e
 
 GIT_COMMIT=$(git rev-list -1 HEAD)
-echo "$GIT_COMMIT"
+echo $GIT_COMMIT
 
-docker build --build-arg GIT_COMMIT="$GIT_COMMIT" -f docker.local/build.sharder/Dockerfile.integration_tests . -t sharder
+docker build --build-arg GIT_COMMIT=$GIT_COMMIT -f docker.local/build.sharder/Dockerfile.integration_tests . -t sharder
 
 for i in $(seq 1 3);
 do
-  SHARDER=$i docker-compose -p sharder"$i" -f docker.local/build.sharder/docker-compose.yml build --force-rm
+  SHARDER=$i docker-compose -p sharder$i -f docker.local/build.sharder/docker-compose.yml build --force-rm
 done
 
 docker.local/bin/sync_clock.sh

--- a/docker.local/bin/build.sharders.sh
+++ b/docker.local/bin/build.sharders.sh
@@ -2,7 +2,7 @@
 set -e
 
 GIT_COMMIT=$(git rev-list -1 HEAD)
-echo "$GIT_COMMIT"
+echo $GIT_COMMIT
 
 cmd="build"
 
@@ -17,7 +17,7 @@ do
     esac
 done
 
-docker $cmd --build-arg GIT_COMMIT="$GIT_COMMIT" -f docker.local/build.sharder/Dockerfile . -t sharder
+docker $cmd --build-arg GIT_COMMIT=$GIT_COMMIT -f docker.local/build.sharder/Dockerfile . -t sharder
 
 for i in $(seq 1 3);
 do

--- a/docker.local/bin/clean.sh
+++ b/docker.local/bin/clean.sh
@@ -3,28 +3,28 @@
 for i in $(seq 1 8)
 do
   echo "deleting miner$i logs"
-  rm -rf docker.local/miner"$i"/log/*
+  rm -rf docker.local/miner$i/log/*
   echo "deleting miner$i redis db"
-  rm -rf docker.local/miner"$i"/data/redis/state/*
-  rm -rf docker.local/miner"$i"/data/redis/transactions/*
+  rm -rf docker.local/miner$i/data/redis/state/*
+  rm -rf docker.local/miner$i/data/redis/transactions/*
   echo "deleting miner$i rocksdb db"
-  rm -rf docker.local/miner"$i"/data/rocksdb/config*
-  rm -rf docker.local/miner"$i"/data/rocksdb/mb*
-  rm -rf docker.local/miner"$i"/data/rocksdb/state*
+  rm -rf docker.local/miner$i/data/rocksdb/config*
+  rm -rf docker.local/miner$i/data/rocksdb/mb*
+  rm -rf docker.local/miner$i/data/rocksdb/state*
 done
 
 for i in $(seq 1 3)
 do
   echo "deleting sharder$i logs"
-  rm -rf docker.local/sharder"$i"/log/*
+  rm -rf docker.local/sharder$i/log/*
   echo "deleting sharder$i cassandra db"
-  rm -rf docker.local/sharder"$i"/data/cassandra/*
+  rm -rf docker.local/sharder$i/data/cassandra/*
   echo "deleting sharder$i rocksdb db"
-  rm -rf docker.local/sharder"$i"/data/rocksdb/*
+  rm -rf docker.local/sharder$i/data/rocksdb/*
 done
 
 for i in $(seq 1 3)
 do
   echo "deleting sharder$i blocks on the file system"
-  rm -rf docker.local/sharder"$i"/data/blocks/*
+  rm -rf docker.local/sharder$i/data/blocks/*
 done

--- a/docker.local/bin/clean_miners_dkg.sh
+++ b/docker.local/bin/clean_miners_dkg.sh
@@ -3,5 +3,5 @@
 for i in $(seq 1 8)
 do
   echo "deleting miner$i rocksdb db for dkg"
-  rm -rf docker.local/miner"$i"/data/rocksdb/dkg*
+  rm -rf docker.local/miner$i/data/rocksdb/dkg*
 done

--- a/docker.local/bin/del_state_db.sh
+++ b/docker.local/bin/del_state_db.sh
@@ -2,10 +2,10 @@
 
 for i in $(seq 1 3)
 do
-  rm -rf docker.local/miner"$i"/data/rocksdb/state
+  rm -rf docker.local/miner$i/data/rocksdb/state
 done
 
 for i in $(seq 1 3)
 do
-  rm -rf docker.local/sharder"$i"/data/rocksdb/state
+  rm -rf docker.local/sharder$i/data/rocksdb/state
 done

--- a/docker.local/bin/fstart.miner.sh
+++ b/docker.local/bin/fstart.miner.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-PWD=$(pwd)
-MINER_DIR=$(basename "$PWD")
-MINER_ID=$(echo "$MINER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+MINER_DIR=`basename $PWD`
+MINER_ID=`echo $MINER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
 
-echo Starting miner"$MINER_ID" ...
+echo Starting miner$MINER_ID ...
 
-MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f ../build.miner/docker-compose.yml start redis_txns
-MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f ../build.miner/docker-compose.yml start miner
+MINER=$MINER_ID docker-compose -p miner$MINER_ID -f ../build.miner/docker-compose.yml start redis_txns
+MINER=$MINER_ID docker-compose -p miner$MINER_ID -f ../build.miner/docker-compose.yml start miner

--- a/docker.local/bin/fstart.sharder.sh
+++ b/docker.local/bin/fstart.sharder.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-PWD=$(pwd)
-SHARDER_DIR=$(basename "$PWD")
-SHARDER_ID=$(echo "$SHARDER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+SHARDER_DIR=`basename $PWD`
+SHARDER_ID=`echo $SHARDER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
-echo Starting sharder"$SHARDER_ID" ...
+echo Starting sharder$SHARDER_ID ...
 
-SHARDER=$SHARDER_ID docker-compose -p sharder"$SHARDER_ID" -f ../build.sharder/docker-compose.yml start sharder
+SHARDER=$SHARDER_ID docker-compose -p sharder$SHARDER_ID -f ../build.sharder/docker-compose.yml start sharder

--- a/docker.local/bin/fstop_all.miner.sh
+++ b/docker.local/bin/fstop_all.miner.sh
@@ -3,7 +3,7 @@
 for i in $(seq 1 3);
 do
   MINER_ID=$i
-  echo Stopping miner"$MINER_ID" ...
-  MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f docker.local/build.miner/docker-compose.yml stop miner
-  MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f docker.local/build.miner/docker-compose.yml stop redis_txns
+  echo Stopping miner$MINER_ID ...
+  MINER=$MINER_ID docker-compose -p miner$MINER_ID -f docker.local/build.miner/docker-compose.yml stop miner
+  MINER=$MINER_ID docker-compose -p miner$MINER_ID -f docker.local/build.miner/docker-compose.yml stop redis_txns
 done

--- a/docker.local/bin/fstop_all.sharder.sh
+++ b/docker.local/bin/fstop_all.sharder.sh
@@ -3,6 +3,6 @@
 for i in $(seq 1 3);
 do
   SHARDER_ID=$i
-  echo Stopping sharder"$SHARDER_ID" ...
-  SHARDER=$SHARDER_ID docker-compose -p sharder"$SHARDER_ID" -f docker.local/build.sharder/docker-compose.yml stop sharder
+  echo Stopping sharder$SHARDER_ID ...
+  SHARDER=$SHARDER_ID docker-compose -p sharder$SHARDER_ID -f docker.local/build.sharder/docker-compose.yml stop sharder
 done

--- a/docker.local/bin/gen_keys.sh
+++ b/docker.local/bin/gen_keys.sh
@@ -8,7 +8,7 @@ fi
 
 
 
-docker run -v "$2":/mykeys -it zchain_genkeys go run encryption/keys/main.go   --signature_scheme "$1" --keys_file_name "$3" --keys_file_path "/mykeys" --generate_keys true  --timestamp true
+docker run -v $2:/mykeys -it zchain_genkeys go run encryption/keys/main.go   --signature_scheme "$1" --keys_file_name "$3" --keys_file_path "/mykeys" --generate_keys true  --timestamp true 
 
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/docker.local/bin/generate_txns.sh
+++ b/docker.local/bin/generate_txns.sh
@@ -3,6 +3,6 @@
 TXNS=${1:-25000}
 for i in $(seq 1 3);
 do
-  code/go/test/miner_stress --address "127.0.0.1:707$i" --num_clients 400 --num_txns "$TXNS"
+  code/go/test/miner_stress --address "127.0.0.1:707$i" --num_clients 400 --num_txns $TXNS
 done
 

--- a/docker.local/bin/init.setup.sh
+++ b/docker.local/bin/init.setup.sh
@@ -2,18 +2,18 @@
 
 for i in $(seq 1 8)
 do
-  mkdir -p docker.local/miner"$i"/data/redis/state
-  mkdir -p docker.local/miner"$i"/data/redis/transactions
-  mkdir -p docker.local/miner"$i"/data/rocksdb
-  mkdir -p docker.local/miner"$i"/log
+  mkdir -p docker.local/miner$i/data/redis/state
+  mkdir -p docker.local/miner$i/data/redis/transactions
+  mkdir -p docker.local/miner$i/data/rocksdb
+  mkdir -p docker.local/miner$i/log
 done
 
 for i in $(seq 1 3)
 do
-  mkdir -p docker.local/sharder"$i"/data/blocks
-  mkdir -p docker.local/sharder"$i"/data/rocksdb
-  mkdir -p docker.local/sharder"$i"/data/cassandra
-  mkdir -p docker.local/sharder"$i"/config/cassandra
-  cp config/cassandra/* docker.local/sharder"$i"/config/cassandra/.
-  mkdir -p docker.local/sharder"$i"/log
+  mkdir -p docker.local/sharder$i/data/blocks
+  mkdir -p docker.local/sharder$i/data/rocksdb
+  mkdir -p docker.local/sharder$i/data/cassandra
+  mkdir -p docker.local/sharder$i/config/cassandra
+  cp config/cassandra/* docker.local/sharder$i/config/cassandra/.
+  mkdir -p docker.local/sharder$i/log
 done

--- a/docker.local/bin/install_deps.sh
+++ b/docker.local/bin/install_deps.sh
@@ -3,16 +3,16 @@ set -e
 
 go_mod=$1
 
-echo Building dependencies from "$go_mod"
+echo Building dependencies from $go_mod
 
 deps="$( \
-        < "$go_mod" \
-        grep -F ' v' | \
-        grep -F -v 0chain.net | \
-        grep -F -v pbc | \
+        cat $go_mod | \
+        fgrep ' v' | \
+        fgrep -v 0chain.net | \
+        fgrep -v pbc | \
         sed -E 's/^\t([a-zA-Z0-9./-]+) ((v[0-9.]+(\+incompatible)?)($| ))?(v[0-9\.]+-[0-9]+-([0-9a-f]+))?.*$/\1@\3\7/' \
       )"
 #echo Deps are "$deps"
 
-cd "$(dirname "$go_mod")"
-go get -v -tags bn256 "$deps"
+cd $(dirname $go_mod)
+go get -v -tags bn256 $deps

--- a/docker.local/bin/miner.join.blockchain.sh
+++ b/docker.local/bin/miner.join.blockchain.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-PWD=$(pwd)
-MINER_DIR=$(basename "$PWD")
-MINER_ID=$(echo "$MINER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+MINER_DIR=`basename $PWD`
+MINER_ID=`echo $MINER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
 
-echo Starting miner"$MINER_ID" ...
+echo Starting miner$MINER_ID ...
 
-MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f ../build.miner/nongenesis_docker_compose.yml up
+MINER=$MINER_ID docker-compose -p miner$MINER_ID -f ../build.miner/nongenesis_docker_compose.yml up

--- a/docker.local/bin/nongenesis_miner_start.sh
+++ b/docker.local/bin/nongenesis_miner_start.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-PWD=$(pwd)
-MINER_DIR=$(basename "$PWD")
-MINER_ID=$(echo "$MINER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+MINER_DIR=`basename $PWD`
+MINER_ID=`echo $MINER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
 
-echo Starting miner"$MINER_ID" ...
+echo Starting miner$MINER_ID ...
 
-MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f ../build.miner/nongenesis_docker_compose.yml up
+MINER=$MINER_ID docker-compose -p miner$MINER_ID -f ../build.miner/nongenesis_docker_compose.yml up

--- a/docker.local/bin/rocksdb_scan.sh
+++ b/docker.local/bin/rocksdb_scan.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
-DB_DIR=$1;shift
-/usr/local/Cellar/rocksdb/5.13.4/bin/rocksdb_ldb --db="$DB_DIR" "$*" scan
-
+DBDIR=$1;shift
+/usr/local/Cellar/rocksdb/5.13.4/bin/rocksdb_ldb --db=$DBDIR $* scan

--- a/docker.local/bin/run.image_shell.sh
+++ b/docker.local/bin/run.image_shell.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run -it "$1" bash
+docker run -it $1 bash

--- a/docker.local/bin/run.miner.sh
+++ b/docker.local/bin/run.miner.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-PWD=$(pwd)
-NODE_DIR=$(basename "$PWD")
-NODE_ID=$(echo "$NODE_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+NODE_DIR=`basename $PWD`
+NODE_ID=`echo $NODE_DIR | sed -e 's/.*\(.\)$/\1/'`
 
 SERVICE=$1; shift
 CMD=$1; shift
 
-echo "$NODE_DIR": running "$SERVICE" "$CMD" "$*"
+echo $NODE_DIR: running $SERVICE $CMD $*
 
-MINER=$MINER_ID docker-compose -p "$NODE_DIR" -f ../build.miner/docker-compose.yml exec "$SERVICE" "$CMD" "$*"
+MINER=$MINER_ID docker-compose -p $NODE_DIR -f ../build.miner/docker-compose.yml exec $SERVICE $CMD $*

--- a/docker.local/bin/run.sharder.sh
+++ b/docker.local/bin/run.sharder.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
-PWD=$(pwd)
-NODE_DIR=$(basename "$PWD")
-NODE_ID=$(echo "$NODE_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+NODE_DIR=`basename $PWD`
+NODE_ID=`echo $NODE_DIR | sed -e 's/.*\(.\)$/\1/'`
 
 SERVICE=$1; shift
 CMD=$1; shift
 
-echo "$NODE_DIR: running $SERVICE $CMD $*"
+echo $NODE_DIR: running $SERVICE $CMD $*
 
-SHARDER=$SHARDER_ID docker-compose -p "$NODE_DIR" -f ../build.sharder/docker-compose.yml exec "$SERVICE" "$CMD" "$*"
+SHARDER=$SHARDER_ID docker-compose -p $NODE_DIR -f ../build.sharder/docker-compose.yml exec $SERVICE $CMD $*

--- a/docker.local/bin/run.test.sh
+++ b/docker.local/bin/run.test.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 num_txns=${1:-1000}
-echo Submitting "$num_txns" transactions to each miner
-docker.local/bin/generate_txns.sh "$num_txns"
+echo Submitting $num_txns transactions to each miner
+docker.local/bin/generate_txns.sh $num_txns
 
 echo Clearing the sharder state
 curl http://localhost:7171/_start -o -

--- a/docker.local/bin/run_all.miner.sh
+++ b/docker.local/bin/run_all.miner.sh
@@ -3,6 +3,6 @@
 for i in $(seq 1 3);
 do
   MINER_ID=$i
-  echo Running command on miner"$MINER_ID" ...
-  MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f docker.local/build.miner/docker-compose.yml exec miner "$*"
+  echo Running command on miner$MINER_ID ...
+  MINER=$MINER_ID docker-compose -p miner$MINER_ID -f docker.local/build.miner/docker-compose.yml exec miner $*
 done

--- a/docker.local/bin/start.b0miner.sh
+++ b/docker.local/bin/start.b0miner.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 set -e
 
-PWD=$(pwd)
-MINER_DIR=$(basename "$PWD")
-MINER_ID=$(echo "$MINER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+MINER_DIR=`basename $PWD`
+MINER_ID=`echo $MINER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
 if [[ "$*" == *"--debug"* ]]
 then
-    echo Starting miner"$MINER_ID" in debug mode ...
+    echo Starting miner$MINER_ID in debug mode ...
 
-    MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f ../build.miner/b0docker-compose-debug.yml up
+    MINER=$MINER_ID docker-compose -p miner$MINER_ID -f ../build.miner/b0docker-compose-debug.yml up
 else
-    echo Starting miner"$MINER_ID" ...
+    echo Starting miner$MINER_ID ...
 
-    MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f ../build.miner/b0docker-compose.yml up
+    MINER=$MINER_ID docker-compose -p miner$MINER_ID -f ../build.miner/b0docker-compose.yml up
 fi

--- a/docker.local/bin/start.b0sharder.sh
+++ b/docker.local/bin/start.b0sharder.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 set -e
 
-PWD=$(pwd)
-SHARDER_DIR=$(basename "$PWD")
-SHARDER_ID=$(echo "$SHARDER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+SHARDER_DIR=`basename $PWD`
+SHARDER_ID=`echo $SHARDER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
 if [[ "$*" == *"--debug"* ]]
 then
-    echo Starting sharder"$SHARDER_ID" in debug mode ...
+    echo Starting sharder$SHARDER_ID in debug mode ...
 
-    SHARDER=$SHARDER_ID docker-compose -p sharder"$SHARDER_ID" -f ../build.sharder/b0docker-compose-debug.yml up
+    SHARDER=$SHARDER_ID docker-compose -p sharder$SHARDER_ID -f ../build.sharder/b0docker-compose-debug.yml up
 else
-    echo Starting sharder"$SHARDER_ID" ...
+    echo Starting sharder$SHARDER_ID ...
 
-    SHARDER=$SHARDER_ID docker-compose -p sharder"$SHARDER_ID" -f ../build.sharder/b0docker-compose.yml up
+    SHARDER=$SHARDER_ID docker-compose -p sharder$SHARDER_ID -f ../build.sharder/b0docker-compose.yml up
 fi

--- a/docker.local/bin/start.conductor.sh
+++ b/docker.local/bin/start.conductor.sh
@@ -4,7 +4,7 @@ set -e
 
 for running in $(docker ps -q)
 do
-    docker stop "$running"
+    docker stop $running
 done
 
 # go caches all build by default

--- a/docker.local/bin/start.miner.sh
+++ b/docker.local/bin/start.miner.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-PWD=$(pwd)
-MINER_DIR=$(basename "$PWD")
-MINER_ID=$(echo "$MINER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+MINER_DIR=`basename $PWD`
+MINER_ID=`echo $MINER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
 
-echo Starting miner"$MINER_ID" ...
+echo Starting miner$MINER_ID ...
 
-MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f ../build.miner/docker-compose.yml up
+MINER=$MINER_ID docker-compose -p miner$MINER_ID -f ../build.miner/docker-compose.yml up

--- a/docker.local/bin/start.p0miner.sh
+++ b/docker.local/bin/start.p0miner.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -e
 
-PWD=$(pwd)
-MINER_DIR=$(basename "$PWD")
-MINER_ID=$(echo "$MINER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+MINER_DIR=`basename $PWD`
+MINER_ID=`echo $MINER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
 
-echo Starting miner"$MINER_ID" in daemon mode ...
+echo Starting miner$MINER_ID in daemon mode ...
 
-MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f ../build.miner/p0docker-compose.yml up -d
+MINER=$MINER_ID docker-compose -p miner$MINER_ID -f ../build.miner/p0docker-compose.yml up -d

--- a/docker.local/bin/start.p0sharder.sh
+++ b/docker.local/bin/start.p0sharder.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 
-PWD=$(pwd)
-SHARDER_DIR=$(basename "$PWD")
-SHARDER_ID=$(echo "$SHARDER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+SHARDER_DIR=`basename $PWD`
+SHARDER_ID=`echo $SHARDER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
-echo Starting sharder"$SHARDER_ID" in daemon mode ...
+echo Starting sharder$SHARDER_ID in daemon mode ...
 
-SHARDER=$SHARDER_ID docker-compose -p sharder"$SHARDER_ID" -f ../build.sharder/p0docker-compose.yml up -d
+SHARDER=$SHARDER_ID docker-compose -p sharder$SHARDER_ID -f ../build.sharder/p0docker-compose.yml up -d

--- a/docker.local/bin/start.sharder.sh
+++ b/docker.local/bin/start.sharder.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-PWD=$(pwd)
-SHARDER_DIR=$(basename "$PWD")
-SHARDER_ID=$(echo "$SHARDER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+SHARDER_DIR=`basename $PWD`
+SHARDER_ID=`echo $SHARDER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
-echo Starting sharder"$SHARDER_ID" ...
+echo Starting sharder$SHARDER_ID ...
 
-SHARDER=$SHARDER_ID docker-compose -p sharder"$SHARDER_ID" -f ../build.sharder/docker-compose.yml up
+SHARDER=$SHARDER_ID docker-compose -p sharder$SHARDER_ID -f ../build.sharder/docker-compose.yml up

--- a/docker.local/bin/stop.b0miner.sh
+++ b/docker.local/bin/stop.b0miner.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-PWD=$(pwd)
-MINER_DIR=$(basename "$PWD")
-MINER_ID=$(echo "$MINER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+MINER_DIR=`basename $PWD`
+MINER_ID=`echo $MINER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
-echo Stopping miner"$MINER_ID" ...
+echo Stopping miner$MINER_ID ...
 
-MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f ../build.miner/b0docker-compose.yml stop
+MINER=$MINER_ID docker-compose -p miner$MINER_ID -f ../build.miner/b0docker-compose.yml stop

--- a/docker.local/bin/stop.b0sharder.sh
+++ b/docker.local/bin/stop.b0sharder.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-PWD=$(pwd)
-SHARDER_DIR=$(basename "$PWD")
-SHARDER_ID=$(echo "$SHARDER_DIR" | sed -e 's/.*\(.\)$/\1/')
+PWD=`pwd`
+SHARDER_DIR=`basename $PWD`
+SHARDER_ID=`echo $SHARDER_DIR | sed -e 's/.*\(.\)$/\1/'`
 
-echo Stopping sharder"$SHARDER_ID" ...
+echo Stopping sharder$SHARDER_ID ...
 
-SHARDER=$SHARDER_ID docker-compose -p sharder"$SHARDER_ID" -f ../build.sharder/b0docker-compose.yml stop
+SHARDER=$SHARDER_ID docker-compose -p sharder$SHARDER_ID -f ../build.sharder/b0docker-compose.yml stop

--- a/docker.local/bin/stop_all.miner.sh
+++ b/docker.local/bin/stop_all.miner.sh
@@ -3,6 +3,6 @@
 for i in $(seq 1 4);
 do
   MINER_ID=$i
-  echo Stopping miner"$MINER_ID" ...
-  MINER=$MINER_ID docker-compose -p miner"$MINER_ID" -f docker.local/build.miner/docker-compose.yml stop
+  echo Stopping miner$MINER_ID ...
+  MINER=$MINER_ID docker-compose -p miner$MINER_ID -f docker.local/build.miner/docker-compose.yml stop
 done

--- a/docker.local/bin/stop_all.sharder.sh
+++ b/docker.local/bin/stop_all.sharder.sh
@@ -3,6 +3,6 @@
 for i in $(seq 1 3);
 do
   SHARDER_ID=$i
-  echo Stopping sharder"$SHARDER_ID" ...
-  SHARDER=$SHARDER_ID docker-compose -p sharder"$SHARDER_ID" -f docker.local/build.sharder/docker-compose.yml stop
+  echo Stopping sharder$SHARDER_ID ...
+  SHARDER=$SHARDER_ID docker-compose -p sharder$SHARDER_ID -f docker.local/build.sharder/docker-compose.yml stop
 done

--- a/docker.local/bin/test.multisigsc.sh
+++ b/docker.local/bin/test.multisigsc.sh
@@ -6,6 +6,6 @@ docker build -f docker.local/build.test.multisigsc/Dockerfile . -t zchain_test_m
 docker run \
     -it \
     --network testnet0 \
-    --mount type=bind,src="$PWD"/docker.local/config,dst=/0chain/config,readonly \
+    --mount type=bind,src=$PWD/docker.local/config,dst=/0chain/config,readonly \
     zchain_test_multisigsc \
     ./bin/test_multisigsc

--- a/docker.local/bin/unit_test.sh
+++ b/docker.local/bin/unit_test.sh
@@ -22,9 +22,9 @@ if [[ -n "$PACKAGE" ]]; then
     # Run tests from a single package.
     # assume that $PACKAGE looks something like: 0chain.net/chaincore/threshold/bls
     echo "Running unit tests from $PACKAGE:"
-    docker run "$INTERACTIVE" zchain_unit_test sh -c "cd /0chain/go/$PACKAGE; go test -tags bn256 -cover ./..."
+    docker run $INTERACTIVE zchain_unit_test sh -c "cd /0chain/go/$PACKAGE; go test -tags bn256 -cover ./..."
 else
     # Run all tests.
     echo "Running general unit tests:"
-    docker run "$INTERACTIVE" zchain_unit_test sh -c "cd 0chain.net; go test -tags bn256 -cover ./..."
+    docker run $INTERACTIVE zchain_unit_test sh -c "cd 0chain.net; go test -tags bn256 -cover ./..."
 fi


### PR DESCRIPTION
Reverts 0chain/0chain#353

There appears to be a problem with `docker.local/bin/build.miners.sh`

Running `build.miners.sh`: 
With this change 
```
Removing intermediate container 3719d2ecadb2
 ---> 31e2044a9d26
Step 12/15 : FROM zchain_run_base
 ---> 4f8ed3986e50
Step 13/15 : ENV APP_DIR=/0chain
 ---> Using cache
 ---> 48f234ef9b16
Step 14/15 : WORKDIR $APP_DIR
 ---> Using cache
 ---> adfee592a173
Step 15/15 : COPY --from=miner_build /go/0chain.net/miner/miner/miner $APP_DIR/bin/miner
COPY failed: stat go/0chain.net/miner/miner/miner: file does not exist
```

With old code
```
ld.BuildTag=$GIT_COMMIT" ;fi
 ---> Using cache
 ---> 31e2044a9d26
Step 12/15 : FROM zchain_run_base
 ---> 4f8ed3986e50
Step 13/15 : ENV APP_DIR=/0chain
 ---> Using cache
 ---> 48f234ef9b16
Step 14/15 : WORKDIR $APP_DIR
 ---> Using cache
 ---> adfee592a173
Step 15/15 : COPY --from=miner_build $APP_DIR/go/0chain.net/miner/miner/miner $APP_DIR/bin/miner
 ---> f66ed9be31c1
Successfully built f66ed9be31c1
Successfully tagged miner:latest
```