### PR TITLE
PR274: Split minersc update settings for miner and sharder

### DIFF
--- a/code/go/0chain.net/smartcontract/minersc/miner.go
+++ b/code/go/0chain.net/smartcontract/minersc/miner.go
@@ -161,40 +161,40 @@ func (msc *MinerSmartContract) UpdateMinerSettings(t *transaction.Transaction,
 
 	var update = NewMinerNode()
 	if err = update.Decode(inputData); err != nil {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_miner_settings",
 			"decoding request: %v", err)
 	}
 
 	if update.ServiceCharge < 0 {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_sharder_settings",
 			"invalid negative service charge: %v", update.ServiceCharge)
 	}
 
 	if update.ServiceCharge > gn.MaxCharge {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_miner_settings",
 			"max_charge is greater than allowed by SC: %v > %v",
 			update.ServiceCharge, gn.MaxCharge)
 	}
 
 	if update.NumberOfDelegates < 0 {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_miner_settings",
 			"invalid negative number_of_delegates: %v", update.ServiceCharge)
 	}
 
 	if update.NumberOfDelegates > gn.MaxDelegates {
-		return "", common.NewErrorf("add_miner",
+		return "", common.NewErrorf("update_miner_settings",
 			"number_of_delegates greater than max_delegates of SC: %v > %v",
 			update.ServiceCharge, gn.MaxDelegates)
 	}
 
 	if update.MinStake < gn.MinStake {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_miner_settings",
 			"min_stake is less than allowed by SC: %v > %v",
 			update.MinStake, gn.MinStake)
 	}
 
 	if update.MaxStake < gn.MaxStake {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_miner_settings",
 			"max_stake is greater than allowed by SC: %v > %v",
 			update.MaxStake, gn.MaxStake)
 	}
@@ -202,11 +202,11 @@ func (msc *MinerSmartContract) UpdateMinerSettings(t *transaction.Transaction,
 	var mn *MinerNode
 	mn, err = getMinerNode(update.ID, balances)
 	if err != nil {
-		return "", common.NewError("update_settings", err.Error())
+		return "", common.NewError("update_miner_settings", err.Error())
 	}
 
 	if mn.DelegateWallet != t.ClientID {
-		return "", common.NewError("update_setings", "access denied")
+		return "", common.NewError("update_miner_settings", "access denied")
 	}
 
 	mn.ServiceCharge = update.ServiceCharge
@@ -215,7 +215,7 @@ func (msc *MinerSmartContract) UpdateMinerSettings(t *transaction.Transaction,
 	mn.MaxStake = update.MaxStake
 
 	if err = mn.save(balances); err != nil {
-		return "", common.NewErrorf("update_setings", "saving: %v", err)
+		return "", common.NewErrorf("update_miner_settings", "saving: %v", err)
 	}
 
 	return string(mn.Encode()), nil

--- a/code/go/0chain.net/smartcontract/minersc/miner.go
+++ b/code/go/0chain.net/smartcontract/minersc/miner.go
@@ -155,7 +155,7 @@ func (msc *MinerSmartContract) AddMiner(t *transaction.Transaction,
 	return string(newMiner.Encode()), nil
 }
 
-func (msc *MinerSmartContract) UpdateSettings(t *transaction.Transaction,
+func (msc *MinerSmartContract) UpdateMinerSettings(t *transaction.Transaction,
 	inputData []byte, gn *GlobalNode, balances cstate.StateContextI) (
 	resp string, err error) {
 

--- a/code/go/0chain.net/smartcontract/minersc/minersc.go
+++ b/code/go/0chain.net/smartcontract/minersc/minersc.go
@@ -45,7 +45,8 @@ func (msc *MinerSmartContract) InitSmartContractFunctions() {
 	msc.smartContractFunctions["shareSignsOrShares"] = msc.shareSignsOrShares
 	msc.smartContractFunctions["wait"] = msc.wait
 
-	msc.smartContractFunctions["update_settings"] = msc.UpdateSettings
+	msc.smartContractFunctions["update_miner_settings"] = msc.UpdateMinerSettings
+	msc.smartContractFunctions["update_sharder_settings"] = msc.UpdateSharderSettings
 
 	msc.smartContractFunctions["addToDelegatePool"] = msc.addToDelegatePool
 	msc.smartContractFunctions["deleteFromDelegatePool"] = msc.deleteFromDelegatePool

--- a/code/go/0chain.net/smartcontract/minersc/sharder.go
+++ b/code/go/0chain.net/smartcontract/minersc/sharder.go
@@ -19,40 +19,40 @@ func (msc *MinerSmartContract) UpdateSharderSettings(t *transaction.Transaction,
 
 	var update = NewMinerNode()
 	if err = update.Decode(inputData); err != nil {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_sharder_settings",
 			"decoding request: %v", err)
 	}
 
 	if update.ServiceCharge < 0 {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_sharder_settings",
 			"invalid negative service charge: %v", update.ServiceCharge)
 	}
 
 	if update.ServiceCharge > gn.MaxCharge {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_sharder_settings",
 			"max_charge is greater than allowed by SC: %v > %v",
 			update.ServiceCharge, gn.MaxCharge)
 	}
 
 	if update.NumberOfDelegates < 0 {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_sharder_settings",
 			"invalid negative number_of_delegates: %v", update.ServiceCharge)
 	}
 
 	if update.NumberOfDelegates > gn.MaxDelegates {
-		return "", common.NewErrorf("add_miner_failed",
+		return "", common.NewErrorf("update_sharder_settings",
 			"number_of_delegates greater than max_delegates of SC: %v > %v",
 			update.ServiceCharge, gn.MaxDelegates)
 	}
 
 	if update.MinStake < gn.MinStake {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_sharder_settings",
 			"min_stake is less than allowed by SC: %v > %v",
 			update.MinStake, gn.MinStake)
 	}
 
 	if update.MaxStake < gn.MaxStake {
-		return "", common.NewErrorf("update_settings",
+		return "", common.NewErrorf("update_sharder_settings",
 			"max_stake is greater than allowed by SC: %v > %v",
 			update.MaxStake, gn.MaxStake)
 	}
@@ -60,11 +60,11 @@ func (msc *MinerSmartContract) UpdateSharderSettings(t *transaction.Transaction,
 	var sn *MinerNode
 	sn, err = msc.getSharderNode(update.ID, balances)
 	if err != nil {
-		return "", common.NewError("update_settings", err.Error())
+		return "", common.NewError("update_sharder_settings", err.Error())
 	}
 
 	if sn.DelegateWallet != t.ClientID {
-		return "", common.NewError("update_setings", "access denied")
+		return "", common.NewError("update_sharder_settings", "access denied")
 	}
 
 	sn.ServiceCharge = update.ServiceCharge
@@ -73,7 +73,7 @@ func (msc *MinerSmartContract) UpdateSharderSettings(t *transaction.Transaction,
 	sn.MaxStake = update.MaxStake
 
 	if err = sn.save(balances); err != nil {
-		return "", common.NewErrorf("update_setings", "saving: %v", err)
+		return "", common.NewErrorf("update_sharder_settings", "saving: %v", err)
 	}
 
 	return string(sn.Encode()), nil


### PR DESCRIPTION
The minerc endpoint `update_settings` replaced with two endpoints `update_miner_settings` and `update_sharder_settings`.

This separates out a self-contained part of https://github.com/0chain/0chain/pull/274

Needed for https://github.com/0chain/gosdk/pull/213 and https://github.com/0chain/zwalletcli/pull/38.