### PR TITLE
writePoolLock creats a new wrteipool if non exists

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/writepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool.go
@@ -333,19 +333,18 @@ func (ssc *StorageSmartContract) createWritePool(
 func (ssc *StorageSmartContract) writePoolLock(t *transaction.Transaction,
 	input []byte, balances chainState.StateContextI) (resp string, err error) {
 
-	// configs
-
 	var conf *writePoolConfig
 	if conf, err = ssc.getWritePoolConfig(balances, true); err != nil {
 		return "", common.NewError("write_pool_lock_failed",
 			"can't get configs: "+err.Error())
 	}
 
-	// user write pools
-
 	var wp *writePool
 	if wp, err = ssc.getWritePool(t.ClientID, balances); err != nil {
-		return "", common.NewError("write_pool_lock_failed", err.Error())
+		if err != util.ErrValueNotPresent {
+			return "", common.NewError("write_pool_lock_failed", err.Error())
+		}
+		wp = new(writePool)
 	}
 
 	// lock request & user balance

--- a/code/go/0chain.net/smartcontract/storagesc/writepool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool_test.go
@@ -134,6 +134,7 @@ func TestStorageSmartContract_writePoolLock(t *testing.T) {
 		errMsg6 = "write_pool_lock_failed: " +
 			"duration (3h0m0s) is longer than max lock period (2h0m0s)"
 		errMsg7 = "write_pool_lock_failed: user already has this write pool"
+		errMsg8 = "write_pool_lock_failed: unexpected end of JSON input"
 	)
 
 	var (
@@ -178,7 +179,7 @@ func TestStorageSmartContract_writePoolLock(t *testing.T) {
 
 	// 1. no pool
 	_, err = ssc.writePoolLock(&tx, nil, balances)
-	requireErrMsg(t, err, errMsg1)
+	requireErrMsg(t, err, errMsg8)
 
 	tx.Hash = "new_write_pool_tx_hash"
 	tx.Value, balances.balances[client.id] = 40, 40 // set {


### PR DESCRIPTION
`writePoolLock` lock tokens with an allocation, but only if the user already has a write pool. This changes writePoolLock to create a new write pool if the user has not made one yet.