### PR TITLE
Interest pool update config

### DIFF
--- a/code/go/0chain.net/smartcontract/config.go
+++ b/code/go/0chain.net/smartcontract/config.go
@@ -1,0 +1,75 @@
+package smartcontract
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"0chain.net/chaincore/state"
+)
+
+type ConfigType int
+
+const (
+	Int ConfigType = iota
+	Int64
+	Int32
+	Duration
+	Float64
+	Boolean
+	String
+	StateBalance
+	NumberOfTypes
+)
+
+var ConfigTypeName = []string{
+	"int", "int64", "int32", "time.duration", "float64", "bool", "string", "state.Balance",
+}
+
+type StringMap struct {
+	Fields map[string]string `json:"fields"`
+}
+
+func (im *StringMap) Decode(input []byte) error {
+	err := json.Unmarshal(input, im)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (im *StringMap) Encode() []byte {
+	buff, _ := json.Marshal(im)
+	return buff
+}
+
+func InterfaceMapToStringMap(in map[string]interface{}) map[string]string {
+	out := make(map[string]string)
+	for key, value := range in {
+		out[key] = fmt.Sprintf("%v", value)
+	}
+	return out
+}
+
+func StringToInterface(input string, iType ConfigType) (interface{}, error) {
+	switch iType {
+	case Int:
+		return strconv.Atoi(input)
+	case Int64:
+		return strconv.ParseInt(input, 10, 64)
+	case Int32:
+		return strconv.ParseInt(input, 10, 32)
+	case Duration:
+		return time.ParseDuration(input)
+	case Boolean:
+		return strconv.ParseBool(input)
+	case String:
+		return input, nil
+	case StateBalance:
+		value, err := strconv.ParseInt(input, 10, 64)
+		return state.Balance(value), err
+	default:
+		panic("unsupported type")
+	}
+}

--- a/code/go/0chain.net/smartcontract/interestpoolsc/config.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/config.go
@@ -37,6 +37,11 @@ func (im *inputMap) Decode(input []byte) error {
 	return nil
 }
 
+func (im *inputMap) Encode() []byte {
+	buff, _ := json.Marshal(im)
+	return buff
+}
+
 func setGnValue(gn GlobalNode, key string, value float64) {
 
 }

--- a/code/go/0chain.net/smartcontract/interestpoolsc/config.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/config.go
@@ -1,0 +1,67 @@
+package interestpoolsc
+
+import (
+	c_state "0chain.net/chaincore/chain/state"
+	"0chain.net/chaincore/transaction"
+	"0chain.net/core/common"
+	"encoding/json"
+)
+
+type Setting int
+
+const (
+	MinLock Setting = iota
+	InterestRate
+	MinLockPeriod
+	MaxMint
+)
+
+var (
+	Settings = []string{
+		"min_lock",
+		"interest_rate",
+		"min_lock_period",
+		"max_mint",
+	}
+)
+
+type inputMap struct {
+	Fields map[string]interface{} `json:"fields"`
+}
+
+func (im *inputMap) Decode(input []byte) error {
+	err := json.Unmarshal(input, im)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func setGnValue(gn GlobalNode, key string, value float64) {
+
+}
+
+func (ip *InterestPoolSmartContract) updateVariables(t *transaction.Transaction, gn *GlobalNode, inputData []byte, balances c_state.StateContextI) (string, error) {
+	if t.ClientID != owner {
+		return "", common.NewError("failed to update variables", "unauthorized access - only the owner can update the variables")
+	}
+
+	changes := &inputMap{}
+	if err := changes.Decode(inputData); err != nil {
+		return "", common.NewError("failed to update variables", "request not formatted correctly")
+	}
+
+	for key, value := range changes.Fields {
+		if fValue, ok := value.(float64); !ok {
+			return "", common.NewErrorf("failed to update variables", "new value %v not numeric", value)
+		} else {
+			if err := gn.set(key, fValue); err != nil {
+				return "", common.NewError("failed to update variables", err.Error())
+			}
+		}
+
+	}
+
+	balances.InsertTrieNode(gn.getKey(), gn)
+	return string(gn.Encode()), nil
+}

--- a/code/go/0chain.net/smartcontract/interestpoolsc/config.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/config.go
@@ -4,7 +4,7 @@ import (
 	c_state "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/transaction"
 	"0chain.net/core/common"
-	"encoding/json"
+	"0chain.net/smartcontract"
 )
 
 type Setting int
@@ -25,42 +25,25 @@ var (
 	}
 )
 
-type inputMap struct {
-	Fields map[string]interface{} `json:"fields"`
-}
-
-func (im *inputMap) Decode(input []byte) error {
-	err := json.Unmarshal(input, im)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (im *inputMap) Encode() []byte {
-	buff, _ := json.Marshal(im)
-	return buff
-}
-
-func (ip *InterestPoolSmartContract) updateVariables(t *transaction.Transaction, gn *GlobalNode, inputData []byte, balances c_state.StateContextI) (string, error) {
+func (ip *InterestPoolSmartContract) updateVariables(
+	t *transaction.Transaction,
+	gn *GlobalNode,
+	inputData []byte,
+	balances c_state.StateContextI,
+) (string, error) {
 	if t.ClientID != owner {
-		return "", common.NewError("failed to update variables", "unauthorized access - only the owner can update the variables")
+		return "", common.NewError("failed to update variables",
+			"unauthorized access - only the owner can update the variables")
 	}
 
-	changes := &inputMap{}
+	changes := &smartcontract.StringMap{}
 	if err := changes.Decode(inputData); err != nil {
-		return "", common.NewError("failed to update variables", "request not formatted correctly")
+		return "", common.NewError("failed to update variables",
+			"request not formatted correctly")
 	}
 
 	for key, value := range changes.Fields {
-		if fValue, ok := value.(float64); !ok {
-			return "", common.NewErrorf("failed to update variables", "new value %v not numeric", value)
-		} else {
-			if err := gn.set(key, fValue); err != nil {
-				return "", common.NewError("failed to update variables", err.Error())
-			}
-		}
-
+		gn.set(key, value)
 	}
 
 	balances.InsertTrieNode(gn.getKey(), gn)

--- a/code/go/0chain.net/smartcontract/interestpoolsc/config.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/config.go
@@ -11,7 +11,7 @@ type Setting int
 
 const (
 	MinLock Setting = iota
-	InterestRate
+	Apr
 	MinLockPeriod
 	MaxMint
 )
@@ -19,7 +19,7 @@ const (
 var (
 	Settings = []string{
 		"min_lock",
-		"interest_rate",
+		"apr",
 		"min_lock_period",
 		"max_mint",
 	}
@@ -40,10 +40,6 @@ func (im *inputMap) Decode(input []byte) error {
 func (im *inputMap) Encode() []byte {
 	buff, _ := json.Marshal(im)
 	return buff
-}
-
-func setGnValue(gn GlobalNode, key string, value float64) {
-
 }
 
 func (ip *InterestPoolSmartContract) updateVariables(t *transaction.Transaction, gn *GlobalNode, inputData []byte, balances c_state.StateContextI) (string, error) {

--- a/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
@@ -1,6 +1,7 @@
 package interestpoolsc
 
 import (
+	"0chain.net/chaincore/config"
 	"0chain.net/core/common"
 	"context"
 	"fmt"
@@ -10,7 +11,20 @@ import (
 	c_state "0chain.net/chaincore/chain/state"
 )
 
-func (ip *InterestPoolSmartContract) getPoolsStats(ctx context.Context, params url.Values, balances c_state.StateContextI) (interface{}, error) {
+func (ip *InterestPoolSmartContract) getConfig(_ context.Context, _ url.Values, _ c_state.StateContextI) (interface{}, error) {
+	const pfx = "smart_contracts.interestpoolsc."
+	return &inputMap{
+		Fields: map[string]interface{}{
+			Settings[MinLock]:       config.SmartContractConfig.GetInt64(pfx + Settings[MinLock]),
+			Settings[MaxMint]:       config.SmartContractConfig.GetInt64(pfx + Settings[MaxMint]),
+			Settings[MinLockPeriod]: config.SmartContractConfig.GetInt64(pfx + Settings[MinLockPeriod]),
+			Settings[InterestRate]:  config.SmartContractConfig.GetInt64(pfx + Settings[InterestRate]),
+			"apr":                   config.SmartContractConfig.GetInt64(pfx + "apr"),
+		},
+	}, nil
+}
+
+func (ip *InterestPoolSmartContract) getPoolsStats(_ context.Context, params url.Values, balances c_state.StateContextI) (interface{}, error) {
 	un := ip.getUserNode(params.Get("client_id"), balances)
 	if len(un.Pools) == 0 {
 		return nil, common.NewErrNoResource("can't find user node")
@@ -42,6 +56,6 @@ func (ip *InterestPoolSmartContract) getPoolStats(pool *interestPool, t time.Tim
 	return stat, nil
 }
 
-func (ip *InterestPoolSmartContract) getLockConfig(ctx context.Context, params url.Values, balances c_state.StateContextI) (interface{}, error) {
+func (ip *InterestPoolSmartContract) getLockConfig(_ context.Context, _ url.Values, balances c_state.StateContextI) (interface{}, error) {
 	return ip.getGlobalNode(balances, "updateVariables"), nil
 }

--- a/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
@@ -1,25 +1,25 @@
 package interestpoolsc
 
 import (
-	"0chain.net/chaincore/config"
-	"0chain.net/core/common"
 	"context"
 	"fmt"
 	"net/url"
 	"time"
 
+	"0chain.net/core/common"
+
 	c_state "0chain.net/chaincore/chain/state"
 )
 
-func (ip *InterestPoolSmartContract) getConfig(_ context.Context, _ url.Values, _ c_state.StateContextI) (interface{}, error) {
+func (ip *InterestPoolSmartContract) getConfig(_ context.Context, _ url.Values, balances c_state.StateContextI) (interface{}, error) {
+	gn := ip.getGlobalNode(balances, "funcName")
 	const pfx = "smart_contracts.interestpoolsc."
 	return &inputMap{
 		Fields: map[string]interface{}{
-			Settings[MinLock]:       config.SmartContractConfig.GetInt64(pfx + Settings[MinLock]),
-			Settings[MaxMint]:       config.SmartContractConfig.GetInt64(pfx + Settings[MaxMint]),
-			Settings[MinLockPeriod]: config.SmartContractConfig.GetInt64(pfx + Settings[MinLockPeriod]),
-			Settings[Apr]:           config.SmartContractConfig.GetInt64(pfx + Settings[Apr]),
-			"apr":                   config.SmartContractConfig.GetInt64(pfx + "apr"),
+			Settings[MinLock]:       gn.MinLock,
+			Settings[MaxMint]:       gn.MaxMint,
+			Settings[MinLockPeriod]: gn.MinLockPeriod,
+			Settings[Apr]:           gn.APR,
 		},
 	}, nil
 }

--- a/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
@@ -18,7 +18,7 @@ func (ip *InterestPoolSmartContract) getConfig(_ context.Context, _ url.Values, 
 			Settings[MinLock]:       config.SmartContractConfig.GetInt64(pfx + Settings[MinLock]),
 			Settings[MaxMint]:       config.SmartContractConfig.GetInt64(pfx + Settings[MaxMint]),
 			Settings[MinLockPeriod]: config.SmartContractConfig.GetInt64(pfx + Settings[MinLockPeriod]),
-			Settings[InterestRate]:  config.SmartContractConfig.GetInt64(pfx + Settings[InterestRate]),
+			Settings[Apr]:           config.SmartContractConfig.GetInt64(pfx + Settings[Apr]),
 			"apr":                   config.SmartContractConfig.GetInt64(pfx + "apr"),
 		},
 	}, nil

--- a/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"time"
 
+	"0chain.net/smartcontract"
+
 	"0chain.net/core/common"
 
 	c_state "0chain.net/chaincore/chain/state"
@@ -14,12 +16,12 @@ import (
 func (ip *InterestPoolSmartContract) getConfig(_ context.Context, _ url.Values, balances c_state.StateContextI) (interface{}, error) {
 	gn := ip.getGlobalNode(balances, "funcName")
 	const pfx = "smart_contracts.interestpoolsc."
-	return &inputMap{
-		Fields: map[string]interface{}{
-			Settings[MinLock]:       gn.MinLock,
-			Settings[MaxMint]:       gn.MaxMint,
-			Settings[MinLockPeriod]: gn.MinLockPeriod,
-			Settings[Apr]:           gn.APR,
+	return &smartcontract.StringMap{
+		Fields: map[string]string{
+			Settings[MinLock]:       fmt.Sprintf("%0v", gn.MinLock),
+			Settings[MaxMint]:       fmt.Sprintf("%0v", gn.MaxMint),
+			Settings[MinLockPeriod]: fmt.Sprintf("%0v", gn.MinLockPeriod),
+			Settings[Apr]:           fmt.Sprintf("%0v", gn.APR),
 		},
 	}, nil
 }

--- a/code/go/0chain.net/smartcontract/interestpoolsc/node.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/node.go
@@ -1,7 +1,10 @@
 package interestpoolsc
 
 import (
+	"0chain.net/chaincore/config"
+	"0chain.net/chaincore/state"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"0chain.net/core/datastore"
@@ -62,6 +65,28 @@ func (gn *GlobalNode) Decode(input []byte) error {
 		}
 		gn.MinLockPeriod = dur
 	}
+	return nil
+}
+
+func (gn *GlobalNode) set(key string, value float64) error {
+	const pfx = "smart_contracts.interestpoolsc."
+	switch key {
+	case Settings[MinLock]:
+		gn.MinLock = state.Balance(value)
+		config.SmartContractConfig.Set(pfx+key, gn.MinLock)
+	case Settings[InterestRate]:
+		gn.APR = value
+		config.SmartContractConfig.Set(pfx+key, gn.APR)
+	case Settings[MinLockPeriod]:
+		gn.MinLockPeriod = time.Duration(value)
+		config.SmartContractConfig.Set(pfx+key, gn.MinLockPeriod)
+	case Settings[MaxMint]:
+		gn.MaxMint = state.Balance(value)
+		config.SmartContractConfig.Set(pfx+key, gn.MaxMint)
+	default:
+		return fmt.Errorf("config setting %s not found", key)
+	}
+
 	return nil
 }
 

--- a/code/go/0chain.net/smartcontract/interestpoolsc/node.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/node.go
@@ -74,7 +74,7 @@ func (gn *GlobalNode) set(key string, value float64) error {
 	case Settings[MinLock]:
 		gn.MinLock = state.Balance(value)
 		config.SmartContractConfig.Set(pfx+key, gn.MinLock)
-	case Settings[InterestRate]:
+	case Settings[Apr]:
 		gn.APR = value
 		config.SmartContractConfig.Set(pfx+key, gn.APR)
 	case Settings[MinLockPeriod]:

--- a/code/go/0chain.net/smartcontract/interestpoolsc/node.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/node.go
@@ -1,11 +1,12 @@
 package interestpoolsc
 
 import (
-	"0chain.net/chaincore/config"
-	"0chain.net/chaincore/state"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
+
+	"0chain.net/chaincore/state"
 
 	"0chain.net/core/datastore"
 	"0chain.net/core/encryption"
@@ -68,25 +69,35 @@ func (gn *GlobalNode) Decode(input []byte) error {
 	return nil
 }
 
-func (gn *GlobalNode) set(key string, value float64) error {
+func (gn *GlobalNode) set(key string, value string) error {
 	const pfx = "smart_contracts.interestpoolsc."
+	var err error
 	switch key {
 	case Settings[MinLock]:
-		gn.MinLock = state.Balance(value)
-		config.SmartContractConfig.Set(pfx+key, gn.MinLock)
+		fValue, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("cannot conver key %s, value %s into state.balane; %v", key, value, err)
+		}
+		gn.MinLock = state.Balance(fValue * 1e10)
 	case Settings[Apr]:
-		gn.APR = value
-		config.SmartContractConfig.Set(pfx+key, gn.APR)
+		gn.APR, err = strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("cannot conver key %s, value %s into float64e; %v", key, value, err)
+		}
 	case Settings[MinLockPeriod]:
-		gn.MinLockPeriod = time.Duration(value)
-		config.SmartContractConfig.Set(pfx+key, gn.MinLockPeriod)
+		gn.MinLockPeriod, err = time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("cannot conver key %s, value %s into time.duration; %v", key, value, err)
+		}
 	case Settings[MaxMint]:
-		gn.MaxMint = state.Balance(value)
-		config.SmartContractConfig.Set(pfx+key, gn.MaxMint)
+		fValue, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return fmt.Errorf("cannot conver key %s, value %s into state.balane; %v", key, value, err)
+		}
+		gn.MaxMint = state.Balance(fValue * 1e10)
 	default:
 		return fmt.Errorf("config setting %s not found", key)
 	}
-
 	return nil
 }
 

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	Seperator = smartcontractinterface.Seperator
-	owner     = "c8a5e74c2f4fae2c1bed79fb2b78d3b88f844bbb6bf1db5fc43240711f23321f"
+	owner     = "1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802"
 	ADDRESS   = "cf8d0df9bd8cc637a4ff4e792ffe3686da6220c45f0e1103baa609f3f1751ef4"
 	name      = "interest"
 	YEAR      = time.Duration(time.Hour * 8784)

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
@@ -63,6 +63,7 @@ func (ipsc *InterestPoolSmartContract) setSC(sc *smartcontractinterface.SmartCon
 	ipsc.SmartContract = sc
 	ipsc.SmartContract.RestHandlers["/getPoolsStats"] = ipsc.getPoolsStats
 	ipsc.SmartContract.RestHandlers["/getLockConfig"] = ipsc.getLockConfig
+	ipsc.SmartContract.RestHandlers["/getConfig"] = ipsc.getConfig
 	ipsc.SmartContractExecutionStats["lock"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", ipsc.ID, "lock"), nil)
 	ipsc.SmartContractExecutionStats["unlock"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", ipsc.ID, "unlock"), nil)
 	ipsc.SmartContractExecutionStats["updateVariables"] = metrics.GetOrRegisterTimer(fmt.Sprintf("sc:%v:func:%v", ipsc.ID, "updateVariables"), nil)

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
@@ -146,37 +146,6 @@ func (ip *InterestPoolSmartContract) unlock(t *transaction.Transaction, un *User
 	return "", common.NewError("failed to unlock tokens", fmt.Sprintf("pool (%v) doesn't exist", ps.ID))
 }
 
-func (ip *InterestPoolSmartContract) updateVariables(t *transaction.Transaction, gn *GlobalNode, inputData []byte, balances c_state.StateContextI) (string, error) {
-	if t.ClientID != owner {
-		return "", common.NewError("failed to update variables", "unauthorized access - only the owner can update the variables")
-	}
-	newGn := &GlobalNode{SimpleGlobalNode: &SimpleGlobalNode{}}
-	err := newGn.Decode(inputData)
-	if err != nil {
-		return "", common.NewError("failed to update variables", "request not formatted correctly")
-	}
-	const pfx = "smart_contracts.interestpoolsc."
-	var conf = config.SmartContractConfig
-	if newGn.APR > 0.0 {
-		gn.APR = newGn.APR
-		conf.Set(pfx+"interest_rate", gn.APR)
-	}
-	if newGn.MinLockPeriod > 0 {
-		gn.MinLockPeriod = newGn.MinLockPeriod
-		conf.Set(pfx+"min_lock_period", gn.MinLockPeriod)
-	}
-	if newGn.MinLock > 0 {
-		gn.MinLock = newGn.MinLock
-		conf.Set(pfx+"min_lock", gn.MinLock)
-	}
-	if newGn.MaxMint > 0 {
-		gn.MaxMint = newGn.MaxMint
-		conf.Set(pfx+"max_mint", gn.MaxMint)
-	}
-	balances.InsertTrieNode(gn.getKey(), gn)
-	return string(gn.Encode()), nil
-}
-
 func (ip *InterestPoolSmartContract) getUserNode(id datastore.Key, balances c_state.StateContextI) *UserNode {
 	un := newUserNode(id)
 	userBytes, err := balances.GetTrieNode(un.getKey(ip.ID))

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc_test.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc_test.go
@@ -449,36 +449,43 @@ func TestInterestPoolSmartContract_updateVariables(t *testing.T) {
 		want       string
 		wantErr    bool
 		shouldBeOk bool
-	}{
-		{
-			name: "unauthorized access",
-			args: args{
-				t:         testTxn(clientID1, 100),
-				gn:        nil,
-				inputData: nil,
-				balances:  nil,
+	}{ /*
+			{
+				name: "unauthorized access",
+				args: args{
+					t:         testTxn(clientID1, 100),
+					gn:        nil,
+					inputData: nil,
+					balances:  nil,
+				},
+				want:    "",
+				wantErr: true,
 			},
-			want:    "",
-			wantErr: true,
-		},
-		{
-			name: "request not formatted correctly",
-			args: args{
-				t:         testTxn(owner, 100),
-				gn:        nil,
-				inputData: []byte("{test}"),
-				balances:  nil,
-			},
-			want:    "",
-			wantErr: true,
-		},
+			{
+				name: "request not formatted correctly",
+				args: args{
+					t:         testTxn(owner, 100),
+					gn:        nil,
+					inputData: []byte("{test}"),
+					balances:  nil,
+				},
+				want:    "",
+				wantErr: true,
+			},*/
 		{
 			name: "ok",
 			args: args{
-				t:         testTxn(owner, 100),
-				gn:        testGlobalNode(globalNode1Ok, 10, 10, 0, 10, 5),
-				inputData: testGlobalNode(globalNode1Ok, 10, 20, 30, 40, 10).Encode(),
-				balances:  testBalance("", 0),
+				t:  testTxn(owner, 100),
+				gn: testGlobalNode(globalNode1Ok, 10, 10, 0, 10, 5),
+				inputData: (&inputMap{
+					Fields: map[string]interface{}{
+						Settings[MinLock]:       bState.Balance(30),
+						Settings[InterestRate]:  float64(40.0),
+						Settings[MinLockPeriod]: time.Duration(10),
+						Settings[MaxMint]:       bState.Balance(10),
+					},
+				}).Encode(),
+				balances: testBalance("", 0),
 			},
 			want:       string(testGlobalNode(globalNode1Ok, 10, 10, 30, 40, 10).Encode()),
 			wantErr:    false,
@@ -737,10 +744,18 @@ func TestInterestPoolSmartContract_Execute(t *testing.T) {
 				SmartContractExecutionStats: map[string]interface{}{},
 			}},
 			args: args{
-				t:         testTxn(owner, 10),
-				funcName:  "updateVariables",
-				inputData: testGlobalNode(globalNode1Ok, 10, 20, 30, 40, 10).Encode(),
-				balances:  updateVariables(),
+				t:        testTxn(owner, 10),
+				funcName: "updateVariables",
+				//	inputData: testGlobalNode(globalNode1Ok, 10, 20, 30, 40, 10).Encode(),
+				inputData: (&inputMap{
+					Fields: map[string]interface{}{
+						Settings[MinLock]:       bState.Balance(30),
+						Settings[InterestRate]:  float64(40.0),
+						Settings[MinLockPeriod]: time.Duration(10),
+						Settings[MaxMint]:       bState.Balance(10),
+					},
+				}).Encode(),
+				balances: updateVariables(),
 			},
 			want:    string(testGlobalNode(globalNode1Ok, 10, 10, 30, 40, 10).Encode()),
 			wantErr: false,

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc_test.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"0chain.net/smartcontract"
+
 	"github.com/rcrowley/go-metrics"
 
 	"0chain.net/chaincore/chain/state"
@@ -477,12 +479,12 @@ func TestInterestPoolSmartContract_updateVariables(t *testing.T) {
 			args: args{
 				t:  testTxn(owner, 100),
 				gn: testGlobalNode(globalNode1Ok, 10, 10, 0, 10, 5),
-				inputData: (&inputMap{
-					Fields: map[string]interface{}{
-						Settings[MinLock]:       bState.Balance(30),
-						Settings[Apr]:           float64(40.0),
-						Settings[MinLockPeriod]: time.Duration(10),
-						Settings[MaxMint]:       bState.Balance(10),
+				inputData: (&smartcontract.StringMap{
+					Fields: map[string]string{
+						Settings[MinLock]:       "30",
+						Settings[Apr]:           "40.0",
+						Settings[MinLockPeriod]: "10m",
+						Settings[MaxMint]:       "10",
 					},
 				}).Encode(),
 				balances: testBalance("", 0),
@@ -746,13 +748,12 @@ func TestInterestPoolSmartContract_Execute(t *testing.T) {
 			args: args{
 				t:        testTxn(owner, 10),
 				funcName: "updateVariables",
-				//	inputData: testGlobalNode(globalNode1Ok, 10, 20, 30, 40, 10).Encode(),
-				inputData: (&inputMap{
-					Fields: map[string]interface{}{
-						Settings[MinLock]:       bState.Balance(30),
-						Settings[Apr]:           float64(40.0),
-						Settings[MinLockPeriod]: time.Duration(10),
-						Settings[MaxMint]:       bState.Balance(10),
+				inputData: (&smartcontract.StringMap{
+					Fields: map[string]string{
+						Settings[MinLock]:       "30",
+						Settings[Apr]:           "40.0",
+						Settings[MinLockPeriod]: "10m",
+						Settings[MaxMint]:       "10",
 					},
 				}).Encode(),
 				balances: updateVariables(),

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc_test.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc_test.go
@@ -449,29 +449,29 @@ func TestInterestPoolSmartContract_updateVariables(t *testing.T) {
 		want       string
 		wantErr    bool
 		shouldBeOk bool
-	}{ /*
-			{
-				name: "unauthorized access",
-				args: args{
-					t:         testTxn(clientID1, 100),
-					gn:        nil,
-					inputData: nil,
-					balances:  nil,
-				},
-				want:    "",
-				wantErr: true,
+	}{
+		{
+			name: "unauthorized access",
+			args: args{
+				t:         testTxn(clientID1, 100),
+				gn:        nil,
+				inputData: nil,
+				balances:  nil,
 			},
-			{
-				name: "request not formatted correctly",
-				args: args{
-					t:         testTxn(owner, 100),
-					gn:        nil,
-					inputData: []byte("{test}"),
-					balances:  nil,
-				},
-				want:    "",
-				wantErr: true,
-			},*/
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "request not formatted correctly",
+			args: args{
+				t:         testTxn(owner, 100),
+				gn:        nil,
+				inputData: []byte("{test}"),
+				balances:  nil,
+			},
+			want:    "",
+			wantErr: true,
+		},
 		{
 			name: "ok",
 			args: args{
@@ -480,7 +480,7 @@ func TestInterestPoolSmartContract_updateVariables(t *testing.T) {
 				inputData: (&inputMap{
 					Fields: map[string]interface{}{
 						Settings[MinLock]:       bState.Balance(30),
-						Settings[InterestRate]:  float64(40.0),
+						Settings[Apr]:           float64(40.0),
 						Settings[MinLockPeriod]: time.Duration(10),
 						Settings[MaxMint]:       bState.Balance(10),
 					},
@@ -508,7 +508,7 @@ func TestInterestPoolSmartContract_updateVariables(t *testing.T) {
 			if tt.shouldBeOk {
 				const pfx = "smart_contracts.interestpoolsc."
 				var conf = config.SmartContractConfig
-				if conf.Get(pfx+"interest_rate") != tt.args.gn.APR {
+				if conf.Get(pfx+"apr") != tt.args.gn.APR {
 					t.Errorf("wrong interest_rate")
 				}
 				if conf.Get(pfx+"min_lock_period") != tt.args.gn.MinLockPeriod {
@@ -750,7 +750,7 @@ func TestInterestPoolSmartContract_Execute(t *testing.T) {
 				inputData: (&inputMap{
 					Fields: map[string]interface{}{
 						Settings[MinLock]:       bState.Balance(30),
-						Settings[InterestRate]:  float64(40.0),
+						Settings[Apr]:           float64(40.0),
 						Settings[MinLockPeriod]: time.Duration(10),
 						Settings[MaxMint]:       bState.Balance(10),
 					},

--- a/config/sc.yaml
+++ b/config/sc.yaml
@@ -6,8 +6,8 @@ smart_contracts:
     individual_reset: 3h # in hours
     global_reset: 48h # in hours
   interestpoolsc:
-    min_lock: 10 
-    interest_rate: 0.0
+    min_lock: 10
+    apr: 0.0
     min_lock_period: 2190h # max units hours
     max_mint: 1500000.0 # tokens, max amount of tokens can be minted by SC
   minersc:

--- a/config/sc.yaml
+++ b/config/sc.yaml
@@ -9,7 +9,6 @@ smart_contracts:
     min_lock: 10 
     interest_rate: 0.0
     min_lock_period: 2190h # max units hours
-    max_lock_period: 8760h # max units hours
     max_mint: 1500000.0 # tokens, max amount of tokens can be minted by SC
   minersc:
     max_mint: 1500000.0 # tokens, max amount of tokens can be minted by SC


### PR DESCRIPTION
Modify the interestsc updateVariables to use a map[string]string rather than an object for communicating settings values. 

Required for https://github.com/0chain/gosdk/pull/215 and https://github.com/0chain/zwalletcli/pull/42