### PR TITLE
Fix thread safe issue on requesting entities from network

### DIFF
--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -160,11 +160,11 @@ func (c *Chain) reachedNotarization(round int64,
 		}
 	}
 
-	logging.Logger.Info("Reached notarization!!!",
+	logging.Logger.Error("Reached notarization!!!",
 		zap.Int64("mb_sr", mb.StartingRound),
 		zap.Int("active_miners", num),
 		zap.Int64("round", round),
-		zap.Int64("current_cound", c.GetCurrentRound()),
+		zap.Int64("current_round", c.GetCurrentRound()),
 		zap.Int("num_signatures", len(bvt)),
 		zap.Int("threshold", threshold))
 

--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -229,7 +229,8 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, txn *transactio
 		err = c.mintAmount(sctx, mint.ToClientID, mint.Amount)
 		if err != nil {
 			logging.Logger.Error("mint error", zap.Any("error", err),
-				zap.Any("transaction", txn.Hash))
+				zap.Any("transaction", txn.Hash),
+				zap.String("to clientID", mint.ToClientID))
 			// Temporary disable returning on mint error: TODO: revert back @bbist
 			// return
 		}
@@ -375,7 +376,7 @@ func (c *Chain) mintAmount(sctx bcstate.StateContextI, toClient datastore.Key, a
 		if state.Debug() {
 			logging.Logger.Error("transfer amount - error", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Any("txn", txn), zap.Error(err))
 		}
-		return err
+		return common.NewError("mint_amount - get state", err.Error())
 	}
 	sctx.SetStateContext(ts)
 	ts.Balance += amount
@@ -398,7 +399,7 @@ func (c *Chain) mintAmount(sctx bcstate.StateContextI, toClient datastore.Key, a
 		if state.Debug() {
 			logging.Logger.Error("transfer amount - error", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Any("txn", txn), zap.Error(err))
 		}
-		return err
+		return common.NewError("mint_amount - insert", err.Error())
 	}
 	return nil
 }

--- a/code/go/0chain.net/chaincore/chain/state_sync.go
+++ b/code/go/0chain.net/chaincore/chain/state_sync.go
@@ -191,33 +191,46 @@ func (c *Chain) getPartialState(ctx context.Context, key util.Key) (*state.Parti
 	psRequestor := PartialStateRequestor
 	params := &url.Values{}
 	params.Add("node", util.ToHex(key))
-	cctx, cancelf := context.WithCancel(ctx)
-	defer cancelf()
-	var ps *state.PartialState
-	handler := func(ctx context.Context, entity datastore.Entity) (interface{}, error) {
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	psC := make(chan *state.PartialState, 1)
+	handler := func(_ context.Context, entity datastore.Entity) (interface{}, error) {
 		logging.Logger.Debug("get partial state", zap.String("ps_id", entity.GetKey()))
 		rps, ok := entity.(*state.PartialState)
 		if !ok {
 			return nil, datastore.ErrInvalidEntity
 		}
-		logging.Logger.Info("get partial state", zap.String("key", util.ToHex(key)), zap.Int("nodes", len(rps.Nodes)))
 		if bytes.Compare(key, rps.Hash) != 0 {
-			logging.Logger.Error("get partial state - state hash mismatch error", zap.String("key", util.ToHex(key)), zap.Any("hash", util.ToHex(ps.Hash)))
+			logging.Logger.Error("get partial state - state hash mismatch error",
+				zap.String("key", util.ToHex(key)),
+				zap.Any("hash", util.ToHex(rps.Hash)))
 			return nil, state.ErrHashMismatch
 		}
 		root := rps.GetRoot()
 		if root == nil {
-			logging.Logger.Error("get partial state - state root error", zap.Int("state_nodes", len(ps.Nodes)))
+			logging.Logger.Error("get partial state - state root error", zap.Int("state_nodes", len(rps.Nodes)))
 			return nil, common.NewError("state_root_error", "Partial state root calculcation error")
 		}
-		cancelf()
-		ps = rps
+		cancel()
+		select {
+		case psC <- rps:
+		default:
+		}
 		return rps, nil
 	}
 	c.RequestEntityFromMinersOnMB(cctx, c.GetCurrentMagicBlock(), psRequestor, params, handler)
+	var ps *state.PartialState
+	select {
+	case ps = <-psC:
+	default:
+	}
 	if ps == nil {
 		return nil, common.NewError("partial_state_change_error", "Error getting the partial state")
 	}
+
+	logging.Logger.Info("get partial state",
+		zap.String("key", util.ToHex(key)),
+		zap.Int("nodes", len(ps.Nodes)))
 	return ps, nil
 }
 
@@ -227,10 +240,10 @@ func (c *Chain) getStateNodes(ctx context.Context, keys []util.Key) (*state.Node
 	for _, key := range keys {
 		params.Add("nodes", util.ToHex(key))
 	}
-	cctx, cancelf := context.WithCancel(ctx)
-	defer cancelf()
-	var ns *state.Nodes
-	handler := func(ctx context.Context, entity datastore.Entity) (interface{}, error) {
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	nodeStateC := make(chan *state.Nodes, 1)
+	handler := func(_ context.Context, entity datastore.Entity) (interface{}, error) {
 		rns, ok := entity.(*state.Nodes)
 		if !ok {
 			return nil, datastore.ErrInvalidEntity
@@ -238,19 +251,37 @@ func (c *Chain) getStateNodes(ctx context.Context, keys []util.Key) (*state.Node
 		if len(rns.Nodes) == 0 {
 			return nil, util.ErrNodeNotFound
 		}
-		logging.Logger.Info("get state nodes", zap.Int("keys", len(keys)), zap.Int("nodes", len(rns.Nodes)))
-		cancelf()
-		ns = rns
+		cancel()
+		select {
+		case nodeStateC <- rns:
+		default:
+		}
 		return rns, nil
 	}
 	mb := c.GetCurrentMagicBlock()
 	c.RequestEntityFromMinersOnMB(cctx, mb, nsRequestor, params, handler)
+	var ns *state.Nodes
+	select {
+	case ns = <-nodeStateC:
+	default:
+	}
+
 	if ns == nil {
 		c.RequestEntityFromShardersOnMB(cctx, mb, nsRequestor, params, handler)
 	}
-	if ns == nil {
-		return nil, common.NewError("state_nodes_error", "Error getting the state nodes")
+
+	select {
+	case ns = <-nodeStateC:
+	default:
 	}
+
+	if ns == nil {
+		return nil, common.NewError("state_nodes_error", "error getting the state nodes")
+	}
+
+	logging.Logger.Info("get state nodes",
+		zap.Int("keys", len(keys)),
+		zap.Int("nodes", len(ns.Nodes)))
 	return ns, nil
 }
 
@@ -260,10 +291,10 @@ func (c *Chain) getStateNodesFromSharders(ctx context.Context, keys []util.Key) 
 	for _, key := range keys {
 		params.Add("nodes", util.ToHex(key))
 	}
-	cctx, cancelf := context.WithCancel(ctx)
-	defer cancelf()
-	var ns *state.Nodes
-	handler := func(ctx context.Context, entity datastore.Entity) (interface{}, error) {
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stateNodeC := make(chan *state.Nodes, 1)
+	handler := func(_ context.Context, entity datastore.Entity) (interface{}, error) {
 		rns, ok := entity.(*state.Nodes)
 		if !ok {
 			return nil, datastore.ErrInvalidEntity
@@ -271,27 +302,37 @@ func (c *Chain) getStateNodesFromSharders(ctx context.Context, keys []util.Key) 
 		if len(rns.Nodes) == 0 {
 			return nil, util.ErrNodeNotFound
 		}
-		logging.Logger.Info("get state nodes", zap.Int("keys", len(keys)), zap.Int("nodes", len(rns.Nodes)))
-		cancelf()
-		ns = rns
+		select {
+		case stateNodeC <- rns:
+		default:
+		}
+		cancel()
 		return rns, nil
 	}
+
 	c.RequestEntityFromShardersOnMB(cctx, c.GetCurrentMagicBlock(), nsRequestor, params, handler)
-	if ns == nil {
-		return nil, common.NewError("state_nodes_error", "Error getting the state nodes")
+	var ns *state.Nodes
+	select {
+	case ns = <-stateNodeC:
+	default:
 	}
+
+	if ns == nil {
+		return nil, common.NewError("state_nodes_error", "error getting the state nodes")
+	}
+
+	logging.Logger.Info("get state nodes", zap.Int("keys", len(keys)), zap.Int("nodes", len(ns.Nodes)))
 	return ns, nil
 }
 
 func (c *Chain) getBlockStateChange(b *block.Block) (*block.StateChange, error) {
-	var (
-		params       = &url.Values{}
-		ctx, cancelf = context.WithCancel(common.GetRootContext())
-		bsc          *block.StateChange
-	)
+	cctx, cancel := context.WithCancel(common.GetRootContext())
+	defer cancel()
+	params := &url.Values{}
 	params.Add("block", b.Hash)
 
-	var handler = func(ctx context.Context, entity datastore.Entity) (
+	stateChangesC := make(chan *block.StateChange, 1)
+	var handler = func(_ context.Context, entity datastore.Entity) (
 		resp interface{}, err error) {
 
 		var rsc, ok = entity.(*block.StateChange)
@@ -326,22 +367,29 @@ func (c *Chain) getBlockStateChange(b *block.Block) (*block.StateChange, error) 
 				"block state root calculation error")
 		}
 
-		logging.Logger.Debug("get_block_state_change - success with root",
-			zap.Int64("round", b.Round),
-			zap.String("bsc root", rsc.GetRoot().GetHash()),
-			zap.String("block state hash", util.ToHex(b.ClientStateHash)))
-		cancelf()
-		bsc = rsc
+		cancel()
+		select {
+		case stateChangesC <- rsc:
+		default:
+		}
 		return rsc, nil
 	}
 
-	c.RequestEntityFromMinersOnMB(ctx, c.GetMagicBlock(b.Round), BlockStateChangeRequestor, params, handler)
-
+	c.RequestEntityFromMinersOnMB(cctx, c.GetMagicBlock(b.Round), BlockStateChangeRequestor, params, handler)
+	var bsc *block.StateChange
+	select {
+	case bsc = <-stateChangesC:
+	default:
+	}
 	if bsc == nil {
 		return nil, common.NewError("block_state_change_error",
 			"error getting the block state change")
 	}
 
+	logging.Logger.Debug("get_block_state_change - success with root",
+		zap.Int64("round", b.Round),
+		zap.String("bsc root", bsc.GetRoot().GetHash()),
+		zap.String("block state hash", util.ToHex(b.ClientStateHash)))
 	return bsc, nil
 }
 

--- a/code/go/0chain.net/chaincore/node/n2n.go
+++ b/code/go/0chain.net/chaincore/node/n2n.go
@@ -15,7 +15,7 @@ f m n  where f is a function that takes a message m and a node n to send the mes
 When this function is partially applied, we get the send handler, i.e., a closure that has the message and can
 be repeatedly applied to different nodes
 */
-type SendHandler func(n *Node) bool
+type SendHandler func(ctx context.Context, n *Node) bool
 
 /*EntitySendHandler is used to send an entity to a given node
 

--- a/code/go/0chain.net/chaincore/node/n2n_push2pull.go
+++ b/code/go/0chain.net/chaincore/node/n2n_push2pull.go
@@ -85,7 +85,7 @@ func pullEntityHandler(ctx context.Context, nd *Node, uri string, handler datast
 			return entity, nil
 		}
 		start := time.Now()
-		_, err := handler(ctx, entity)
+		_, err := handler(pctx, entity)
 		duration := time.Since(start)
 		if err != nil {
 			logging.N2n.Error("message pull", zap.Int("from", nd.SetIndex),
@@ -151,7 +151,7 @@ func pullEntityHandler(ctx context.Context, nd *Node, uri string, handler datast
 			break
 		}
 		requestNode.requested = true
-		result := rhandler(requestNode.node)
+		result := rhandler(ctx, requestNode.node)
 		if result {
 			pcde.state = pullStateDone
 			break

--- a/code/go/0chain.net/chaincore/node/n2n_send.go
+++ b/code/go/0chain.net/chaincore/node/n2n_send.go
@@ -28,12 +28,12 @@ func SetMaxConcurrentRequests(maxConcurrentRequests int) {
 }
 
 /*SendAll - send to every node */
-func (np *Pool) SendAll(handler SendHandler) []*Node {
-	return np.SendAtleast(np.Size(), handler)
+func (np *Pool) SendAll(ctx context.Context, handler SendHandler) []*Node {
+	return np.SendAtleast(ctx, np.Size(), handler)
 }
 
 /*SendTo - send to a specific node */
-func (np *Pool) SendTo(handler SendHandler, to string) (bool, error) {
+func (np *Pool) SendTo(ctx context.Context, handler SendHandler, to string) (bool, error) {
 	recepient := np.GetNode(to)
 	if recepient == nil {
 		return false, ErrNodeNotFound
@@ -41,18 +41,18 @@ func (np *Pool) SendTo(handler SendHandler, to string) (bool, error) {
 	if Self.IsEqual(recepient) {
 		return false, ErrSendingToSelf
 	}
-	return handler(recepient), nil
+	return handler(ctx, recepient), nil
 }
 
 /*SendOne - send message to a single node in the pool */
-func (np *Pool) SendOne(handler SendHandler) *Node {
+func (np *Pool) SendOne(ctx context.Context, handler SendHandler) *Node {
 	nodes := np.shuffleNodesLock(false)
-	return np.sendOne(handler, nodes)
+	return np.sendOne(ctx, handler, nodes)
 }
 
 /*SendToMultiple - send to multiple nodes */
-func (np *Pool) SendToMultiple(handler SendHandler, nodes []*Node) (bool, error) {
-	sentTo := np.sendTo(len(nodes), nodes, handler)
+func (np *Pool) SendToMultiple(ctx context.Context, handler SendHandler, nodes []*Node) (bool, error) {
+	sentTo := np.sendTo(ctx, len(nodes), nodes, handler)
 	if len(sentTo) == len(nodes) {
 		return true, nil
 	}
@@ -60,27 +60,27 @@ func (np *Pool) SendToMultiple(handler SendHandler, nodes []*Node) (bool, error)
 }
 
 /*SendToMultipleNodes - send to multiple nodes */
-func (np *Pool) SendToMultipleNodes(handler SendHandler, nodes []*Node) (result []*Node) {
+func (np *Pool) SendToMultipleNodes(ctx context.Context, handler SendHandler, nodes []*Node) (result []*Node) {
 	defer func() {
 		if r := recover(); r != nil {
 			logging.Logger.Error("PANIC", zap.Any("error", r))
 		}
 	}()
-	result = np.sendTo(len(nodes), nodes, handler)
+	result = np.sendTo(ctx, len(nodes), nodes, handler)
 	return
 }
 
 /*SendAtleast - It tries to communicate to at least the given number of active nodes */
-func (np *Pool) SendAtleast(numNodes int, handler SendHandler) []*Node {
+func (np *Pool) SendAtleast(ctx context.Context, numNodes int, handler SendHandler) []*Node {
 	nodes := np.shuffleNodesLock(false)
-	return np.sendTo(numNodes, nodes, handler)
+	return np.sendTo(ctx, numNodes, nodes, handler)
 }
 
-func (np *Pool) sendTo(numNodes int, nodes []*Node, handler SendHandler) []*Node {
+func (np *Pool) sendTo(ctx context.Context, numNodes int, nodes []*Node, handler SendHandler) []*Node {
 	const THRESHOLD = 2
 	sentTo := make([]*Node, 0, numNodes)
 	if numNodes == 1 {
-		node := np.sendOne(handler, nodes)
+		node := np.sendOne(ctx, handler, nodes)
 		if node == nil {
 			return sentTo
 		}
@@ -100,7 +100,7 @@ func (np *Pool) sendTo(numNodes int, nodes []*Node, handler SendHandler) []*Node
 	for i := 0; i < numWorkers; i++ {
 		go func() {
 			for node := range sendBucket {
-				valid := handler(node)
+				valid := handler(ctx, node)
 				if valid {
 					validBucket <- node
 				}
@@ -146,12 +146,12 @@ func (np *Pool) sendTo(numNodes int, nodes []*Node, handler SendHandler) []*Node
 	return sentTo
 }
 
-func (np *Pool) sendOne(handler SendHandler, nodes []*Node) *Node {
+func (np *Pool) sendOne(ctx context.Context, handler SendHandler, nodes []*Node) *Node {
 	for _, node := range nodes {
 		if node.GetStatus() == NodeStatusInactive {
 			continue
 		}
-		valid := handler(node)
+		valid := handler(ctx, node)
 		if valid {
 			return node
 		}
@@ -192,7 +192,7 @@ func SendEntityHandler(uri string, options *SendOptions) EntitySendHandler {
 			pdce := &pushDataCacheEntry{Options: *options, Data: data, EntityName: entity.GetEntityMetadata().GetName()}
 			pushDataCache.Add(key, pdce)
 		}
-		return func(receiver *Node) bool {
+		return func(ctx context.Context, receiver *Node) bool {
 			timer := receiver.GetTimer(uri)
 			url := receiver.GetN2NURLBase() + uri
 			var buffer *bytes.Buffer
@@ -213,8 +213,9 @@ func SendEntityHandler(uri string, options *SendOptions) EntitySendHandler {
 			}
 			req.Header.Set("Content-Type", "application/json; charset=utf-8")
 			SetSendHeaders(req, entity, options)
-			ctx, cancel := context.WithCancel(context.TODO())
-			req = req.WithContext(ctx)
+			cctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			req = req.WithContext(cctx)
 			// Keep the number of messages to a node bounded
 			var (
 				ts       time.Time

--- a/code/go/0chain.net/chaincore/node/n2n_send.go
+++ b/code/go/0chain.net/chaincore/node/n2n_send.go
@@ -379,7 +379,7 @@ func ToN2NReceiveEntityHandler(handler datastore.JSONEntityReqResponderF, option
 				return
 			}
 		}
-		ctx := r.Context()
+		ctx := context.Background()
 		initialNodeID := r.Header.Get(HeaderInitialNodeID)
 		if initialNodeID != "" {
 			initSender := GetNode(initialNodeID)

--- a/code/go/0chain.net/chaincore/node/node_test.go
+++ b/code/go/0chain.net/chaincore/node/node_test.go
@@ -107,7 +107,7 @@ func TestNode2NodeCommunication(t *testing.T) {
 
 	options := SendOptions{MaxRelayLength: 0, CurrentRelayLength: 0, Compress: true, CODEC: datastore.CodecMsgpack}
 	sendHandler := SendEntityHandler("/v1/_n2n/entity/post", &options)
-	_ = np.SendAtleast(2, sendHandler(entity))
+	_ = np.SendAtleast(context.Background(), 2, sendHandler(entity))
 }
 
 func TestPoolScorer(t *testing.T) {

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -520,9 +520,6 @@ func (r *Round) GetMinerRank(miner *node.Node) int {
 		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 		logging.Logger.DPanic(fmt.Sprintf("miner ranks not computed yet: %v, random seed: %v, round: %v", r.GetState(), r.GetRandomSeed(), r.GetRoundNumber()))
 	}
-	logging.Logger.Info("get miner rank", zap.Any("minerPerm", r.minerPerm),
-		zap.Any("miner", miner), zap.Any("round", r.Number),
-		zap.Any("miner_set_index", miner.SetIndex))
 	if miner.SetIndex >= len(r.minerPerm) {
 		logging.Logger.Warn("get miner rank -- the node index in the permutation is missing. Returns: -1.",
 			zap.Any("r.minerPerm", r.minerPerm), zap.Any("set_index", miner.SetIndex),

--- a/code/go/0chain.net/core/util/merkle_patricia_trie.go
+++ b/code/go/0chain.net/core/util/merkle_patricia_trie.go
@@ -733,7 +733,6 @@ func (mpt *MerklePatriciaTrie) iterate(ctx context.Context, path Path, key Key, 
 
 	node, err := mpt.db.GetNode(key)
 	if err != nil {
-		Logger.Error("iterate - get node error", zap.Error(err))
 		if herr := handler(ctx, path, key, node); herr != nil {
 			return herr
 		}

--- a/code/go/0chain.net/miner/m_handler.go
+++ b/code/go/0chain.net/miner/m_handler.go
@@ -185,8 +185,8 @@ func VRFShareHandler(ctx context.Context, entity datastore.Entity) (
 
 		// send verify block message, then send notarized block
 		go func() {
-			mb.Miners.SendTo(VerifyBlockSender(hnb), found.ID)
-			mb.Miners.SendTo(MinerNotarizedBlockSender(hnb), found.ID)
+			mb.Miners.SendTo(ctx, VerifyBlockSender(hnb), found.ID)
+			mb.Miners.SendTo(ctx, MinerNotarizedBlockSender(hnb), found.ID)
 		}()
 
 		logging.Logger.Info("Rejecting VRFShare: push not. block message for the miner behind",

--- a/code/go/0chain.net/miner/m_handler.go
+++ b/code/go/0chain.net/miner/m_handler.go
@@ -318,6 +318,10 @@ func NotarizedBlockHandler(ctx context.Context, entity datastore.Entity) (
 
 	if err := mc.VerifyNotarization(ctx, b, b.GetVerificationTickets(),
 		r.GetRoundNumber()); err != nil {
+		logging.Logger.Error("not. block handler -- verify notarization failed",
+			zap.Int64("round", b.Round),
+			zap.String("block", b.Hash),
+			zap.Error(err))
 		return nil, err
 	}
 

--- a/code/go/0chain.net/miner/protocol_send.go
+++ b/code/go/0chain.net/miner/protocol_send.go
@@ -19,7 +19,7 @@ func (mc *Chain) SendBlock(ctx context.Context, b *block.Block) {
 	}
 	mb := mc.GetMagicBlock(b.Round)
 	m2m := mb.Miners
-	m2m.SendAll(VerifyBlockSender(b))
+	m2m.SendAll(ctx, VerifyBlockSender(b))
 }
 
 // SendNotarization - send the block notarization (collection of verification
@@ -39,7 +39,7 @@ func (mc *Chain) SendNotarization(ctx context.Context, b *block.Block) {
 		miners = mb.Miners
 	)
 
-	go miners.SendAll(BlockNotarizationSender(notarization))
+	go miners.SendAll(ctx, BlockNotarizationSender(notarization))
 	mc.SendNotarizedBlock(ctx, b)
 }
 
@@ -50,7 +50,7 @@ func (mc *Chain) SendNotarizedBlock(ctx context.Context, b *block.Block) {
 			mb  = mc.GetMagicBlock(b.Round)
 			mbs = mb.Sharders
 		)
-		mbs.SendAll(NotarizedBlockSender(b))
+		mbs.SendAll(ctx, NotarizedBlockSender(b))
 	}
 }
 
@@ -59,7 +59,7 @@ func (mc *Chain) ForcePushNotarizedBlock(ctx context.Context, b *block.Block) {
 	if mc.BlocksToSharder == chain.NOTARIZED {
 		mb := mc.GetMagicBlock(b.Round)
 		m2s := mb.Sharders
-		m2s.SendAll(NotarizedBlockForcePushSender(b))
+		m2s.SendAll(ctx, NotarizedBlockForcePushSender(b))
 	}
 }
 
@@ -68,6 +68,6 @@ func (mc *Chain) SendFinalizedBlock(ctx context.Context, b *block.Block) {
 	if mc.BlocksToSharder == chain.FINALIZED {
 		mb := mc.GetMagicBlock(b.Round)
 		m2s := mb.Sharders
-		m2s.SendAll(FinalizedBlockSender(b))
+		m2s.SendAll(ctx, FinalizedBlockSender(b))
 	}
 }

--- a/code/go/0chain.net/miner/protocol_send_main.go
+++ b/code/go/0chain.net/miner/protocol_send_main.go
@@ -15,7 +15,7 @@ import (
 func (mc *Chain) SendVRFShare(ctx context.Context, vrfs *round.VRFShare) {
 	mb := mc.GetMagicBlock(vrfs.Round)
 	m2m := mb.Miners
-	m2m.SendAll(RoundVRFSender(vrfs))
+	m2m.SendAll(ctx, RoundVRFSender(vrfs))
 }
 
 /*SendVerificationTicket - send the block verification ticket */
@@ -30,9 +30,9 @@ func (mc *Chain) SendVerificationTicket(ctx context.Context, b *block.Block,
 	if mc.VerificationTicketsTo == chain.Generator &&
 		b.MinerID != node.Self.Underlying().GetKey() {
 
-		m2m.SendTo(VerificationTicketSender(bvt), b.MinerID)
+		m2m.SendTo(ctx, VerificationTicketSender(bvt), b.MinerID)
 		return
 	}
 
-	m2m.SendAll(VerificationTicketSender(bvt))
+	m2m.SendAll(ctx, VerificationTicketSender(bvt))
 }

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -198,6 +198,10 @@ func (sc *Chain) setupLatestBlocks(ctx context.Context, bl *blocksLoaded) (
 	err = sc.VerifyNotarization(ctx, bl.lfb, bl.lfb.GetVerificationTickets(),
 		bl.r.GetRoundNumber())
 	if err != nil {
+		Logger.Error("load_lfb - verify notarization failed",
+			zap.Error(err),
+			zap.Int64("round", bl.lfb.Round),
+			zap.String("block", bl.lfb.Hash))
 		err = nil // not a real error
 		return    // do nothing, if not notarized
 	}

--- a/code/go/0chain.net/sharder/health_check.go
+++ b/code/go/0chain.net/sharder/health_check.go
@@ -162,26 +162,14 @@ func (sc *Chain) setCycleBounds(_ context.Context, scanMode HealthCheckScan) {
 	bss := sc.BlockSyncStats
 	cb := &bss.cycle[scanMode].bounds
 
-	// Clear old bounds
-	*cb = CycleBounds{}
-	config := &sc.HCCycleScan[scanMode]
-	cb.window = config.Window
-
-	//roundEntity, err := sc.GetMostRecentRoundFromDB(ctx)
 	r := sc.GetLatestFinalizedBlock().Round
+	cb.window = r - cb.highRound
 	cb.highRound = r
 	if r == 0 {
 		cb.highRound = 1
 	}
 
-	// Start from the high round
-	cb.currentRound = cb.highRound
-	if cb.window == 0 || cb.window > cb.highRound {
-		// Cover entire blockchain.
-		cb.lowRound = 1
-	} else {
-		cb.lowRound = cb.highRound - cb.window + 1
-	}
+	cb.lowRound = cb.highRound - cb.window
 }
 
 // HealthCheckSetup - checks the health for each round

--- a/code/go/0chain.net/sharder/health_check_test.go
+++ b/code/go/0chain.net/sharder/health_check_test.go
@@ -9,8 +9,6 @@ func init() {
 }
 
 func TestHealthCheckScan_String(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name      string
 		e         HealthCheckScan

--- a/code/go/0chain.net/sharder/protocol_block.go
+++ b/code/go/0chain.net/sharder/protocol_block.go
@@ -185,9 +185,9 @@ func (sc *Chain) processBlock(ctx context.Context, b *block.Block) {
 		er.GetRoundNumber())
 	if err != nil {
 		Logger.Error("notarization verification failed",
+			zap.Error(err),
 			zap.Int64("round", b.Round),
-			zap.String("block", b.Hash),
-			zap.Error(err))
+			zap.String("block", b.Hash))
 		return
 	}
 

--- a/code/go/0chain.net/sharder/sharder/main.go
+++ b/code/go/0chain.net/sharder/sharder/main.go
@@ -207,14 +207,6 @@ func main() {
 		Logger.Panic("node not configured as sharder")
 	}
 
-	// start sharding from the LFB stored
-	if err = sc.LoadLatestBlocksFromStore(common.GetRootContext()); err != nil {
-		Logger.Error("load latest blocks from store: " + err.Error())
-		return
-	}
-
-	startBlocksInfoLogs(sc)
-
 	mode := "main net"
 	if config.Development() {
 		mode = "development"
@@ -259,6 +251,14 @@ func main() {
 	common.ConfigRateLimits()
 	initN2NHandlers()
 	initWorkers(ctx)
+
+	// start sharding from the LFB stored
+	if err = sc.LoadLatestBlocksFromStore(common.GetRootContext()); err != nil {
+		Logger.Error("load latest blocks from store: " + err.Error())
+		return
+	}
+
+	startBlocksInfoLogs(sc)
 
 	if err := sc.UpdateLatesMagicBlockFromSharders(ctx); err != nil {
 		Logger.Fatal("update LFMB from sharders", zap.Error(err))


### PR DESCRIPTION
Fixes:
- It is not thread safe to assign value to variables defined outside of the `handler` callback function as the `handler` will be called concurrently. Instead, we should pass the value to the variable through a channel or protect it with locks.
- Sharders repeatedly saving transaction summaries of the whole chain to persistent storage. See details here: https://github.com/0chain/0chain/commit/5e86c06bf5bc49590c5c7f3d2f24a330cb03f30d