### PR TITLE
Fix sharder panic on start

### DIFF
--- a/code/go/0chain.net/sharder/sharder/main.go
+++ b/code/go/0chain.net/sharder/sharder/main.go
@@ -207,14 +207,6 @@ func main() {
 		Logger.Panic("node not configured as sharder")
 	}
 
-	// start sharding from the LFB stored
-	if err = sc.LoadLatestBlocksFromStore(common.GetRootContext()); err != nil {
-		Logger.Error("load latest blocks from store: " + err.Error())
-		return
-	}
-
-	startBlocksInfoLogs(sc)
-
 	mode := "main net"
 	if config.Development() {
 		mode = "development"
@@ -259,6 +251,14 @@ func main() {
 	common.ConfigRateLimits()
 	initN2NHandlers()
 	initWorkers(ctx)
+
+	// start sharding from the LFB stored
+	if err = sc.LoadLatestBlocksFromStore(common.GetRootContext()); err != nil {
+		Logger.Error("load latest blocks from store: " + err.Error())
+		return
+	}
+
+	startBlocksInfoLogs(sc)
 
 	if err := sc.UpdateLatesMagicBlockFromSharders(ctx); err != nil {
 		Logger.Fatal("update LFMB from sharders", zap.Error(err))


### PR DESCRIPTION
Fix issue reported in https://0chain.slack.com/archives/C01V27E2Z9N/p1627278798076400.

Sharders would panic on start if they try to load Latest finalized block from others before running the `initN2NHandlers()`.