### PR TITLE
Fund allocation pools for someone else

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
@@ -27,6 +27,7 @@ type lockRequest struct {
 	Duration     time.Duration `json:"duration"`
 	AllocationID datastore.Key `json:"allocation_id"`
 	BlobberID    datastore.Key `json:"blobber_id,omitempty"`
+	TargetId     datastore.Key `json:"target_id,omitempty"`
 }
 
 func (lr *lockRequest) decode(input []byte) (err error) {
@@ -41,7 +42,8 @@ func (lr *lockRequest) decode(input []byte) (err error) {
 
 // unlock request used to unlock all tokens of a read pool
 type unlockRequest struct {
-	PoolID datastore.Key `json:"pool_id"`
+	PoolOwner datastore.Key `json:"pool_owner,omitempty"`
+	PoolID    datastore.Key `json:"pool_id"`
 }
 
 func (ur *unlockRequest) decode(input []byte) error {

--- a/code/go/0chain.net/smartcontract/storagesc/funded_pools.go
+++ b/code/go/0chain.net/smartcontract/storagesc/funded_pools.go
@@ -1,0 +1,88 @@
+package storagesc
+
+import (
+	cstate "0chain.net/chaincore/chain/state"
+	"0chain.net/core/common"
+	"0chain.net/core/datastore"
+	"0chain.net/core/util"
+	"encoding/json"
+	"fmt"
+)
+
+func fundedPoolsKey(scKey, clientID string) datastore.Key {
+	return datastore.Key(scKey + ":fundedpools:" + clientID)
+}
+
+type fundedPools []string
+
+func (fp *fundedPools) Encode() []byte {
+	var b, err = json.Marshal(fp)
+	if err != nil {
+		panic(err) // must never happens
+	}
+	return b
+}
+
+func (ssc *StorageSmartContract) addToFundedPools(
+	clientId, poolId string,
+	balances cstate.StateContextI,
+) error {
+	pools, err := ssc.getFundedPools(clientId, balances)
+	if err != nil {
+		return fmt.Errorf("error getting funded pools: %v", err)
+	}
+	pools = append(pools, poolId)
+	_, err = balances.InsertTrieNode(fundedPoolsKey(ssc.ID, clientId), &pools)
+	return nil
+}
+
+func (ssc *StorageSmartContract) isFundedPool(
+	clientId, poolId string,
+	balances cstate.StateContextI,
+) (bool, error) {
+	pools, err := ssc.getFundedPools(clientId, balances)
+	if err != nil {
+		return false, fmt.Errorf("error getting funded pools: %v", err)
+	}
+	for _, id := range pools {
+		if id == poolId {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (fp *fundedPools) Decode(p []byte) error {
+	return json.Unmarshal(p, fp)
+}
+
+// getReadPoolBytes of a client
+func (ssc *StorageSmartContract) getFundedPoolsBytes(
+	clientID datastore.Key,
+	balances cstate.StateContextI,
+) ([]byte, error) {
+	var val util.Serializable
+	val, err := balances.GetTrieNode(fundedPoolsKey(ssc.ID, clientID))
+	if err != nil {
+		return nil, err
+	}
+	return val.Encode(), nil
+}
+
+// getReadPool of current client
+func (ssc *StorageSmartContract) getFundedPools(
+	clientID datastore.Key,
+	balances cstate.StateContextI,
+) (fundedPools, error) {
+	var poolb []byte
+	var err error
+	if poolb, err = ssc.getFundedPoolsBytes(clientID, balances); err != nil {
+		return nil, err
+	}
+	fp := new(fundedPools)
+	err = fp.Decode(poolb)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", common.ErrDecoding, err)
+	}
+	return *fp, nil
+}

--- a/code/go/0chain.net/smartcontract/storagesc/funded_pools_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/funded_pools_test.go
@@ -1,0 +1,170 @@
+package storagesc
+
+import (
+	cstate "0chain.net/chaincore/chain/state"
+	"0chain.net/chaincore/mocks"
+	sci "0chain.net/chaincore/smartcontractinterface"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestAddToFundedPools(t *testing.T) {
+	const (
+		mockClient     = "mock client"
+		mockNewPool    = "mock new pool"
+		mockExistingId = "mock existing id"
+	)
+
+	type parameters struct {
+		client, newPool string
+		existing        []string
+	}
+	var setExpectations = func(
+		t *testing.T, p parameters,
+	) (*StorageSmartContract, cstate.StateContextI) {
+		var balances = &mocks.StateContextI{}
+		var ssc = &StorageSmartContract{
+			SmartContract: sci.NewSC(ADDRESS),
+		}
+		var existingPools fundedPools = p.existing
+		balances.On(
+			"GetTrieNode",
+			fundedPoolsKey(ssc.ID, p.client),
+		).Return(&existingPools, nil).Once()
+		balances.On(
+			"InsertTrieNode",
+			fundedPoolsKey(ssc.ID, p.client),
+			mock.MatchedBy(func(fp *fundedPools) bool {
+				if len(p.existing) != len(*fp)-1 {
+					return false
+				}
+				for i, id := range p.existing {
+					if id != (*fp)[i] {
+						return false
+					}
+				}
+				return p.newPool == (*fp)[len(*fp)-1]
+			}),
+		).Return("", nil).Once()
+
+		return ssc, balances
+	}
+
+	type want struct {
+		error    bool
+		errorMsg string
+	}
+	tests := []struct {
+		name       string
+		parameters parameters
+		want       want
+	}{
+		{
+			name: "ok",
+			parameters: parameters{
+				client:   mockClient,
+				newPool:  mockNewPool,
+				existing: []string{mockExistingId},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ssc, balances := setExpectations(t, tt.parameters)
+
+			err := ssc.addToFundedPools(tt.parameters.client, tt.parameters.newPool, balances)
+
+			require.EqualValues(t, tt.want.error, err != nil)
+			if err != nil {
+				require.EqualValues(t, tt.want.errorMsg, err.Error())
+				return
+			}
+			require.True(t, mock.AssertExpectationsForObjects(t, balances))
+		})
+	}
+}
+
+func TestIsFundedPool(t *testing.T) {
+	const (
+		mockClient     = "mock client"
+		mockPoolId     = "mock pool id"
+		mockExistingId = "mock existing id"
+	)
+
+	type parameters struct {
+		client, poolId string
+		existing       []string
+	}
+	var setExpectations = func(
+		t *testing.T, p parameters,
+	) (*StorageSmartContract, cstate.StateContextI) {
+		var balances = &mocks.StateContextI{}
+		var ssc = &StorageSmartContract{
+			SmartContract: sci.NewSC(ADDRESS),
+		}
+		var existingPools fundedPools = p.existing
+		balances.On(
+			"GetTrieNode",
+			fundedPoolsKey(ssc.ID, p.client),
+		).Return(&existingPools, nil).Once()
+
+		return ssc, balances
+	}
+
+	type want struct {
+		error    bool
+		errorMsg string
+		ok       bool
+	}
+	tests := []struct {
+		name       string
+		parameters parameters
+		want       want
+	}{
+		{
+			name: "ok_not_found",
+			parameters: parameters{
+				client:   mockClient,
+				poolId:   mockPoolId,
+				existing: []string{mockExistingId},
+			},
+		},
+		{
+			name: "ok_found",
+			parameters: parameters{
+				client: mockClient,
+				poolId: mockPoolId,
+				existing: []string{
+					mockExistingId, mockPoolId,
+				},
+			},
+			want: want{
+				ok: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ssc, balances := setExpectations(t, tt.parameters)
+
+			ok, err := ssc.isFundedPool(tt.parameters.client, tt.parameters.poolId, balances)
+
+			require.EqualValues(t, tt.want.error, err != nil)
+			if err != nil {
+				require.EqualValues(t, tt.want.errorMsg, err.Error())
+				return
+			}
+			require.EqualValues(t, tt.want.ok, ok)
+			require.True(t, mock.AssertExpectationsForObjects(t, balances))
+		})
+	}
+}

--- a/code/go/0chain.net/smartcontract/storagesc/readpool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/readpool.go
@@ -451,10 +451,6 @@ func (ssc *StorageSmartContract) readPoolLock(t *transaction.Transaction,
 func (ssc *StorageSmartContract) readPoolUnlock(t *transaction.Transaction,
 	input []byte, balances cstate.StateContextI) (resp string, err error) {
 
-	// user read pool
-
-	// the request
-
 	var (
 		transfer *state.Transfer
 		req      unlockRequest
@@ -468,11 +464,6 @@ func (ssc *StorageSmartContract) readPoolUnlock(t *transaction.Transaction,
 		req.PoolOwner = t.ClientID
 	}
 
-	var rp *readPool
-	if rp, err = ssc.getReadPool(req.PoolOwner, balances); err != nil {
-		return "", common.NewError("read_pool_unlock_failed", err.Error())
-	}
-
 	isFunded, err := ssc.isFundedPool(t.ClientID, req.PoolOwner, balances)
 	if err != nil {
 		return "", common.NewError("read_pool_unlock_failed", err.Error())
@@ -480,6 +471,11 @@ func (ssc *StorageSmartContract) readPoolUnlock(t *transaction.Transaction,
 	if !isFunded {
 		return "", common.NewErrorf("read_pool_unlock_failed",
 			"%s did not fund pool %s", t.ClientID, req.PoolID)
+	}
+
+	var rp *readPool
+	if rp, err = ssc.getReadPool(req.PoolOwner, balances); err != nil {
+		return "", common.NewError("read_pool_unlock_failed", err.Error())
 	}
 
 	var ap *allocationPool

--- a/code/go/0chain.net/smartcontract/storagesc/readpool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/readpool_test.go
@@ -222,6 +222,9 @@ func TestStorageSmartContract_readPoolLock(t *testing.T) {
 		MaxLockPeriod: 100 * time.Second,
 	}, balances, ssc.ID)
 
+	var fp fundedPools = []string{client.id}
+	_, err = balances.InsertTrieNode(fundedPoolsKey(ssc.ID, client.id), &fp)
+
 	// 1. no pool
 	_, err = ssc.readPoolLock(&tx, nil, balances)
 	requireErrMsg(t, err, errMsg1)

--- a/code/go/0chain.net/smartcontract/storagesc/writepool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool_test.go
@@ -164,6 +164,9 @@ func TestStorageSmartContract_writePoolLock(t *testing.T) {
 		MaxLockPeriod: 2 * time.Hour,
 	}, balances, ssc.ID)
 
+	var fp fundedPools = []string{client.id}
+	_, err = balances.InsertTrieNode(fundedPoolsKey(ssc.ID, client.id), &fp)
+
 	var alloc = StorageAllocation{
 		ID: allocID,
 		BlobberDetails: []*BlobberAllocation{


### PR DESCRIPTION
Add ability to fund allocation pools for someone else, and add to their read or write pool.
1. New fundedPools object to hold the list of allocation pools a user has funded. Plus unit test.
2. Modified writePoolLock and readPoolLock to remember the funder of the new allocation pool.
3. Check that the client funded the pool being unlocked in writePoolUnlock and readPoolUnlock.
4. Fix existing unit tests to work with this new feature.