### PR TITLE
Allocation payments, spread cost across all write pools

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -667,7 +667,6 @@ func (sc *StorageSmartContract) adjustChallengePool(
 // here we use new terms of blobbers
 func (sc *StorageSmartContract) extendAllocation(
 	t *transaction.Transaction,
-	all *StorageNodes,
 	alloc *StorageAllocation,
 	blobbers []*StorageNode,
 	uar *updateAllocationRequest,
@@ -801,7 +800,7 @@ func (sc *StorageSmartContract) extendAllocation(
 // reduceAllocation reduces size or/and expiration (no one can be increased);
 // here we use the same terms of related blobbers
 func (sc *StorageSmartContract) reduceAllocation(t *transaction.Transaction,
-	all *StorageNodes, alloc *StorageAllocation, blobbers []*StorageNode,
+	alloc *StorageAllocation, blobbers []*StorageNode,
 	uar *updateAllocationRequest, balances chainstate.StateContextI,
 ) (err error) {
 	var (
@@ -979,13 +978,13 @@ func (sc *StorageSmartContract) updateAllocationRequestInternal(
 	// if size or expiration increased, then we use new terms
 	// otherwise, we use the same terms
 	if request.Size > 0 || request.Expiration > 0 {
-		err = sc.extendAllocation(t, all, alloc, blobbers, &request, mintTokens, balances)
+		err = sc.extendAllocation(t, alloc, blobbers, &request, mintTokens, balances)
 	} else if request.Size != 0 || request.Expiration != 0 {
 		if mintTokens {
 			return "", common.NewError("allocation_updating_failed",
 				"cannot reduce when minting tokens")
 		}
-		err = sc.reduceAllocation(t, all, alloc, blobbers, &request, balances)
+		err = sc.reduceAllocation(t, alloc, blobbers, &request, balances)
 	}
 	if err != nil {
 		return "", err

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -142,6 +142,7 @@ func (nar *newAllocationRequest) storageAllocation() (sa *StorageAllocation) {
 	sa.Expiration = nar.Expiration
 	sa.Owner = nar.Owner
 	sa.OwnerPublicKey = nar.OwnerPublicKey
+	sa.WritePoolOwners = append(sa.WritePoolOwners, nar.Owner)
 	sa.PreferredBlobbers = nar.PreferredBlobbers
 	sa.ReadPriceRange = nar.ReadPriceRange
 	sa.WritePriceRange = nar.WritePriceRange

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -457,6 +457,17 @@ func (uar *updateAllocationRequest) validate(
 		return errors.New("invalid allocation for updating: no blobbers")
 	}
 
+	var found = false
+	for _, wpOwner := range alloc.WritePoolOwners {
+		if wpOwner == uar.OwnerID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("%s does not have allocation write pool", uar.OwnerID)
+	}
+
 	return
 }
 
@@ -914,18 +925,6 @@ func (sc *StorageSmartContract) updateAllocationRequestInternal(
 
 	if request.OwnerID == "" {
 		request.OwnerID = t.ClientID
-	}
-
-	var clist *Allocations // client allocations list
-	if clist, err = sc.getAllocationsList(request.OwnerID, balances); err != nil {
-		return "", common.NewError("allocation_updating_failed",
-			"can't get client's allocations list: "+err.Error())
-	}
-
-	if !clist.has(request.ID) {
-		return "", common.NewErrorf("allocation_updating_failed",
-			"can't find allocation in client's allocations list: %s (%d)",
-			request.ID, len(clist.List))
 	}
 
 	var alloc *StorageAllocation

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -786,8 +786,7 @@ func (sc *StorageSmartContract) extendAllocation(
 
 	// add more tokens to related challenge pool, or move some tokens back
 	var ndr = alloc.Expiration - t.CreationDate
-	err = sc.adjustChallengePool(alloc, wps, odr, ndr, oterms, t.CreationDate,
-		balances)
+	err = sc.adjustChallengePool(alloc, wps, odr, ndr, oterms, t.CreationDate, balances)
 	if err != nil {
 		return common.NewErrorf("allocation_extending_failed", "%v", err)
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
@@ -7,7 +7,6 @@ import (
 	"0chain.net/chaincore/transaction"
 	"0chain.net/core/common"
 	"0chain.net/core/datastore"
-	. "0chain.net/core/logging"
 	"encoding/json"
 	"errors"
 	"fmt"

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
@@ -2,17 +2,17 @@ package storagesc
 
 import (
 	chainState "0chain.net/chaincore/chain/state"
+	"0chain.net/chaincore/state"
+	"0chain.net/chaincore/tokenpool"
 	"0chain.net/chaincore/transaction"
+	"0chain.net/core/common"
+	"0chain.net/core/datastore"
+	. "0chain.net/core/logging"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
 	"time"
-
-	"0chain.net/chaincore/state"
-	"0chain.net/chaincore/tokenpool"
-	"0chain.net/core/common"
-	"0chain.net/core/datastore"
 )
 
 //

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
@@ -1,8 +1,11 @@
 package storagesc
 
 import (
+	chainState "0chain.net/chaincore/chain/state"
+	"0chain.net/chaincore/transaction"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 	"time"
 
@@ -142,6 +145,47 @@ type allocationPool struct {
 	Blobbers          blobberPools     `json:"blobbers"`      //
 }
 
+func newAllocationPool(
+	t *transaction.Transaction,
+	alloc *StorageAllocation,
+	until common.Timestamp,
+	mintNewTokens bool,
+	balances chainState.StateContextI,
+) (*allocationPool, error) {
+	var err error
+	if !mintNewTokens {
+		if err = checkFill(t, balances); err != nil {
+			return nil, nil
+		}
+	}
+
+	var ap allocationPool
+	var transfer *state.Transfer
+	if transfer, _, err = ap.DigPool(t.Hash, t); err != nil {
+		return nil, fmt.Errorf("digging write pool: %v", err)
+	}
+	if mintNewTokens {
+		balances.AddMint(&state.Mint{
+			Minter:     ADDRESS,
+			ToClientID: ADDRESS,
+			Amount:     state.Balance(t.Value),
+		})
+	} else {
+		if err = balances.AddTransfer(transfer); err != nil {
+			return nil, fmt.Errorf("adding transfer to write pool: %v", err)
+		}
+	}
+
+	// set fields
+	ap.AllocationID = alloc.ID
+	ap.ExpireAt = until
+	ap.Blobbers = makeCopyAllocationBlobbers(*alloc, t.Value)
+
+	// add the allocation pool
+	alloc.WritePoolOwners.add(alloc.Owner)
+	return &ap, nil
+}
+
 //
 // allocation read/write pools (list)
 //
@@ -157,16 +201,6 @@ func (aps allocationPools) getIndex(allocID string) (i int, ok bool) {
 		}
 	}
 	return 0, false
-	// i = sort.Search(len(aps), func(i int) bool {
-	// 	return aps[i].AllocationID >= allocID
-	// })
-	// if i == len(aps) {
-	// 	return // not found
-	// }
-	// if aps[i].AllocationID == allocID {
-	// 	return i, true // found
-	// }
-	// return // not found
 }
 
 func (aps allocationPools) get(allocID string) (
@@ -182,19 +216,6 @@ func (aps allocationPools) get(allocID string) (
 		return aps[i], true // found
 	}
 	return // not found
-}
-
-func (aps *allocationPools) removeByIndex(i int) {
-	(*aps) = append((*aps)[:i], (*aps)[i+1:]...)
-}
-
-func (aps *allocationPools) remove(allocID string) (ok bool) {
-	var i int
-	if i, ok = aps.getIndex(allocID); !ok {
-		return // false
-	}
-	aps.removeByIndex(i)
-	return true // removed
 }
 
 func (aps *allocationPools) add(ap *allocationPool) {
@@ -289,6 +310,63 @@ Outer:
 		(*aps)[i], i = ax, i+1
 	}
 	(*aps) = (*aps)[:i]
+}
+
+func (aps *allocationPools) moveToChallenge(
+	allocID, blobID string,
+	cp *challengePool,
+	now common.Timestamp,
+	value state.Balance,
+) (err error) {
+	if value == 0 {
+		return // nothing to move, ok
+	}
+
+	var cut = aps.blobberCut(allocID, blobID, now)
+
+	if len(cut) == 0 {
+		return fmt.Errorf("no tokens in write pool for allocation: %s,"+
+			" blobber: %s", allocID, blobID)
+	}
+
+	var torm []*allocationPool // to remove later (empty allocation pools)
+	for _, ap := range cut {
+		if value == 0 {
+			break // all required tokens has moved to the blobber
+		}
+		var bi, ok = ap.Blobbers.getIndex(blobID)
+		if !ok {
+			continue // impossible case, but leave the check here
+		}
+		var (
+			bp   = ap.Blobbers[bi]
+			move state.Balance
+		)
+		if value >= bp.Balance {
+			move, bp.Balance = bp.Balance, 0
+		} else {
+			move, bp.Balance = value, bp.Balance-value
+		}
+		if _, _, err = ap.TransferTo(cp, move, nil); err != nil {
+			return // transferring error
+		}
+		value -= move
+		if bp.Balance == 0 {
+			ap.Blobbers.removeByIndex(bi)
+		}
+		if ap.Balance == 0 {
+			torm = append(torm, ap) // remove the allocation pool later
+		}
+	}
+
+	if value != 0 {
+		return fmt.Errorf("not enough tokens in write pool for allocation: %s,"+
+			" blobber: %s", allocID, blobID)
+	}
+
+	// remove empty allocation pools
+	aps.removeEmpty(allocID, torm)
+	return
 }
 
 func removeExpired(cut []*allocationPool, now common.Timestamp) (

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
@@ -155,7 +155,7 @@ func newAllocationPool(
 	var err error
 	if !mintNewTokens {
 		if err = checkFill(t, balances); err != nil {
-			return nil, nil
+			return nil, err
 		}
 	}
 
@@ -182,7 +182,7 @@ func newAllocationPool(
 	ap.Blobbers = makeCopyAllocationBlobbers(*alloc, t.Value)
 
 	// add the allocation pool
-	alloc.WritePoolOwners.add(alloc.Owner)
+	alloc.addWritePoolOwner(alloc.Owner)
 	return &ap, nil
 }
 

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
@@ -164,11 +164,13 @@ func newAllocationPool(
 		return nil, fmt.Errorf("digging write pool: %v", err)
 	}
 	if mintNewTokens {
-		balances.AddMint(&state.Mint{
+		if err := balances.AddMint(&state.Mint{
 			Minter:     ADDRESS,
 			ToClientID: ADDRESS,
 			Amount:     state.Balance(t.Value),
-		})
+		}); err != nil {
+			return nil, fmt.Errorf("minting tokens for write pool: %v", err)
+		}
 	} else {
 		if err = balances.AddTransfer(transfer); err != nil {
 			return nil, fmt.Errorf("adding transfer to write pool: %v", err)

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool_test.go
@@ -204,10 +204,12 @@ func Test_allocationPools(t *testing.T) {
 	cut = aps.allocationCut(a3)
 	require.EqualValues(t, []*allocationPool{
 		&allocationPool{AllocationID: a3},
+		&allocationPool{AllocationID: a3},
 	}, cut)
 
 	cut = aps.allocationCut(a4)
 	require.EqualValues(t, []*allocationPool{
+		&allocationPool{AllocationID: a4},
 		&allocationPool{AllocationID: a4},
 	}, cut)
 

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool_test.go
@@ -151,8 +151,6 @@ func Test_allocationPools(t *testing.T) {
 	require.Nil(t, ap)
 	require.False(t, ok)
 
-	require.False(t, aps.remove("alloc_id"))
-
 	var (
 		a1, a2, a3, a4, a5 = "a1", "a2", "a3", "a4", "a5"
 		random             = []string{a4, a1, a3, a5, a2}
@@ -184,12 +182,6 @@ func Test_allocationPools(t *testing.T) {
 	ap, ok = aps.get(a3)
 	require.True(t, ok)
 	require.Equal(t, aps[i], ap)
-
-	aps.removeByIndex(i)
-	aps.remove(a4)
-	for i, o := range []string{a1, a1, a2, a2, a3, a4, a5, a5} {
-		require.Equal(t, aps[i].AllocationID, o)
-	}
 
 	// special methods
 

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -222,6 +222,7 @@ func TestExtendAllocation(t *testing.T) {
 		randomSeed                  = 1
 		mockURL                     = "mock_url"
 		mockOwner                   = "mock owner"
+		mockNotTheOwner             = "mock not the owner"
 		mockWpOwner                 = "mock write pool owner"
 		mockPublicKey               = "mock public key"
 		mockBlobberId               = "mock_blobber_id"
@@ -429,9 +430,41 @@ func TestExtendAllocation(t *testing.T) {
 		name string
 		args args
 		want want
-	}{
+	}{ /*
+			{
+				name: "ok_multiple_users",
+				args: args{
+					request: updateAllocationRequest{
+						ID:           mockAllocationId,
+						OwnerID:      mockOwner,
+						Size:         zcnToInt64(31),
+						Expiration:   7000,
+						SetImmutable: false,
+					},
+					expiration: mockExpiration,
+					value:      0.1,
+					poolFunds:  []float64{0.0, 5.0, 5.0},
+					poolCount:  []int{1, 3, 4},
+				},
+			},
+			{
+				name: "ok_multiple_allocation_pools",
+				args: args{
+					request: updateAllocationRequest{
+						ID:           mockAllocationId,
+						OwnerID:      mockOwner,
+						Size:         zcnToInt64(31),
+						Expiration:   7000,
+						SetImmutable: false,
+					},
+					expiration: mockExpiration,
+					value:      0.1,
+					poolFunds:  []float64{7},
+					poolCount:  []int{5},
+				},
+			},*/
 		{
-			name: "ok",
+			name: "ok_multiple_users",
 			args: args{
 				request: updateAllocationRequest{
 					ID:           mockAllocationId,
@@ -441,9 +474,13 @@ func TestExtendAllocation(t *testing.T) {
 					SetImmutable: false,
 				},
 				expiration: mockExpiration,
-				value:      0.0000023,
-				poolFunds:  []float64{0.0, 5.0, 5.0},
-				poolCount:  []int{1, 3, 4},
+				value:      0.1,
+				poolFunds:  []float64{0.0, 0.0},
+				poolCount:  []int{1, 3},
+			},
+			want: want{
+				err:    true,
+				errMsg: "allocation_extending_failed: not enough tokens in write pool to extend allocation",
 			},
 		},
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -284,7 +284,6 @@ func TestExtendAllocation(t *testing.T) {
 		StorageSmartContract,
 		transaction.Transaction,
 		StorageAllocation,
-		*StorageNodes,
 		[]*StorageNode,
 		chainState.StateContextI,
 	) {
@@ -328,11 +327,9 @@ func TestExtendAllocation(t *testing.T) {
 		require.True(t, len(args.poolFunds) > 0)
 
 		bCount := sa.DataShards + sa.ParityShards
-		var sNodes = StorageNodes{}
 		var blobbers []*StorageNode
 		for i := 0; i < mockNumAllBlobbers; i++ {
 			mockBlobber := makeMockBlobber(i)
-			sNodes.Nodes.add(mockBlobber)
 
 			if i < sa.DataShards+sa.ParityShards {
 				blobbers = append(blobbers, mockBlobber)
@@ -423,7 +420,7 @@ func TestExtendAllocation(t *testing.T) {
 			}),
 		).Return("", nil).Once()
 
-		return ssc, txn, sa, &sNodes, blobbers, balances
+		return ssc, txn, sa, blobbers, balances
 	}
 
 	testCases := []struct {
@@ -488,11 +485,10 @@ func TestExtendAllocation(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ssc, txn, sa, allBlobbers, aBlobbers, balances := setup(t, tt.args)
+			ssc, txn, sa, aBlobbers, balances := setup(t, tt.args)
 
 			err := ssc.extendAllocation(
 				&txn,
-				allBlobbers,
 				&sa,
 				aBlobbers,
 				&tt.args.request,

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -430,39 +430,39 @@ func TestExtendAllocation(t *testing.T) {
 		name string
 		args args
 		want want
-	}{ /*
-			{
-				name: "ok_multiple_users",
-				args: args{
-					request: updateAllocationRequest{
-						ID:           mockAllocationId,
-						OwnerID:      mockOwner,
-						Size:         zcnToInt64(31),
-						Expiration:   7000,
-						SetImmutable: false,
-					},
-					expiration: mockExpiration,
-					value:      0.1,
-					poolFunds:  []float64{0.0, 5.0, 5.0},
-					poolCount:  []int{1, 3, 4},
+	}{
+		{
+			name: "ok_multiple_users",
+			args: args{
+				request: updateAllocationRequest{
+					ID:           mockAllocationId,
+					OwnerID:      mockOwner,
+					Size:         zcnToInt64(31),
+					Expiration:   7000,
+					SetImmutable: false,
 				},
+				expiration: mockExpiration,
+				value:      0.1,
+				poolFunds:  []float64{0.0, 5.0, 5.0},
+				poolCount:  []int{1, 3, 4},
 			},
-			{
-				name: "ok_multiple_allocation_pools",
-				args: args{
-					request: updateAllocationRequest{
-						ID:           mockAllocationId,
-						OwnerID:      mockOwner,
-						Size:         zcnToInt64(31),
-						Expiration:   7000,
-						SetImmutable: false,
-					},
-					expiration: mockExpiration,
-					value:      0.1,
-					poolFunds:  []float64{7},
-					poolCount:  []int{5},
+		},
+		{
+			name: "ok_multiple_allocation_pools",
+			args: args{
+				request: updateAllocationRequest{
+					ID:           mockAllocationId,
+					OwnerID:      mockOwner,
+					Size:         zcnToInt64(31),
+					Expiration:   7000,
+					SetImmutable: false,
 				},
-			},*/
+				expiration: mockExpiration,
+				value:      0.1,
+				poolFunds:  []float64{7},
+				poolCount:  []int{5},
+			},
+		},
 		{
 			name: "ok_multiple_users",
 			args: args{
@@ -1503,7 +1503,6 @@ func (alloc *StorageAllocation) deepCopy(t *testing.T) (cp *StorageAllocation) {
 }
 
 func TestStorageSmartContract_updateAllocationRequest(t *testing.T) {
-	t.Skip("Tests two pools for same allocating in write pool. Ths should not happen.")
 	var (
 		ssc                  = newTestStorageSC()
 		balances             = newTestBalances(t, false)

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -244,7 +244,7 @@ func TestExtendAllocation(t *testing.T) {
 		mockBlobberBalance          = 11
 		mockHash                    = "mock hash"
 	)
-	var mockBlobberCapacity int64 = 1000 * confMinAllocSize
+	var mockBlobberCapacity int64 = 3700000000 * confMinAllocSize
 	var mockMaxPrice = zcnToBalance(100.0)
 	var mockReadPrice = zcnToBalance(0.01)
 	var mockWritePrice = zcnToBalance(0.10)
@@ -411,7 +411,11 @@ func TestExtendAllocation(t *testing.T) {
 		balances.On(
 			"InsertTrieNode", challengePoolKey(ssc.ID, sa.ID),
 			mock.MatchedBy(func(cp *challengePool) bool {
-				newFunds := sizeInGB(sa.Size+args.request.Size) *
+				var size int64
+				for _, blobber := range sa.BlobberDetails {
+					size += blobber.Stats.UsedSize
+				}
+				newFunds := sizeInGB(size) *
 					float64(mockWritePrice) *
 					float64(sa.durationInTimeUnits(args.request.Expiration))
 				return cp.Balance/10 == state.Balance(newFunds/10) // ignore type cast errors
@@ -432,14 +436,14 @@ func TestExtendAllocation(t *testing.T) {
 				request: updateAllocationRequest{
 					ID:           mockAllocationId,
 					OwnerID:      mockOwner,
-					Size:         1,
+					Size:         zcnToInt64(31),
 					Expiration:   7000,
 					SetImmutable: false,
 				},
 				expiration: mockExpiration,
-				value:      0.1,
+				value:      0.0000023,
 				poolFunds:  []float64{0.0, 5.0, 5.0},
-				poolCount:  []int{1, 2, 4},
+				poolCount:  []int{1, 3, 4},
 			},
 		},
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_write_pools.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_write_pools.go
@@ -54,7 +54,7 @@ func (aps allocationWritePools) allocUntil(
 	return aps.allocationPools.allocUntil(allocID, until)
 }
 
-func (awp allocationWritePools) addOwnerWritePool(ap *allocationPool) error {
+func (awp *allocationWritePools) addOwnerWritePool(ap *allocationPool) error {
 	if len(awp.writePools) == 0 {
 		return errors.New("no write pools")
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_write_pools.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_write_pools.go
@@ -1,0 +1,59 @@
+package storagesc
+
+import (
+	chainstate "0chain.net/chaincore/chain/state"
+	"0chain.net/chaincore/state"
+	"0chain.net/core/common"
+	"errors"
+	"fmt"
+)
+
+type allocationWritePools struct {
+	// The indices for ids and writePools match
+	ids             []string
+	writePools      []*writePool
+	allocationPools allocationPools
+}
+
+func (awp *allocationWritePools) getOwnerWP() (*writePool, error) {
+	if len(awp.writePools) == 0 {
+		return nil, errors.New("no write pools")
+	}
+	return awp.writePools[0], nil
+}
+
+func (awp *allocationWritePools) saveWritePools(
+	sscId string, balances chainstate.StateContextI,
+) error {
+	for i, wp := range awp.writePools {
+		err := wp.save(sscId, awp.ids[i], balances)
+		if err != nil {
+			return fmt.Errorf("cannot save write pool of %s", awp.ids[i])
+		}
+	}
+	return nil
+}
+
+func (awp *allocationWritePools) moveToChallenge(
+	allocID, blobID string,
+	cp *challengePool,
+	now common.Timestamp,
+	value state.Balance,
+) (err error) {
+	return awp.allocationPools.moveToChallenge(allocID, blobID, cp, now, value)
+}
+
+func (aps allocationWritePools) allocUntil(
+	allocID string, until common.Timestamp,
+) (value state.Balance) {
+	return aps.allocationPools.allocUntil(allocID, until)
+}
+
+func (awp allocationWritePools) addOwnerWritePool(ap *allocationPool) error {
+	if len(awp.writePools) == 0 {
+		return errors.New("no write pools")
+	}
+	awp.writePools[0].Pools.add(ap)
+	awp.allocationPools.add(ap)
+	return nil
+}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_write_pools.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_write_pools.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 )
 
+// Created using StorageAllocation.getAllocationPools
 type allocationWritePools struct {
 	// The indices for ids and writePools match
+	ownerId         int
 	ids             []string
 	writePools      []*writePool
 	allocationPools allocationPools
@@ -19,7 +21,10 @@ func (awp *allocationWritePools) getOwnerWP() (*writePool, error) {
 	if len(awp.writePools) == 0 {
 		return nil, errors.New("no write pools")
 	}
-	return awp.writePools[0], nil
+	if awp.ownerId < 0 || len(awp.writePools) <= awp.ownerId {
+		return nil, errors.New("no owner write pool")
+	}
+	return awp.writePools[awp.ownerId], nil
 }
 
 func (awp *allocationWritePools) saveWritePools(
@@ -53,7 +58,10 @@ func (awp allocationWritePools) addOwnerWritePool(ap *allocationPool) error {
 	if len(awp.writePools) == 0 {
 		return errors.New("no write pools")
 	}
-	awp.writePools[0].Pools.add(ap)
+	if awp.ownerId < 0 || len(awp.writePools) <= awp.ownerId {
+		return errors.New("no owner write pool")
+	}
+	awp.writePools[awp.ownerId].Pools.add(ap)
 	awp.allocationPools.add(ap)
 	return nil
 }

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -487,13 +487,6 @@ func (sc *StorageSmartContract) commitMoveTokens(alloc *StorageAllocation,
 		return // zero size write marker -- no tokens movements
 	}
 
-	// write pool
-	wp, err := sc.getWritePool(alloc.Owner, balances)
-	if err != nil {
-		return errors.New("can't get related write pool")
-	}
-
-	// challenge pool
 	cp, err := sc.getChallengePool(alloc.ID, balances)
 	if err != nil {
 		return errors.New("can't get related challenge pool")
@@ -506,22 +499,30 @@ func (sc *StorageSmartContract) commitMoveTokens(alloc *StorageAllocation,
 
 	// the details will be saved in caller with allocation object (the details
 	// is part of the allocation object)
+	wps, err := alloc.getAllocationPools(sc, balances)
+	if err != nil {
+		return fmt.Errorf("can't move tokens to challenge pool: %v", err)
+	}
 
 	if size > 0 {
 		move = details.upload(size, wmTime,
 			alloc.restDurationInTimeUnits(wmTime))
-		// upload (write_pool -> challenge_pool)
-		err = wp.moveToChallenge(alloc.ID, details.BlobberID, cp, now, move)
+
+		err = wps.moveToChallenge(alloc.ID, details.BlobberID, cp, now, move)
 		if err != nil {
 			return fmt.Errorf("can't move tokens to challenge pool: %v", err)
 		}
+
 		alloc.MovedToChallenge += move
 		details.Spent += move
 	} else {
 		// delete (challenge_pool -> write_pool)
-		move = details.delete(-size, wmTime,
-			alloc.restDurationInTimeUnits(wmTime))
-		err = cp.moveToWritePool(alloc.ID, details.BlobberID, until, wp, move)
+		move = details.delete(-size, wmTime, alloc.restDurationInTimeUnits(wmTime))
+		wp, err := wps.getOwnerWP()
+		if err != nil {
+			return fmt.Errorf("can't move tokens to challenge pool: %v", err)
+		}
+		err = cp.moveToWritePool(alloc, details.BlobberID, until, wp, move)
 		if err != nil {
 			return fmt.Errorf("can't move tokens to write pool: %v", err)
 		}
@@ -529,10 +530,10 @@ func (sc *StorageSmartContract) commitMoveTokens(alloc *StorageAllocation,
 		details.Returned += move
 	}
 
-	// save pools
-	if err = wp.save(sc.ID, alloc.Owner, balances); err != nil {
-		return fmt.Errorf("can't save write pool: %v", err)
+	if err := wps.saveWritePools(sc.ID, balances); err != nil {
+		return fmt.Errorf("can't move tokens to challenge pool: %v", err)
 	}
+
 	if err = cp.save(sc.ID, alloc.ID, balances); err != nil {
 		return fmt.Errorf("can't save challenge pool: %v", err)
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -122,7 +122,7 @@ func (sc *StorageSmartContract) blobberReward(t *transaction.Transaction,
 			return fmt.Errorf("can't get allocation's write pool: %v", err)
 		}
 		var until = alloc.Until()
-		err = cp.moveToWritePool(alloc.ID, details.BlobberID, until, wp, back)
+		err = cp.moveToWritePool(alloc, details.BlobberID, until, wp, back)
 		if err != nil {
 			return fmt.Errorf("moving partial challenge to write pool: %v", err)
 		}
@@ -271,7 +271,7 @@ func (sc *StorageSmartContract) blobberPenalty(t *transaction.Transaction,
 
 	// move back to write pool
 	var until = alloc.Until()
-	err = cp.moveToWritePool(alloc.ID, details.BlobberID, until, wp, move)
+	err = cp.moveToWritePool(alloc, details.BlobberID, until, wp, move)
 	if err != nil {
 		return fmt.Errorf("moving failed challenge to write pool: %v", err)
 	}
@@ -297,7 +297,7 @@ func (sc *StorageSmartContract) blobberPenalty(t *transaction.Transaction,
 		}
 
 		var move state.Balance
-		move, err = sp.slash(alloc.ID, details.BlobberID, until, wp, offer.Lock,
+		move, err = sp.slash(alloc, details.BlobberID, until, wp, offer.Lock,
 			slash)
 		if err != nil {
 			return fmt.Errorf("can't move tokens to write pool: %v", err)

--- a/code/go/0chain.net/smartcontract/storagesc/challengepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challengepool.go
@@ -69,8 +69,13 @@ func (cp *challengePool) save(sscKey, allocationID string,
 }
 
 // moveToWritePool moves tokens back to write pool on data deleted
-func (cp *challengePool) moveToWritePool(allocID, blobID string,
-	until common.Timestamp, wp *writePool, value state.Balance) (err error) {
+func (cp *challengePool) moveToWritePool(
+	alloc *StorageAllocation,
+	blobID string,
+	until common.Timestamp,
+	wp *writePool,
+	value state.Balance,
+) (err error) {
 
 	if value == 0 {
 		return // nothing to move
@@ -81,11 +86,12 @@ func (cp *challengePool) moveToWritePool(allocID, blobID string,
 			cp.ID, cp.Balance, value)
 	}
 
-	var ap = wp.allocPool(allocID, until)
+	var ap = wp.allocPool(alloc.ID, until)
 	if ap == nil {
 		ap = new(allocationPool)
-		ap.AllocationID = allocID
+		ap.AllocationID = alloc.ID
 		ap.ExpireAt = 0
+		alloc.WritePoolOwners.add(alloc.Owner)
 		wp.Pools.add(ap)
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/challengepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challengepool.go
@@ -91,7 +91,7 @@ func (cp *challengePool) moveToWritePool(
 		ap = new(allocationPool)
 		ap.AllocationID = alloc.ID
 		ap.ExpireAt = 0
-		alloc.WritePoolOwners.add(alloc.Owner)
+		alloc.addWritePoolOwner(alloc.Owner)
 		wp.Pools.add(ap)
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -566,7 +566,7 @@ type StorageAllocation struct {
 	MaxChallengeCompletionTime time.Duration `json:"max_challenge_completion_time"`
 
 	//AllocationPools allocationPools `json:"allocation_pools"`
-	WritePoolOwners sortedList `json:"write_pool_owners"`
+	WritePoolOwners []string `json:"write_pool_owners"`
 
 	// ChallengeCompletionTime is max challenge completion time of
 	// all blobbers of the allocation.
@@ -614,15 +614,24 @@ func (sa *StorageAllocation) restMinLockDemand() (rest state.Balance) {
 	return
 }
 
+func (sa *StorageAllocation) addWritePoolOwner(userId string) {
+	for _, id := range sa.WritePoolOwners {
+		if userId == id {
+			return
+		}
+	}
+	sa.WritePoolOwners = append(sa.WritePoolOwners, userId)
+}
+
 func (sa *StorageAllocation) getAllocationPools(
 	ssc *StorageSmartContract,
 	balances chainstate.StateContextI,
 ) (*allocationWritePools, error) {
 	var awp = allocationWritePools{
-		ids: sa.WritePoolOwners,
+		ownerId: -1,
 	}
 
-	for _, wpOwner := range sa.WritePoolOwners {
+	for i, wpOwner := range sa.WritePoolOwners {
 		wp, err := ssc.getWritePool(wpOwner, balances)
 		if err != nil {
 			return nil, err
@@ -632,7 +641,25 @@ func (sa *StorageAllocation) getAllocationPools(
 		for _, ap := range cut {
 			awp.allocationPools.add(ap)
 		}
+		if wpOwner == sa.Owner {
+			awp.ownerId = i
+		}
 	}
+
+	if awp.ownerId < 0 {
+		wp, err := ssc.getWritePool(sa.Owner, balances)
+		if err != nil {
+			return nil, err
+		}
+		awp.writePools = append(awp.writePools, wp)
+		cut := wp.Pools.allocationCut(sa.ID)
+		for _, ap := range cut {
+			awp.allocationPools.add(ap)
+		}
+		awp.ownerId = len(awp.writePools) - 1
+		sa.WritePoolOwners = append(sa.WritePoolOwners, sa.Owner)
+	}
+	awp.ids = sa.WritePoolOwners
 
 	return &awp, nil
 }

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool.go
@@ -548,10 +548,13 @@ func (sp *stakePool) update(conf *scConfig, sscID string, now common.Timestamp,
 
 // slash represents blobber penalty; it returns number of tokens moved in
 // reality, with regards to division errors
-func (sp *stakePool) slash(allocID, blobID string, until common.Timestamp,
-	wp *writePool, offer, slash state.Balance) (
-	move state.Balance, err error) {
-
+func (sp *stakePool) slash(
+	alloc *StorageAllocation,
+	blobID string,
+	until common.Timestamp,
+	wp *writePool,
+	offer, slash state.Balance,
+) (move state.Balance, err error) {
 	if offer == 0 || slash == 0 {
 		return // nothing to move
 	}
@@ -564,11 +567,12 @@ func (sp *stakePool) slash(allocID, blobID string, until common.Timestamp,
 	// related stake holders, that can loose some tokens due to
 	// division error;
 
-	var ap = wp.allocPool(allocID, until)
+	var ap = wp.allocPool(alloc.ID, until)
 	if ap == nil {
 		ap = new(allocationPool)
-		ap.AllocationID = allocID
+		ap.AllocationID = alloc.ID
 		ap.ExpireAt = 0
+		alloc.WritePoolOwners.add(alloc.Owner)
 		wp.Pools.add(ap)
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool.go
@@ -572,7 +572,7 @@ func (sp *stakePool) slash(
 		ap = new(allocationPool)
 		ap.AllocationID = alloc.ID
 		ap.ExpireAt = 0
-		alloc.WritePoolOwners.add(alloc.Owner)
+		alloc.addWritePoolOwner(alloc.Owner)
 		wp.Pools.add(ap)
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/writepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool.go
@@ -187,7 +187,7 @@ func (ssc *StorageSmartContract) createEmptyWritePool(
 		Blobbers:     makeCopyAllocationBlobbers(*alloc, txn.Value),
 	}
 	ap.TokenPool.ID = txn.Hash
-	alloc.WritePoolOwners.add(alloc.Owner)
+	alloc.addWritePoolOwner(alloc.Owner)
 	wp.Pools.add(&ap)
 
 	if err = wp.save(ssc.ID, alloc.Owner, balances); err != nil {
@@ -224,7 +224,7 @@ func (ssc *StorageSmartContract) createWritePool(
 		var until = alloc.Until()
 		ap, err := newAllocationPool(t, alloc, until, mintNewTokens, balances)
 		if err != nil {
-			return fmt.Errorf("creating write pool: %v", err)
+			return err
 		}
 		wp.Pools.add(ap)
 	}
@@ -348,7 +348,7 @@ func (ssc *StorageSmartContract) writePoolLock(t *transaction.Transaction,
 	ap.Blobbers = bps
 
 	// add and save
-	alloc.WritePoolOwners.add(t.ClientID)
+	alloc.addWritePoolOwner(alloc.Owner)
 	wp.Pools.add(&ap)
 	if err = wp.save(ssc.ID, t.ClientID, balances); err != nil {
 		return "", common.NewError("write_pool_lock_failed", err.Error())

--- a/code/go/0chain.net/smartcontract/storagesc/writepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool.go
@@ -348,7 +348,7 @@ func (ssc *StorageSmartContract) writePoolLock(t *transaction.Transaction,
 	ap.Blobbers = bps
 
 	// add and save
-	alloc.addWritePoolOwner(alloc.Owner)
+	alloc.addWritePoolOwner(t.ClientID)
 	wp.Pools.add(&ap)
 	if err = wp.save(ssc.ID, t.ClientID, balances); err != nil {
 		return "", common.NewError("write_pool_lock_failed", err.Error())


### PR DESCRIPTION
Currently, only the owner of an allocation can pay for upgrades and write markers. This PR changes it so that funds can be sourced from all allocation pools linked to an allocation. 

1. New WritePoolOwners field added to `StorageAllocation` to keep users with linked allocation pools. Modifications to various methods to populate this field when a new allocation pool is applied as in writePoolLock. 
2. New `allocationWritePools` object. This temporary object holds the write pools and allocation pools linked to an allocation. It is used in place of a `wrtiePool` in the endpoints `commitBlobberConnection` and `updateAllocationRequest`.
3. New method `getAllocationPools` added to `StorageAllocation` to return the allocation's `allocationWritePools` object.
4. writePools methods modified to be used by allocationWrtePools, and various updates to apply these changes
   * `moveToChallange` changed to be a`allocationPools` method so allocationWritePools.allocationPools can use it.
   * `fill` method changed to return an allocation pool rather than add to a `writePool`. The new function renamed to `newAllocatinoPool`  to better suit its purpose. The add to write pool bit being moved outside the method.
5. Couple of unused methods removed from `allocationPools`.
6. New unit test for `extendAllocation`.
7. Fixes to various unit tests that were broken by the above changes.
