### PR TITLE
vestingsc update config

### DIFF
--- a/code/go/0chain.net/smartcontract/config.go
+++ b/code/go/0chain.net/smartcontract/config.go
@@ -1,0 +1,75 @@
+package smartcontract
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"0chain.net/chaincore/state"
+)
+
+type ConfigType int
+
+const (
+	Int ConfigType = iota
+	Int64
+	Int32
+	Duration
+	Float64
+	Boolean
+	String
+	StateBalance
+	NumberOfTypes
+)
+
+var ConfigTypeName = []string{
+	"int", "int64", "int32", "time.duration", "float64", "bool", "string", "state.Balance",
+}
+
+type StringMap struct {
+	Fields map[string]string `json:"fields"`
+}
+
+func (im *StringMap) Decode(input []byte) error {
+	err := json.Unmarshal(input, im)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (im *StringMap) Encode() []byte {
+	buff, _ := json.Marshal(im)
+	return buff
+}
+
+func InterfaceMapToStringMap(in map[string]interface{}) map[string]string {
+	out := make(map[string]string)
+	for key, value := range in {
+		out[key] = fmt.Sprintf("%v", value)
+	}
+	return out
+}
+
+func StringToInterface(input string, iType ConfigType) (interface{}, error) {
+	switch iType {
+	case Int:
+		return strconv.Atoi(input)
+	case Int64:
+		return strconv.ParseInt(input, 10, 64)
+	case Int32:
+		return strconv.ParseInt(input, 10, 32)
+	case Duration:
+		return time.ParseDuration(input)
+	case Boolean:
+		return strconv.ParseBool(input)
+	case String:
+		return input, nil
+	case StateBalance:
+		value, err := strconv.ParseInt(input, 10, 64)
+		return state.Balance(value), err
+	default:
+		panic("unsupported type")
+	}
+}

--- a/code/go/0chain.net/smartcontract/vestingsc/config.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/config.go
@@ -1,8 +1,12 @@
 package vestingsc
 
 import (
+	"0chain.net/chaincore/transaction"
 	"0chain.net/core/common"
+	"0chain.net/core/datastore"
+	"0chain.net/core/util"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/url"
 	"time"
@@ -11,6 +15,10 @@ import (
 	configpkg "0chain.net/chaincore/config"
 	"0chain.net/chaincore/state"
 )
+
+func scConfigKey(scKey string) datastore.Key {
+	return datastore.Key(scKey + ":configurations")
+}
 
 type config struct {
 	MinLock              state.Balance `json:"min_lock"`
@@ -36,12 +44,82 @@ func (c *config) validate() (err error) {
 	return
 }
 
+func (conf *config) Encode() (b []byte) {
+	var err error
+	if b, err = json.Marshal(conf); err != nil {
+		panic(err) // must not happens
+	}
+	return
+}
+
+func (conf *config) Decode(b []byte) error {
+	return json.Unmarshal(b, conf)
+}
+
+func (conf *config) update(newConf *config) {
+	if newConf.MinLock > 0 {
+		conf.MinLock = newConf.MinLock
+	}
+	if newConf.MinDuration > 0 {
+		conf.MinDuration = newConf.MinDuration
+	}
+	if newConf.MaxDuration > 0 {
+		conf.MaxDuration = newConf.MaxDuration
+	}
+	if newConf.MaxDestinations > 0 {
+		conf.MaxDestinations = newConf.MaxDestinations
+	}
+	if newConf.MaxDescriptionLength > 0 {
+		conf.MaxDescriptionLength = newConf.MaxDescriptionLength
+	}
+}
+
+func (vsc *VestingSmartContract) updateConfig(t *transaction.Transaction,
+	input []byte, balances chainstate.StateContextI,
+) (resp string, err error) {
+	if t.ClientID != owner {
+		return "", common.NewError("update_config",
+			"unauthorized access - only the owner can update the variables")
+	}
+
+	var conf *config
+	if conf, err = vsc.getConfig(balances); err != nil {
+		return "", common.NewError("update_config",
+			"can't get config: "+err.Error())
+	}
+
+	update := &config{}
+	if err = update.Decode(input); err != nil {
+		return "", common.NewError("update_config", err.Error())
+	}
+
+	conf.update(update)
+
+	_, err = balances.InsertTrieNode(scConfigKey(vsc.ID), conf)
+	if err != nil {
+		return "", common.NewError("update_config", err.Error())
+	}
+
+	return string(conf.Encode()), nil
+}
+
 //
 // helpers
 //
 
+func (vsc *VestingSmartContract) getConfigBytes(
+	balances chainstate.StateContextI,
+) (b []byte, err error) {
+	var val util.Serializable
+	val, err = balances.GetTrieNode(scConfigKey(vsc.ID))
+	if err != nil {
+		return
+	}
+	return val.Encode(), nil
+}
+
 // configurations from sc.yaml
-func getConfig() (conf *config, err error) {
+func getConfiguredConfig() (conf *config, err error) {
 
 	const prefix = "smart_contracts.vestingsc."
 
@@ -62,14 +140,50 @@ func getConfig() (conf *config, err error) {
 	return
 }
 
+func (vsc *VestingSmartContract) setupConfig(
+	balances chainstate.StateContextI,
+) (conf *config, err error) {
+	if conf, err = getConfiguredConfig(); err != nil {
+		return
+	}
+	_, err = balances.InsertTrieNode(scConfigKey(vsc.ID), conf)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+func (vsc *VestingSmartContract) getConfig(
+	balances chainstate.StateContextI,
+) (conf *config, err error) {
+	var confb []byte
+	confb, err = vsc.getConfigBytes(balances)
+	if err != nil && err != util.ErrValueNotPresent {
+		return
+	}
+
+	conf = new(config)
+
+	if err == util.ErrValueNotPresent {
+		return vsc.setupConfig(balances)
+	}
+
+	if err = conf.Decode(confb); err != nil {
+		return nil, err
+	}
+	return
+}
+
 //
 // REST-handler
 //
 
-func (vsc *VestingSmartContract) getConfigHandler(context.Context,
-	url.Values, chainstate.StateContextI) (interface{}, error) {
-
-	res, err := getConfig()
+func (vsc *VestingSmartContract) getConfigHandler(
+	ctx context.Context,
+	params url.Values,
+	balances chainstate.StateContextI,
+) (interface{}, error) {
+	res, err := vsc.getConfig(balances)
 	if err != nil {
 		return nil, common.NewErrInternal("can't get config", err.Error())
 	}

--- a/code/go/0chain.net/smartcontract/vestingsc/config_test.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/config_test.go
@@ -1,26 +1,24 @@
 package vestingsc
 
 import (
+	"0chain.net/chaincore/transaction"
+	"0chain.net/core/common"
 	"context"
 	"testing"
 	"time"
 
 	configpkg "0chain.net/chaincore/config"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func assertErrMsg(t *testing.T, err error, msg string) {
+func requireErrMsg(t *testing.T, err error, msg string) {
 	t.Helper()
-
 	if msg == "" {
-		assert.Nil(t, err)
-		return
-	}
-
-	if assert.NotNil(t, err) {
-		assert.Equal(t, msg, err.Error())
+		require.Nil(t, err)
+	} else {
+		require.NotNil(t, err)
+		require.Equal(t, msg, err.Error())
 	}
 }
 
@@ -50,7 +48,7 @@ func Test_config_validate(t *testing.T) {
 		// max_description_length
 		{config{1, s(1), s(2), 1, 0}, "invalid max_description_length (< 1)"},
 	} {
-		assertErrMsg(t, tt.config.validate(), tt.err)
+		requireErrMsg(t, tt.config.validate(), tt.err)
 	}
 }
 
@@ -72,11 +70,13 @@ func configureConfig() (configured *config) {
 
 func Test_getConfig(t *testing.T) {
 	var (
+		vsc        = newTestVestingSC()
+		balances   = newTestBalances()
 		configured = configureConfig()
-		conf, err  = getConfig()
+		conf, err  = vsc.getConfig(balances)
 	)
 	require.NoError(t, err)
-	assert.EqualValues(t, configured, conf)
+	require.EqualValues(t, configured, conf)
 }
 
 func TestVestingSmartContract_getConfigHandler(t *testing.T) {
@@ -89,5 +89,123 @@ func TestVestingSmartContract_getConfigHandler(t *testing.T) {
 		resp, err  = vsc.getConfigHandler(ctx, nil, balances)
 	)
 	require.NoError(t, err)
-	assert.EqualValues(t, configured, resp)
+	require.EqualValues(t, configured, resp)
+}
+
+func TestVestingSmartContractUpdate(t *testing.T) {
+
+	var (
+		vsc            = newTestVestingSC()
+		balances       = newTestBalances()
+		ownerTxn       = newTransaction(owner, vsc.ID, 0, common.Now())
+		nonOwnerTxn    = newTransaction(randString(32), vsc.ID, 0, common.Now())
+		originalConfig = configureConfig()
+		err            error
+		currentConfig  *config
+	)
+
+	//test cases that produce errors
+	errorTestCases := []struct {
+		title string
+		txn   *transaction.Transaction
+		bytes []byte
+		err   string
+	}{
+		{"malformed update", ownerTxn, []byte("} malformed {"), "update_config: invalid character '}' looking for beginning of value"},
+		{"non owner account", nonOwnerTxn, []byte("} malformed {"), "update_config: unauthorized access - only the owner can update the variables"},
+	}
+	for _, tc := range errorTestCases {
+		t.Run(tc.title, func(t *testing.T) {
+			balances.txn = tc.txn
+			_, err = vsc.updateConfig(tc.txn, tc.bytes, balances)
+			require.Error(t, err)
+			require.EqualError(t, err, tc.err)
+		})
+	}
+
+	//test cases that will be denied
+	deniedTestCases := []struct {
+		title       string
+		request     *config
+		requireFunc func(config, request *config)
+	}{
+		{"all variables denied",
+			&config{},
+			func(config, request *config) {
+				require.Equal(t, config, request)
+			},
+		},
+	}
+	for _, tc := range deniedTestCases {
+		t.Run(tc.title, func(t *testing.T) {
+			_, err = vsc.updateConfig(ownerTxn, tc.request.Encode(), balances)
+			require.NoError(t, err)
+			currentConfig, err = vsc.getConfig(balances)
+			require.NoError(t, err)
+			tc.requireFunc(currentConfig, originalConfig)
+		})
+	}
+
+	//test cases that will be updated
+	updateTestCases := []struct {
+		title       string
+		request     *config
+		requireFunc func(config, request *config)
+	}{
+		{
+			"min lock update",
+			&config{
+				MinLock: 987654321,
+			},
+			func(config, request *config) {
+				require.Equal(t, config.MinLock, request.MinLock)
+			},
+		},
+		{
+			"min duration update",
+			&config{
+				MinDuration: time.Hour * 10,
+			},
+			func(config, request *config) {
+				require.Equal(t, config.MinDuration, request.MinDuration)
+			},
+		},
+		{
+			"max duration update",
+			&config{
+				MaxDuration: time.Hour * 87600,
+			},
+			func(config, request *config) {
+				require.Equal(t, config.MaxDuration, request.MaxDuration)
+			},
+		},
+		{
+			"max destinations update",
+			&config{
+				MaxDestinations: 57,
+			},
+			func(config, request *config) {
+				require.Equal(t, config.MaxDestinations, request.MaxDestinations)
+			},
+		},
+		{
+			"max description length update",
+			&config{
+				MaxDescriptionLength: 32,
+			},
+			func(config, request *config) {
+				require.Equal(t, config.MaxDescriptionLength, request.MaxDescriptionLength)
+			},
+		},
+	}
+	for _, tc := range updateTestCases {
+		t.Run(tc.title, func(t *testing.T) {
+			balances.txn = ownerTxn
+			_, err = vsc.updateConfig(ownerTxn, tc.request.Encode(), balances)
+			require.NoError(t, err)
+			currentConfig, err = vsc.getConfig(balances)
+			require.NoError(t, err)
+			tc.requireFunc(currentConfig, tc.request)
+		})
+	}
 }

--- a/code/go/0chain.net/smartcontract/vestingsc/sc.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/sc.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	ADDRESS = "2bba5b05949ea59c80aed3ac3474d7379d3be737e8eb5a968c52295e48333ead"
+	owner   = "1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802"
 )
 
 type RestPoints = map[string]smartcontractinterface.SmartContractRestHandler
@@ -97,7 +98,8 @@ func (vsc *VestingSmartContract) Execute(t *transaction.Transaction,
 		resp, err = vsc.stop(t, input, balances)
 	case "delete":
 		resp, err = vsc.delete(t, input, balances)
-
+	case "vestingsc-update-settings":
+		resp, err = vsc.updateConfig(t, input, balances)
 	default:
 		err = common.NewError("vesting_sc_failed",
 			fmt.Sprintf("no function with %q name", function))

--- a/code/go/0chain.net/smartcontract/vestingsc/vesting.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/vesting.go
@@ -1,7 +1,6 @@
 package vestingsc
 
 import (
-	"0chain.net/smartcontract"
 	"context"
 	"encoding/json"
 	"errors"
@@ -9,6 +8,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"0chain.net/smartcontract"
 
 	chainstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/state"

--- a/code/go/0chain.net/smartcontract/vestingsc/vesting.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/vesting.go
@@ -557,7 +557,7 @@ func (vsc *VestingSmartContract) add(t *transaction.Transaction,
 	}
 
 	var conf *config
-	if conf, err = getConfig(); err != nil {
+	if conf, err = vsc.getConfig(balances); err != nil {
 		return "", common.NewError("create_vesting_pool_failed",
 			"can't get SC configurations: "+err.Error())
 	}

--- a/code/go/0chain.net/smartcontract/vestingsc/vesting_test.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/vesting_test.go
@@ -44,25 +44,25 @@ func Test_addRequest_validate(t *testing.T) {
 		ar   addRequest
 	)
 	ar.Description = "very very very long description"
-	assertErrMsg(t, ar.validate(10, conf), "entry description is too long")
+	requireErrMsg(t, ar.validate(10, conf), "entry description is too long")
 	ar.Description = "short desc."
 
 	ar.StartTime = 1
-	assertErrMsg(t, ar.validate(10, conf), "vesting starts before now")
+	requireErrMsg(t, ar.validate(10, conf), "vesting starts before now")
 	ar.StartTime = 20
 
-	assertErrMsg(t, ar.validate(10, conf), "vesting duration is too short")
+	requireErrMsg(t, ar.validate(10, conf), "vesting duration is too short")
 	ar.Duration = 20 * time.Hour
-	assertErrMsg(t, ar.validate(10, conf), "vesting duration is too long")
+	requireErrMsg(t, ar.validate(10, conf), "vesting duration is too long")
 	ar.Duration = 1 * time.Minute
 
-	assertErrMsg(t, ar.validate(10, conf), "no destinations")
+	requireErrMsg(t, ar.validate(10, conf), "no destinations")
 	ar.Destinations = destinations{
 		&destination{ID: "one", Amount: 10},
 		&destination{ID: "two", Amount: 20},
 		&destination{ID: "three", Amount: 30},
 	}
-	assertErrMsg(t, ar.validate(10, conf), "too many destinations")
+	requireErrMsg(t, ar.validate(10, conf), "too many destinations")
 	ar.Destinations = destinations{
 		&destination{ID: "one", Amount: 10},
 		&destination{ID: "two", Amount: 20},
@@ -161,7 +161,7 @@ func TestVestingSmartContract_add(t *testing.T) {
 
 	// 1. malformed request
 	_, err = vsc.add(tx, []byte(`} malformed {`), balances)
-	assertErrMsg(t, err, `create_vesting_pool_failed: malformed request:`+
+	requireErrMsg(t, err, `create_vesting_pool_failed: malformed request:`+
 		` invalid character '}' looking for beginning of value`)
 
 	// 2. invalid
@@ -174,28 +174,28 @@ func TestVestingSmartContract_add(t *testing.T) {
 		&destination{ID: "two", Amount: 20},
 	}
 	_, err = vsc.add(tx, mustEncode(t, &ar), balances)
-	assertErrMsg(t, err, `create_vesting_pool_failed: invalid request:`+
+	requireErrMsg(t, err, `create_vesting_pool_failed: invalid request:`+
 		` vesting duration is too short`)
 
 	// 3. empty client id
 	ar.Duration = 2 * time.Second
 	tx.ClientID = ""
 	_, err = vsc.add(tx, mustEncode(t, &ar), balances)
-	assertErrMsg(t, err, `create_vesting_pool_failed: `+
+	requireErrMsg(t, err, `create_vesting_pool_failed: `+
 		`empty client_id of transaction`)
 
 	// 4. min lock
 	tx = newTransaction(client.id, vsc.ID, 1, tp)
 	balances.txn = tx
 	_, err = vsc.add(tx, mustEncode(t, &ar), balances)
-	assertErrMsg(t, err, `create_vesting_pool_failed: `+
+	requireErrMsg(t, err, `create_vesting_pool_failed: `+
 		`not enough tokens to create pool provided`)
 
 	// 5. no tokens
 	tx = newTransaction(client.id, vsc.ID, 800e10, tp)
 	balances.txn = tx
 	_, err = vsc.add(tx, mustEncode(t, &ar), balances)
-	assertErrMsg(t, err, `create_vesting_pool_failed: `+
+	requireErrMsg(t, err, `create_vesting_pool_failed: `+
 		`can't fill pool: lock amount is greater than balance`)
 
 	// 6. ok
@@ -234,25 +234,25 @@ func TestVestingSmartContract_delete(t *testing.T) {
 
 	// 1. malformed (lock, unlock)
 	_, err = vsc.delete(tx, []byte("} malformed {"), balances)
-	assertErrMsg(t, err, "delete_vesting_pool_failed: invalid request:"+
+	requireErrMsg(t, err, "delete_vesting_pool_failed: invalid request:"+
 		" invalid character '}' looking for beginning of value")
 
 	// 2. pool_id = ""
 	_, err = vsc.delete(tx, mustEncode(t, &dr), balances)
-	assertErrMsg(t, err, "delete_vesting_pool_failed: invalid request:"+
+	requireErrMsg(t, err, "delete_vesting_pool_failed: invalid request:"+
 		" missing pool id")
 
 	// 3. invalid transaction
 	dr.PoolID = "pool_id"
 	tx.ClientID = ""
 	_, err = vsc.delete(tx, mustEncode(t, &dr), balances)
-	assertErrMsg(t, err, "delete_vesting_pool_failed: "+
+	requireErrMsg(t, err, "delete_vesting_pool_failed: "+
 		"empty client id of transaction")
 
 	// 4. not found
 	tx.ClientID = client.id
 	_, err = vsc.delete(tx, mustEncode(t, &dr), balances)
-	assertErrMsg(t, err, "delete_vesting_pool_failed: "+
+	requireErrMsg(t, err, "delete_vesting_pool_failed: "+
 		"can't get pool: value not present")
 
 	// 5. another client
@@ -274,7 +274,7 @@ func TestVestingSmartContract_delete(t *testing.T) {
 	tx.ClientID = "another_one"
 	balances.txn = tx
 	_, err = vsc.delete(tx, mustEncode(t, &dr), balances)
-	assertErrMsg(t, err, "delete_vesting_pool_failed: "+
+	requireErrMsg(t, err, "delete_vesting_pool_failed: "+
 		"only pool owner can delete the pool")
 
 	// 6. delete
@@ -303,19 +303,19 @@ func TestVestingSmartContract_stop(t *testing.T) {
 
 	// 1. malformed (stop)
 	_, err = vsc.stop(tx, []byte("} malformed {"), balances)
-	assertErrMsg(t, err, "stop_vesting_failed: malformed request:"+
+	requireErrMsg(t, err, "stop_vesting_failed: malformed request:"+
 		" invalid character '}' looking for beginning of value")
 
 	// 2. destination = ""
 	_, err = vsc.stop(tx, mustEncode(t, &sr), balances)
-	assertErrMsg(t, err, "stop_vesting_failed:"+
+	requireErrMsg(t, err, "stop_vesting_failed:"+
 		" missing destination to stop vesting")
 
 	// 3. not found
 	sr.PoolID = "pool_hex"
 	sr.Destination = "dest_hex"
 	_, err = vsc.stop(tx, mustEncode(t, &sr), balances)
-	assertErrMsg(t, err, "stop_vesting_failed: "+
+	requireErrMsg(t, err, "stop_vesting_failed: "+
 		"can't get vesting pool: value not present")
 
 	// 4. another client
@@ -337,14 +337,14 @@ func TestVestingSmartContract_stop(t *testing.T) {
 	tx.ClientID = "another_one"
 	balances.txn = tx
 	_, err = vsc.stop(tx, mustEncode(t, &sr), balances)
-	assertErrMsg(t, err, "stop_vesting_failed: "+
+	requireErrMsg(t, err, "stop_vesting_failed: "+
 		"only owner can stop a vesting")
 
 	// 6. destination not found
 	tx.Value = 1
 	tx.ClientID = client.id
 	_, err = vsc.stop(tx, mustEncode(t, &sr), balances)
-	assertErrMsg(t, err, `stop_vesting_failed: `+
+	requireErrMsg(t, err, `stop_vesting_failed: `+
 		`destination dest_hex not found in the pool`)
 
 	// 8. stop
@@ -376,18 +376,18 @@ func TestVestingSmartContract_unlock(t *testing.T) {
 
 	// 1. malformed
 	_, err = vsc.unlock(tx, []byte("} malformed {"), balances)
-	assertErrMsg(t, err, "unlock_vesting_pool_failed: invalid request:"+
+	requireErrMsg(t, err, "unlock_vesting_pool_failed: invalid request:"+
 		" invalid character '}' looking for beginning of value")
 
 	// 2. pool_id = ""
 	_, err = vsc.unlock(tx, mustEncode(t, &lr), balances)
-	assertErrMsg(t, err, "unlock_vesting_pool_failed: invalid request:"+
+	requireErrMsg(t, err, "unlock_vesting_pool_failed: invalid request:"+
 		" missing pool id")
 
 	// 3. not found
 	lr.PoolID = "pool_hex"
 	_, err = vsc.unlock(tx, mustEncode(t, &lr), balances)
-	assertErrMsg(t, err, "unlock_vesting_pool_failed: "+
+	requireErrMsg(t, err, "unlock_vesting_pool_failed: "+
 		"can't get pool: value not present")
 
 	// 4. another client
@@ -409,7 +409,7 @@ func TestVestingSmartContract_unlock(t *testing.T) {
 	tx.ClientID = "another_one"
 	balances.txn = tx
 	_, err = vsc.unlock(tx, mustEncode(t, &lr), balances)
-	assertErrMsg(t, err, "unlock_vesting_pool_failed: "+
+	requireErrMsg(t, err, "unlock_vesting_pool_failed: "+
 		`vesting pool: destination another_one not found in the pool`)
 
 	// 6. min lock
@@ -440,18 +440,18 @@ func TestVestingSmartContract_trigger(t *testing.T) {
 
 	// 1. malformed
 	_, err = vsc.trigger(tx, []byte("} malformed {"), balances)
-	assertErrMsg(t, err, "trigger_vesting_pool_failed: invalid request:"+
+	requireErrMsg(t, err, "trigger_vesting_pool_failed: invalid request:"+
 		" invalid character '}' looking for beginning of value")
 
 	// 2. pool_id = ""
 	_, err = vsc.trigger(tx, mustEncode(t, &lr), balances)
-	assertErrMsg(t, err, "trigger_vesting_pool_failed: invalid request:"+
+	requireErrMsg(t, err, "trigger_vesting_pool_failed: invalid request:"+
 		" missing pool id")
 
 	// 3. not found
 	lr.PoolID = "pool_hex"
 	_, err = vsc.trigger(tx, mustEncode(t, &lr), balances)
-	assertErrMsg(t, err, "trigger_vesting_pool_failed: "+
+	requireErrMsg(t, err, "trigger_vesting_pool_failed: "+
 		"can't get pool: value not present")
 
 	// 4. vesting is not started yet
@@ -473,7 +473,7 @@ func TestVestingSmartContract_trigger(t *testing.T) {
 	tx.ClientID = "another_one"
 	balances.txn = tx
 	_, err = vsc.trigger(tx, mustEncode(t, &lr), balances)
-	assertErrMsg(t, err, "trigger_vesting_pool_failed: "+
+	requireErrMsg(t, err, "trigger_vesting_pool_failed: "+
 		"only owner can trigger the pool")
 
 	// 6. vest (trigger)

--- a/docker.local/config/0chain.yaml
+++ b/docker.local/config/0chain.yaml
@@ -117,7 +117,7 @@ server_chain:
     max_simultaneous_from_sharders: 30
 
 network:
-  magic_block_file: config/b0magicBlock_4_miners_2_sharders.json
+  magic_block_file: config/b0magicBlock_4_miners_1_sharder_piers.json
   initial_states: config/initial_state.yaml
   genesis_dkg: 0
   dns_url: "" # http://198.18.0.98:9091


### PR DESCRIPTION
This is part of https://github.com/0chain/0chain/pull/274.

Adds an `vestingsc-update-settings` endpoint that allows the vesting owner to update the config settings. 
Changed to use a map[string]string as input, so it is possible to set a config value to the type default value.

Added some unit tests, and modified some to use require.

Required for https://github.com/0chain/gosdk/pull/215 and https://github.com/0chain/zwalletcli/pull/42