### PR TITLE
readPoolLock creates read pool if necessary.

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/readpool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/readpool.go
@@ -274,7 +274,7 @@ func (ssc *StorageSmartContract) getReadPool(clientID datastore.Key,
 
 // newReadPool SC function creates new read pool for a client.
 func (ssc *StorageSmartContract) newReadPool(t *transaction.Transaction,
-	input []byte, balances cstate.StateContextI) (resp string, err error) {
+	_ []byte, balances cstate.StateContextI) (resp string, err error) {
 
 	_, err = ssc.getReadPoolBytes(t.ClientID, balances)
 
@@ -335,7 +335,10 @@ func (ssc *StorageSmartContract) readPoolLock(t *transaction.Transaction,
 
 	var rp *readPool
 	if rp, err = ssc.getReadPool(t.ClientID, balances); err != nil {
-		return "", common.NewError("read_pool_lock_failed", err.Error())
+		if err != util.ErrValueNotPresent {
+			return "", common.NewError("read_pool_lock_failed", err.Error())
+		}
+		rp = new(readPool)
 	}
 
 	// lock request & user balance

--- a/code/go/0chain.net/smartcontract/storagesc/readpool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/readpool_test.go
@@ -183,7 +183,7 @@ func TestStorageSmartContract_readPoolLock(t *testing.T) {
 	const (
 		allocID, txHash = "alloc_hex", "tx_hash"
 
-		errMsg1 = "read_pool_lock_failed: value not present"
+		errMsg1 = "read_pool_lock_failed: unexpected end of JSON input"
 		errMsg2 = "read_pool_lock_failed: " +
 			"invalid character '}' looking for beginning of value"
 		errMsg3 = "read_pool_lock_failed: no tokens to lock"


### PR DESCRIPTION
Modify readPool lock to create a new read pool if one has not already been created. Fixes https://github.com/0chain/gosdk/issues/104.