### PR TITLE
Fix curator transfer allocation not changing client allocation list

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
@@ -705,6 +705,7 @@ func setupMocksFinishAllocation(
 		Pools: allocationPools{},
 	}
 	var newPool = &allocationPool{}
+	newPool.ID = "first_mock_write_pool"
 	newPool.Balance = state.Balance(0)
 	newPool.AllocationID = sAllocation.ID
 	newPool.Blobbers = blobberPools{}
@@ -719,6 +720,7 @@ func setupMocksFinishAllocation(
 	for i := 0; i < otherWritePools; i++ {
 		var id = strconv.Itoa(i)
 		var newPool = &allocationPool{}
+		newPool.ID = "mock_write_pool_" + id
 		newPool.AllocationID = allocationId + " " + id
 		wPool.Pools.add(newPool)
 	}


### PR DESCRIPTION
https://github.com/0chain/0chain/pull/366 failed to alter the clientAllocation lists for the new and old owner. This PR removes the id from the old owner's list and adds it to the new owner's list.