### PR TITLE
Add endpoint for direct mpt access

### DIFF
--- a/code/go/0chain.net/chaincore/smartcontract/handler_test.go
+++ b/code/go/0chain.net/chaincore/smartcontract/handler_test.go
@@ -206,7 +206,7 @@ func TestGetSmartContract(t *testing.T) {
 		{
 			name:       "storage",
 			address:    storagesc.ADDRESS,
-			restpoints: 16,
+			restpoints: 17,
 		},
 		{
 			name:       "zrc20",

--- a/code/go/0chain.net/smartcontract/storagesc/config.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config.go
@@ -156,6 +156,9 @@ type scConfig struct {
 	MaxCharge float64 `json:"max_charge"`
 
 	BlockReward *blockReward `json:"block_reward"`
+
+	// Allow direct access to MPT
+	ExposeMpt bool `json:"expose_mpt"`
 }
 
 func (sc *scConfig) validate() (err error) {
@@ -445,6 +448,7 @@ func getConfiguredConfig() (conf *scConfig, err error) {
 		scc.GetFloat64(pfx+"block_reward.blobber_capacity_ratio"),
 		scc.GetFloat64(pfx+"block_reward.blobber_usage_ratio"),
 	)
+	conf.ExposeMpt = scc.GetBool(pfx + "expose_mpt")
 
 	err = conf.validate()
 	return

--- a/code/go/0chain.net/smartcontract/storagesc/expose_mpt.go
+++ b/code/go/0chain.net/smartcontract/storagesc/expose_mpt.go
@@ -1,0 +1,32 @@
+package storagesc
+
+import (
+	"0chain.net/chaincore/chain/state"
+	"0chain.net/core/common"
+	"context"
+	"net/url"
+)
+
+func (ssc *StorageSmartContract) GetMptKey(
+	_ context.Context,
+	params url.Values,
+	balances state.StateContextI,
+) (interface{}, error) {
+	var err error
+	var conf *scConfig
+	if conf, err = ssc.getConfig(balances, false); err != nil {
+		return nil, common.NewError("get_mpt_key",
+			"can't get SC configurations: "+err.Error())
+	}
+	if !conf.ExposeMpt {
+		return nil, common.NewError("get_mpt_key",
+			"exposed mpt not enabled")
+	}
+
+	var key = params.Get("key")
+	val, err := balances.GetTrieNode(stakePoolKey(ssc.ID, key))
+	if err != nil {
+		return nil, err
+	}
+	return string(val.Encode()), nil
+}

--- a/code/go/0chain.net/smartcontract/storagesc/expose_mpt.go
+++ b/code/go/0chain.net/smartcontract/storagesc/expose_mpt.go
@@ -24,7 +24,7 @@ func (ssc *StorageSmartContract) GetMptKey(
 	}
 
 	var key = params.Get("key")
-	val, err := balances.GetTrieNode(stakePoolKey(ssc.ID, key))
+	val, err := balances.GetTrieNode(key)
 	if err != nil {
 		return nil, err
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/expose_mpt.go
+++ b/code/go/0chain.net/smartcontract/storagesc/expose_mpt.go
@@ -26,7 +26,8 @@ func (ssc *StorageSmartContract) GetMptKey(
 	var key = params.Get("key")
 	val, err := balances.GetTrieNode(key)
 	if err != nil {
-		return nil, err
+		return nil, common.NewErrorf("get_mpt_key",
+			"get trie node %s failed: %v", key, err)
 	}
 	return string(val.Encode()), nil
 }

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -46,6 +46,7 @@ func (ipsc *StorageSmartContract) GetExecutionStats() map[string]interface{} {
 
 func (ssc *StorageSmartContract) setSC(sc *sci.SmartContract, bcContext sci.BCContextI) {
 	ssc.SmartContract = sc
+	ssc.SmartContract.RestHandlers["/get_mpt_key"] = ssc.GetMptKey
 	// sc configurations
 	ssc.SmartContract.RestHandlers["/getConfig"] = ssc.getConfigHandler
 	ssc.SmartContractExecutionStats["update_config"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", ssc.ID, "update_config"), nil)

--- a/config/sc.yaml
+++ b/config/sc.yaml
@@ -101,6 +101,7 @@ smart_contracts:
       miner_ratio: 20
       blobber_capacity_ratio: 20
       blobber_usage_ratio: 80
+    expose_mpt: true
   vestingsc:
     min_lock: 0.01
     min_duration: '2m'


### PR DESCRIPTION
This allows inspecting MPT keys directly from  GUI. Needs `expose_mpt` set to true.

Not sure where to put this, it's in storagesc for the moment.