### PR TITLE
Add immutable allocations

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -403,6 +403,11 @@ func (sc *StorageSmartContract) commitBlobberRead(t *transaction.Transaction,
 			"can't get related allocation: %v", err)
 	}
 
+	if alloc.IsImmutable {
+		return "", common.NewError("commit_blobber_read",
+			"allocation is immutable")
+	}
+
 	if commitRead.ReadMarker.Timestamp < alloc.StartTime {
 		return "", common.NewError("commit_blobber_read",
 			"early reading, allocation not started yet")
@@ -595,6 +600,11 @@ func (sc *StorageSmartContract) commitBlobberConnection(
 	if err != nil {
 		return "", common.NewError("commit_connection_failed",
 			"can't get allocation: "+err.Error())
+	}
+
+	if alloc.IsImmutable {
+		return "", common.NewError("commit_blobber_read",
+			"allocation is immutable")
 	}
 
 	if alloc.Owner != commitConnection.WriteMarker.ClientID {

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -522,6 +522,7 @@ type StorageAllocation struct {
 	PreferredBlobbers []string                      `json:"preferred_blobbers"`
 	BlobberDetails    []*BlobberAllocation          `json:"blobber_details"`
 	BlobberMap        map[string]*BlobberAllocation `json:"-"`
+	IsImmutable       bool                          `json:"is_immutable"`
 
 	// Requested ranges.
 	ReadPriceRange             PriceRange    `json:"read_price_range"`


### PR DESCRIPTION
* Add an `isImmutable` field to allocation objects. 
* Option to set `isImmutable` in updateAllocationRequest. Some refoactoring.
* `commitBlobberRead` give error if `isImmutable` is set.
* `commitBlobberConnection` give error if `isImmutable` is set.