### PR TITLE
faucetsc update config

### DIFF
--- a/code/go/0chain.net/smartcontract/config.go
+++ b/code/go/0chain.net/smartcontract/config.go
@@ -1,0 +1,75 @@
+package smartcontract
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"0chain.net/chaincore/state"
+)
+
+type ConfigType int
+
+const (
+	Int ConfigType = iota
+	Int64
+	Int32
+	Duration
+	Float64
+	Boolean
+	String
+	StateBalance
+	NumberOfTypes
+)
+
+var ConfigTypeName = []string{
+	"int", "int64", "int32", "time.duration", "float64", "bool", "string", "state.Balance",
+}
+
+type StringMap struct {
+	Fields map[string]string `json:"fields"`
+}
+
+func (im *StringMap) Decode(input []byte) error {
+	err := json.Unmarshal(input, im)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (im *StringMap) Encode() []byte {
+	buff, _ := json.Marshal(im)
+	return buff
+}
+
+func InterfaceMapToStringMap(in map[string]interface{}) map[string]string {
+	out := make(map[string]string)
+	for key, value := range in {
+		out[key] = fmt.Sprintf("%v", value)
+	}
+	return out
+}
+
+func StringToInterface(input string, iType ConfigType) (interface{}, error) {
+	switch iType {
+	case Int:
+		return strconv.Atoi(input)
+	case Int64:
+		return strconv.ParseInt(input, 10, 64)
+	case Int32:
+		return strconv.ParseInt(input, 10, 32)
+	case Duration:
+		return time.ParseDuration(input)
+	case Boolean:
+		return strconv.ParseBool(input)
+	case String:
+		return input, nil
+	case StateBalance:
+		value, err := strconv.ParseInt(input, 10, 64)
+		return state.Balance(value), err
+	default:
+		panic("unsupported type")
+	}
+}

--- a/code/go/0chain.net/smartcontract/faucetsc/config.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/config.go
@@ -1,7 +1,6 @@
 package faucetsc
 
 import (
-	"encoding/json"
 	"time"
 
 	"0chain.net/chaincore/config"
@@ -30,34 +29,22 @@ var (
 	}
 )
 
-type inputMap struct {
-	Fields map[string]interface{} `json:"fields"`
-}
-
-func (im *inputMap) Decode(input []byte) error {
-	err := json.Unmarshal(input, im)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 type FaucetConfig struct {
 	PourAmount      state.Balance `json:"pour_amount"`
 	MaxPourAmount   state.Balance `json:"max_pour_amount"`
 	PeriodicLimit   state.Balance `json:"periodic_limit"`
 	GlobalLimit     state.Balance `json:"global_limit"`
-	IndividualReset time.Duration `json:"individual_reset"` //in hours
-	GlobalReset     time.Duration `json:"global_rest"`      //in hours
+	IndividualReset time.Duration `json:"individual_reset"`
+	GlobalReset     time.Duration `json:"global_rest"`
 }
 
 // configurations from sc.yaml
 func getConfig() (conf *FaucetConfig) {
 	conf = new(FaucetConfig)
-	conf.PourAmount = state.Balance(config.SmartContractConfig.GetInt("smart_contracts.faucetsc.pour_amount"))
-	conf.MaxPourAmount = state.Balance(config.SmartContractConfig.GetInt("smart_contracts.faucetsc.max_pour_amount"))
-	conf.PeriodicLimit = state.Balance(config.SmartContractConfig.GetInt("smart_contracts.faucetsc.periodic_limit"))
-	conf.GlobalLimit = state.Balance(config.SmartContractConfig.GetInt("smart_contracts.faucetsc.global_limit"))
+	conf.PourAmount = state.Balance(config.SmartContractConfig.GetFloat64("smart_contracts.faucetsc.pour_amount") * 1e10)
+	conf.MaxPourAmount = state.Balance(config.SmartContractConfig.GetFloat64("smart_contracts.faucetsc.max_pour_amount") * 1e10)
+	conf.PeriodicLimit = state.Balance(config.SmartContractConfig.GetFloat64("smart_contracts.faucetsc.periodic_limit") * 1e10)
+	conf.GlobalLimit = state.Balance(config.SmartContractConfig.GetFloat64("smart_contracts.faucetsc.global_limit") * 1e10)
 	conf.IndividualReset = config.SmartContractConfig.GetDuration("smart_contracts.faucetsc.individual_reset")
 	conf.GlobalReset = config.SmartContractConfig.GetDuration("smart_contracts.faucetsc.global_reset")
 	return

--- a/code/go/0chain.net/smartcontract/faucetsc/config.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/config.go
@@ -1,12 +1,8 @@
 package faucetsc
 
 import (
-	"0chain.net/core/common"
-	"context"
-	"net/url"
 	"time"
 
-	chainstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/config"
 	"0chain.net/chaincore/state"
 )
@@ -21,7 +17,7 @@ type faucetConfig struct {
 }
 
 // configurations from sc.yaml
-func getConfig() (conf *faucetConfig, err error) {
+func getConfig() (conf *faucetConfig) {
 	conf = new(faucetConfig)
 	conf.PourAmount = state.Balance(config.SmartContractConfig.GetInt("smart_contracts.faucetsc.pour_amount"))
 	conf.MaxPourAmount = state.Balance(config.SmartContractConfig.GetInt("smart_contracts.faucetsc.max_pour_amount"))
@@ -30,19 +26,4 @@ func getConfig() (conf *faucetConfig, err error) {
 	conf.IndividualReset = config.SmartContractConfig.GetDuration("smart_contracts.faucetsc.individual_reset")
 	conf.GlobalReset = config.SmartContractConfig.GetDuration("smart_contracts.faucetsc.global_reset")
 	return
-}
-
-//
-// REST-handler
-//
-
-const cantGetConfig = "can't get config"
-
-func (fc *FaucetSmartContract) getConfigHandler(context.Context,
-	url.Values, chainstate.StateContextI) (interface{}, error) {
-	res, err := getConfig()
-	if err != nil {
-		return nil, common.NewErrNoResource(cantGetConfig, err.Error())
-	}
-	return res, nil
 }

--- a/code/go/0chain.net/smartcontract/faucetsc/config.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/config.go
@@ -1,13 +1,48 @@
 package faucetsc
 
 import (
+	"encoding/json"
 	"time"
 
 	"0chain.net/chaincore/config"
 	"0chain.net/chaincore/state"
 )
 
-type faucetConfig struct {
+type Setting int
+
+const (
+	PourAmount Setting = iota
+	MaxPourAmount
+	PeriodicLimit
+	GlobalLimit
+	IndividualReset
+	GlobalReset
+)
+
+var (
+	Settings = []string{
+		"pour_amount",
+		"max_pour_amount",
+		"periodic_limit",
+		"global_limit",
+		"individual_reset",
+		"global_rest",
+	}
+)
+
+type inputMap struct {
+	Fields map[string]interface{} `json:"fields"`
+}
+
+func (im *inputMap) Decode(input []byte) error {
+	err := json.Unmarshal(input, im)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type FaucetConfig struct {
 	PourAmount      state.Balance `json:"pour_amount"`
 	MaxPourAmount   state.Balance `json:"max_pour_amount"`
 	PeriodicLimit   state.Balance `json:"periodic_limit"`
@@ -17,8 +52,8 @@ type faucetConfig struct {
 }
 
 // configurations from sc.yaml
-func getConfig() (conf *faucetConfig) {
-	conf = new(faucetConfig)
+func getConfig() (conf *FaucetConfig) {
+	conf = new(FaucetConfig)
 	conf.PourAmount = state.Balance(config.SmartContractConfig.GetInt("smart_contracts.faucetsc.pour_amount"))
 	conf.MaxPourAmount = state.Balance(config.SmartContractConfig.GetInt("smart_contracts.faucetsc.max_pour_amount"))
 	conf.PeriodicLimit = state.Balance(config.SmartContractConfig.GetInt("smart_contracts.faucetsc.periodic_limit"))

--- a/code/go/0chain.net/smartcontract/faucetsc/handler.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/handler.go
@@ -74,22 +74,25 @@ func (fc *FaucetSmartContract) getConfigHandler(
 	balances c_state.StateContextI,
 ) (interface{}, error) {
 	gn, err := fc.getGlobalNode(balances)
-
 	if err != nil && err != util.ErrValueNotPresent {
 		return nil, common.NewError("get config handler", err.Error())
 	}
-	if gn.FaucetConfig == nil {
-		gn.FaucetConfig = getConfig()
+
+	var faucetConfig *FaucetConfig
+	if gn == nil || gn.FaucetConfig == nil {
+		faucetConfig = getConfig()
+	} else {
+		faucetConfig = gn.FaucetConfig
 	}
 
-	return inputMap{
-		Fields: map[string]interface{}{
-			Settings[PourAmount]:      gn.FaucetConfig.PourAmount,
-			Settings[MaxPourAmount]:   gn.FaucetConfig.MaxPourAmount,
-			Settings[PeriodicLimit]:   gn.FaucetConfig.PeriodicLimit,
-			Settings[GlobalLimit]:     gn.FaucetConfig.GlobalLimit,
-			Settings[IndividualReset]: gn.FaucetConfig.IndividualReset,
-			Settings[GlobalReset]:     gn.FaucetConfig.GlobalReset,
+	return smartcontract.StringMap{
+		Fields: map[string]string{
+			Settings[PourAmount]:      fmt.Sprintf("%v", float64(faucetConfig.PourAmount)/1e10),
+			Settings[MaxPourAmount]:   fmt.Sprintf("%v", float64(faucetConfig.MaxPourAmount)/1e10),
+			Settings[PeriodicLimit]:   fmt.Sprintf("%v", float64(faucetConfig.PeriodicLimit)/1e10),
+			Settings[GlobalLimit]:     fmt.Sprintf("%v", float64(faucetConfig.GlobalLimit)/1e10),
+			Settings[IndividualReset]: fmt.Sprintf("%v", faucetConfig.IndividualReset),
+			Settings[GlobalReset]:     fmt.Sprintf("%v", faucetConfig.GlobalReset),
 		},
 	}, nil
 }

--- a/code/go/0chain.net/smartcontract/faucetsc/handler.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/handler.go
@@ -1,10 +1,15 @@
 package faucetsc
 
 import (
-	"0chain.net/smartcontract"
 	"context"
 	"fmt"
 	"time"
+
+	"0chain.net/core/common"
+	"0chain.net/core/util"
+
+	"0chain.net/smartcontract"
+
 	// "encoding/json"
 	"net/url"
 
@@ -61,4 +66,19 @@ func (fc *FaucetSmartContract) pourAmount(ctx context.Context, params url.Values
 		return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, "can't get pour amount", noGlobalNodeMsg)
 	}
 	return fmt.Sprintf("Pour amount per request: %v", gn.PourAmount), nil
+}
+
+func (fc *FaucetSmartContract) getConfigHandler(
+	_ context.Context,
+	_ url.Values,
+	balances c_state.StateContextI,
+) (interface{}, error) {
+	gn, err := fc.getGlobalNode(balances)
+	if err != nil && err != util.ErrValueNotPresent {
+		return nil, common.NewError("get config handler", err.Error())
+	}
+	if gn.faucetConfig == nil {
+		return getConfig(), nil
+	}
+	return gn.faucetConfig, nil
 }

--- a/code/go/0chain.net/smartcontract/faucetsc/handler.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/handler.go
@@ -74,11 +74,22 @@ func (fc *FaucetSmartContract) getConfigHandler(
 	balances c_state.StateContextI,
 ) (interface{}, error) {
 	gn, err := fc.getGlobalNode(balances)
+
 	if err != nil && err != util.ErrValueNotPresent {
 		return nil, common.NewError("get config handler", err.Error())
 	}
-	if gn.faucetConfig == nil {
-		return getConfig(), nil
+	if gn.FaucetConfig == nil {
+		gn.FaucetConfig = getConfig()
 	}
-	return gn.faucetConfig, nil
+
+	return inputMap{
+		Fields: map[string]interface{}{
+			Settings[PourAmount]:      gn.FaucetConfig.PourAmount,
+			Settings[MaxPourAmount]:   gn.FaucetConfig.MaxPourAmount,
+			Settings[PeriodicLimit]:   gn.FaucetConfig.PeriodicLimit,
+			Settings[GlobalLimit]:     gn.FaucetConfig.GlobalLimit,
+			Settings[IndividualReset]: gn.FaucetConfig.IndividualReset,
+			Settings[GlobalReset]:     gn.FaucetConfig.GlobalReset,
+		},
+	}, nil
 }

--- a/code/go/0chain.net/smartcontract/faucetsc/models.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/models.go
@@ -13,25 +13,6 @@ import (
 	"0chain.net/core/util"
 )
 
-type limitRequest struct {
-	PourAmount      state.Balance `json:"pour_amount"`
-	MaxPourAmount   state.Balance `json:"max_pour_amount"`
-	PeriodicLimit   state.Balance `json:"periodic_limit"`
-	GlobalLimit     state.Balance `json:"global_limit"`
-	IndividualReset time.Duration `json:"individual_reset"` //in hours
-	GlobalReset     time.Duration `json:"global_rest"`      //in hours
-}
-
-func (lr *limitRequest) encode() []byte {
-	buff, _ := json.Marshal(lr)
-	return buff
-}
-
-func (lr *limitRequest) decode(input []byte) error {
-	err := json.Unmarshal(input, lr)
-	return err
-}
-
 type periodicResponse struct {
 	Used    state.Balance `json:"tokens_poured"`
 	Start   time.Time     `json:"start_time"`
@@ -50,7 +31,7 @@ func (pr *periodicResponse) decode(input []byte) error {
 }
 
 type GlobalNode struct {
-	*faucetConfig `json:"faucet_config"`
+	*FaucetConfig `json:"faucet_config"`
 	ID            string        `json:"id"`
 	Used          state.Balance `json:"used"`
 	StartTime     time.Time     `json:"start_time"`

--- a/code/go/0chain.net/smartcontract/faucetsc/models.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/models.go
@@ -1,10 +1,11 @@
 package faucetsc
 
 import (
-	"0chain.net/core/common"
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"0chain.net/core/common"
 
 	"0chain.net/chaincore/state"
 	"0chain.net/core/datastore"
@@ -49,15 +50,10 @@ func (pr *periodicResponse) decode(input []byte) error {
 }
 
 type GlobalNode struct {
-	ID              string        `json:"id"`
-	PourAmount      state.Balance `json:"pour_amount"`
-	MaxPourAmount   state.Balance `json:"max_pour_amount"`
-	PeriodicLimit   state.Balance `json:"periodic_limit"`
-	GlobalLimit     state.Balance `json:"global_limit"`
-	IndividualReset time.Duration `json:"individual_reset"` //in hours
-	GlobalReset     time.Duration `json:"global_rest"`      //in hours
-	Used            state.Balance `json:"used"`
-	StartTime       time.Time     `json:"start_time"`
+	*faucetConfig `json:"faucet_config"`
+	ID            string        `json:"id"`
+	Used          state.Balance `json:"used"`
+	StartTime     time.Time     `json:"start_time"`
 }
 
 func (gn *GlobalNode) GetKey() datastore.Key {

--- a/code/go/0chain.net/smartcontract/faucetsc/models.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/models.go
@@ -1,7 +1,9 @@
 package faucetsc
 
 import (
+	"0chain.net/core/common"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"0chain.net/chaincore/state"
@@ -78,6 +80,24 @@ func (gn *GlobalNode) Encode() []byte {
 func (gn *GlobalNode) Decode(input []byte) error {
 	err := json.Unmarshal(input, gn)
 	return err
+}
+
+func (gn *GlobalNode) validate() error {
+	switch {
+	case gn.PourAmount < 1:
+		return common.NewError("failed to validate global node", fmt.Sprintf("pour amount(%v) is less than 1", gn.PourAmount))
+	case gn.PourAmount > gn.MaxPourAmount:
+		return common.NewError("failed to validate global node", fmt.Sprintf("max pour amount(%v) is less than pour amount(%v)", gn.MaxPourAmount, gn.PourAmount))
+	case gn.MaxPourAmount > gn.PeriodicLimit:
+		return common.NewError("failed to validate global node", fmt.Sprintf("periodic limit(%v) is less than max pour amount(%v)", gn.PeriodicLimit, gn.MaxPourAmount))
+	case gn.PeriodicLimit > gn.GlobalLimit:
+		return common.NewError("failed to validate global node", fmt.Sprintf("global periodic limit(%v) is less than periodic limit(%v)", gn.GlobalLimit, gn.PeriodicLimit))
+	case toSeconds(gn.IndividualReset) < 1:
+		return common.NewError("failed to validate global node", fmt.Sprintf("individual reset(%v) is too short", gn.IndividualReset))
+	case gn.GlobalReset < gn.IndividualReset:
+		return common.NewError("failed to validate global node", fmt.Sprintf("global reset(%v) is less than individual reset(%v)", gn.GlobalReset, gn.IndividualReset))
+	}
+	return nil
 }
 
 type UserNode struct {

--- a/code/go/0chain.net/smartcontract/faucetsc/models.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/models.go
@@ -3,6 +3,7 @@ package faucetsc
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"0chain.net/core/common"
@@ -57,6 +58,51 @@ func (gn *GlobalNode) Encode() []byte {
 func (gn *GlobalNode) Decode(input []byte) error {
 	err := json.Unmarshal(input, gn)
 	return err
+}
+
+func (gn *GlobalNode) updateConfig(fields map[string]string) error {
+	var err error
+	for key, value := range fields {
+		switch key {
+		case Settings[PourAmount]:
+			fAmount, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return fmt.Errorf("key %s, unable to convert %v to state.balance", key, value)
+			}
+			gn.PourAmount = state.Balance(fAmount * 1e10)
+		case Settings[MaxPourAmount]:
+			fAmount, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return fmt.Errorf("key %s, unable to convert %v to state.balance", key, value)
+			}
+			gn.MaxPourAmount = state.Balance(fAmount * 1e10)
+		case Settings[PeriodicLimit]:
+			fAmount, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return fmt.Errorf("key %s, unable to convert %v to state.balance", key, value)
+			}
+			gn.PeriodicLimit = state.Balance(fAmount * 1e10)
+		case Settings[GlobalLimit]:
+			fAmount, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return fmt.Errorf("key %s, unable to convert %v to state.balance", key, value)
+			}
+			gn.GlobalLimit = state.Balance(fAmount * 1e10)
+		case Settings[IndividualReset]:
+			gn.IndividualReset, err = time.ParseDuration(value)
+			if err != nil {
+				return fmt.Errorf("key %s, unable to convert %v to time.duration", key, value)
+			}
+		case Settings[GlobalReset]:
+			gn.GlobalReset, err = time.ParseDuration(value)
+			if err != nil {
+				return fmt.Errorf("key %s, unable to convert %v to time.duration", key, value)
+			}
+		default:
+			return fmt.Errorf("key %s not recognised as setting", key)
+		}
+	}
+	return nil
 }
 
 func (gn *GlobalNode) validate() error {

--- a/code/go/0chain.net/smartcontract/faucetsc/sc.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/sc.go
@@ -64,7 +64,7 @@ func (fc *FaucetSmartContract) setSC(sc *smartcontractinterface.SmartContract, _
 	fc.SmartContract.RestHandlers["/globalPerodicLimit"] = fc.globalPerodicLimit
 	fc.SmartContract.RestHandlers["/pourAmount"] = fc.pourAmount
 	fc.SmartContract.RestHandlers["/getConfig"] = fc.getConfigHandler
-	fc.SmartContractExecutionStats["update-settings"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", fc.ID, "faucetsc-update-settings"), nil)
+	fc.SmartContractExecutionStats["update-settings"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", fc.ID, "update-settings"), nil)
 	fc.SmartContractExecutionStats["pour"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", fc.ID, "pour"), nil)
 	fc.SmartContractExecutionStats["refill"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", fc.ID, "refill"), nil)
 	fc.SmartContractExecutionStats["tokens Poured"] = metrics.GetOrRegisterHistogram(fmt.Sprintf("sc:%v:func:%v", fc.ID, "tokens Poured"), nil, metrics.NewUniformSample(1024))

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
@@ -1,11 +1,12 @@
 package interestpoolsc
 
 import (
-	"0chain.net/chaincore/smartcontract"
 	"context"
 	"fmt"
 	"net/url"
 	"time"
+
+	"0chain.net/chaincore/smartcontract"
 
 	c_state "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/config"
@@ -220,6 +221,6 @@ func (ip *InterestPoolSmartContract) Execute(t *transaction.Transaction, funcNam
 	case "updateVariables":
 		return ip.updateVariables(t, gn, inputData, balances)
 	default:
-		return "", common.NewError("failed execution", "no function with that name")
+		return "", common.NewErrorf("failed execution", "no interest pool smart contract method with name %s", funcName)
 	}
 }

--- a/code/go/0chain.net/smartcontract/minersc/sc.go
+++ b/code/go/0chain.net/smartcontract/minersc/sc.go
@@ -1,13 +1,14 @@
 package minersc
 
 import (
-	"0chain.net/chaincore/smartcontract"
 	"context"
 	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
 	"sync"
+
+	"0chain.net/chaincore/smartcontract"
 
 	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/config"
@@ -143,7 +144,7 @@ func (msc *MinerSmartContract) Execute(t *transaction.Transaction,
 	}
 	scFunc, found := msc.smartContractFunctions[funcName]
 	if !found {
-		return common.NewError("failed execution", "no function with that name").Error(), nil
+		return common.NewErrorf("failed execution", "no miner smart contract method with name", funcName).Error(), nil
 	}
 	return scFunc(t, input, gn, balances)
 }

--- a/code/go/0chain.net/smartcontract/multisigsc/sc.go
+++ b/code/go/0chain.net/smartcontract/multisigsc/sc.go
@@ -1,12 +1,13 @@
 package multisigsc
 
 import (
-	"0chain.net/chaincore/smartcontract"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"time"
+
+	"0chain.net/chaincore/smartcontract"
 
 	"0chain.net/chaincore/chain/state"
 	c_state "0chain.net/chaincore/chain/state"
@@ -74,7 +75,7 @@ func (ms MultiSigSmartContract) Execute(t *transaction.Transaction, funcName str
 	case VoteFuncName:
 		return ms.vote(t.Hash, t.ClientID, balances.GetBlock().CreationDate, inputData, balances)
 	default:
-		return "err_execute_function_not_found: no function with that name: " + funcName, nil
+		return "err_execute_function_not_found: no multi sig smart contract function with that name: " + funcName, nil
 	}
 }
 

--- a/code/go/0chain.net/smartcontract/zrc20sc/sc.go
+++ b/code/go/0chain.net/smartcontract/zrc20sc/sc.go
@@ -1,10 +1,11 @@
 package zrc20sc
 
 import (
-	"0chain.net/chaincore/smartcontract"
 	"context"
 	"fmt"
 	"net/url"
+
+	"0chain.net/chaincore/smartcontract"
 
 	c_state "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/smartcontractinterface"
@@ -266,6 +267,6 @@ func (zrc *ZRC20SmartContract) Execute(t *transaction.Transaction, funcName stri
 	case "emptyPool":
 		return zrc.emptyPool(t, inputData, balances)
 	default:
-		return common.NewError("failed execution", "no function with that name").Error(), nil
+		return common.NewErrorf("failed execution", "no zrc20 smart contract method with name %s", funcName).Error(), nil
 	}
 }

--- a/config/sc.yaml
+++ b/config/sc.yaml
@@ -1,8 +1,9 @@
 smart_contracts:
-  faucetsc: 
-    pour_limit: 10000000000
-    periodic_limit: 1000000000000
-    global_limit: 100000000000000
+  faucetsc:
+    pour_amount: 1
+    max_pour_amount: 10
+    periodic_limit: 1000
+    global_limit: 100000
     individual_reset: 3h # in hours
     global_reset: 48h # in hours
   interestpoolsc:

--- a/docker.local/config/sc.yaml
+++ b/docker.local/config/sc.yaml
@@ -1,11 +1,11 @@
 smart_contracts:
   faucetsc:
-    pour_amount: 10000000000
-    max_pour_amount: 100000000000
-    periodic_limit: 10000000000000
-    global_limit: 1000000000000000
-    individual_reset: 3h # in hours
-    global_reset: 48h # in hours
+    pour_amount: 1
+    max_pour_amount: 10
+    periodic_limit: 1000
+    global_limit: 100000
+    individual_reset: 3h
+    global_reset: 48h
   interestpoolsc:
     min_lock: 10
     apr: 0.1


### PR DESCRIPTION
This is part of https://github.com/0chain/0chain/pull/274.

- Renames the endpoint `update-limits` to `faucestsc-update-settings` to conform with similar changes to other smart contracts.
- Modify the validation for the `faucestsc-update-settings`  endoint.
- update change and get config endpoints to use map[string]string to communicate setting values.
- Change `sc.yaml.faucetsc` state.balance entries to zcn.

Required for https://github.com/0chain/gosdk/pull/215 and https://github.com/0chain/zwalletcli/pull/42