### PR TITLE
Change storagesc owner

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	owner   = "c8a5e74c2f4fae2c1bed79fb2b78d3b88f844bbb6bf1db5fc43240711f23321f"
+	owner   = "1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802"
 	ADDRESS = "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7"
 	name    = "storage"
 


### PR DESCRIPTION
For testing free storage change storagesc.owner so we know the private key. After testing it will need to be changed back.

<details>
  <summary>storagesc keys </summary>

```json
{
   "client_id":"1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802",
   "client_key":"7b630ba670dac2f22d43c2399b70eff378689a53ee03ea20957bb7e73df016200fea410ba5102558b0c39617e5afd2c1843b161a1dedec15e1ab40543a78a518",
   "keys":[
      {
         "public_key":"7b630ba670dac2f22d43c2399b70eff378689a53ee03ea20957bb7e73df016200fea410ba5102558b0c39617e5afd2c1843b161a1dedec15e1ab40543a78a518",
         "private_key":"c06b6f6945ba02d5a3be86b8779deca63bb636ce7e46804a479c50e53c864915"
      }
   ],
   "mnemonics":"cactus panther essence ability copper fox wise actual need cousin boat uncover ride diamond group jacket anchor current float rely tragic omit child payment",
   "version":"1.0",
   "date_created":"2021-08-04 18:53:56.949069945 +0100 BST m=+0.018986002"
}
```

</details>