### PR TITLE
Execute smart contract with timeout

### DIFF
--- a/code/go/0chain.net/chaincore/block/entity.go
+++ b/code/go/0chain.net/chaincore/block/entity.go
@@ -740,7 +740,7 @@ type Chainer interface {
 	GetBlockStateChange(b *Block) error
 	ComputeState(ctx context.Context, pb *Block) error
 	GetStateDB() util.NodeDB
-	UpdateState(b *Block, txn *transaction.Transaction) error
+	UpdateState(ctx context.Context, b *Block, txn *transaction.Transaction) error
 }
 
 // ComputeState computes block client state
@@ -844,7 +844,7 @@ func (b *Block) ComputeState(ctx context.Context, c Chainer) error {
 		if datastore.IsEmpty(txn.ClientID) {
 			txn.ComputeClientID()
 		}
-		if err := c.UpdateState(b, txn); err != nil {
+		if err := c.UpdateState(ctx, b, txn); err != nil {
 			b.SetStateStatus(StateFailed)
 			logging.Logger.Error("compute state - update state failed",
 				zap.Int64("round", b.Round),

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -332,6 +332,9 @@ func (c *Chain) Delete(ctx context.Context) error {
 	return c.GetEntityMetadata().GetStore().Delete(ctx, c)
 }
 
+// DefaultSmartContractTimeout represents the default smart contract execution timeout
+const DefaultSmartContractTimeout = time.Second
+
 //NewChainFromConfig - create a new chain from config
 func NewChainFromConfig() *Chain {
 	chain := Provider().(*Chain)
@@ -406,6 +409,9 @@ func NewChainFromConfig() *Chain {
 	chain.MinActiveSharders = viper.GetInt("server_chain.block.sharding.min_active_sharders")
 	chain.MinActiveReplicators = viper.GetInt("server_chain.block.sharding.min_active_replicators")
 	chain.SmartContractTimeout = viper.GetDuration("server_chain.smart_contract.timeout") * time.Millisecond
+	if chain.SmartContractTimeout == 0 {
+		chain.SmartContractTimeout = DefaultSmartContractTimeout
+	}
 	chain.RoundTimeoutSofttoMin = viper.GetInt("server_chain.round_timeouts.softto_min")
 	chain.RoundTimeoutSofttoMult = viper.GetInt("server_chain.round_timeouts.softto_mult")
 	chain.RoundRestartMult = viper.GetInt("server_chain.round_timeouts.round_restart_mult")

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -1,12 +1,13 @@
 package miner
 
 import (
-	"0chain.net/smartcontract/storagesc"
 	"bytes"
 	"context"
 	"fmt"
 	"strconv"
 	"time"
+
+	"0chain.net/smartcontract/storagesc"
 
 	"0chain.net/chaincore/block"
 	"0chain.net/chaincore/client"
@@ -52,7 +53,7 @@ func (mc *Chain) processTxn(ctx context.Context, txn *transaction.Transaction, b
 		}
 		return common.NewError("process fee transaction", "transaction already exists")
 	}
-	if err := mc.UpdateState(b, txn); err != nil {
+	if err := mc.UpdateState(ctx, b, txn); err != nil {
 		logging.Logger.Error("processTxn", zap.String("txn", txn.Hash),
 			zap.String("txn_object", datastore.ToJSON(txn).String()),
 			zap.Error(err))

--- a/code/go/0chain.net/miner/protocol_block_integration_tests.go
+++ b/code/go/0chain.net/miner/protocol_block_integration_tests.go
@@ -140,7 +140,7 @@ func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block,
 				return false
 			}
 		}
-		if err := mc.UpdateState(b, txn); err != nil {
+		if err := mc.UpdateState(ctx, b, txn); err != nil {
 			if debugTxn {
 				logging.Logger.Error("generate block (debug transaction) update state", zap.String("txn", txn.Hash), zap.Int32("idx", idx), zap.String("txn_object", datastore.ToJSON(txn).String()), zap.Error(err))
 			}

--- a/code/go/0chain.net/miner/protocol_block_main.go
+++ b/code/go/0chain.net/miner/protocol_block_main.go
@@ -88,7 +88,7 @@ func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block,
 			}
 			return false
 		}
-		if err := mc.UpdateState(b, txn); err != nil {
+		if err := mc.UpdateState(ctx, b, txn); err != nil {
 			if debugTxn {
 				logging.Logger.Error("generate block (debug transaction) update state",
 					zap.String("txn", txn.Hash), zap.Int32("idx", idx),


### PR DESCRIPTION
It used to execute a smart contract with no limited time if the block is notarized or
the SmartContractTimeout is 0. We should always have the timeout when executing a smart  contract.