### PR TITLE
Make all smartcontract owners the same

### DIFF
--- a/code/go/0chain.net/smartcontract/faucetsc/sc.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/sc.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	Seperator = smartcontractinterface.Seperator
-	owner     = "c8a5e74c2f4fae2c1bed79fb2b78d3b88f844bbb6bf1db5fc43240711f23321f"
+	owner     = "1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802"
 	ADDRESS   = "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d3"
 	name      = "faucet"
 )

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	Seperator = smartcontractinterface.Seperator
-	owner     = "c8a5e74c2f4fae2c1bed79fb2b78d3b88f844bbb6bf1db5fc43240711f23321f"
+	owner     = "1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802"
 	ADDRESS   = "cf8d0df9bd8cc637a4ff4e792ffe3686da6220c45f0e1103baa609f3f1751ef4"
 	name      = "interest"
 	YEAR      = time.Duration(time.Hour * 8784)

--- a/code/go/0chain.net/smartcontract/minersc/sc.go
+++ b/code/go/0chain.net/smartcontract/minersc/sc.go
@@ -26,7 +26,7 @@ import (
 const (
 	//ADDRESS address of minersc
 	ADDRESS = "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d9"
-	owner   = "c8a5e74c2f4fae2c1bed79fb2b78d3b88f844bbb6bf1db5fc43240711f23321f"
+	owner   = "1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802"
 	name    = "miner"
 )
 


### PR DESCRIPTION
Make all smart contract owners the same with known keys. This is for testing only and should be changed to something else afterwards.

<details>
  <summary>smartcontract keys </summary>

```json
{
   "client_id":"1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802",
   "client_key":"7b630ba670dac2f22d43c2399b70eff378689a53ee03ea20957bb7e73df016200fea410ba5102558b0c39617e5afd2c1843b161a1dedec15e1ab40543a78a518",
   "keys":[
      {
         "public_key":"7b630ba670dac2f22d43c2399b70eff378689a53ee03ea20957bb7e73df016200fea410ba5102558b0c39617e5afd2c1843b161a1dedec15e1ab40543a78a518",
         "private_key":"c06b6f6945ba02d5a3be86b8779deca63bb636ce7e46804a479c50e53c864915"
      }
   ],
   "mnemonics":"cactus panther essence ability copper fox wise actual need cousin boat uncover ride diamond group jacket anchor current float rely tragic omit child payment",
   "version":"1.0",
   "date_created":"2021-08-04 18:53:56.949069945 +0100 BST m=+0.018986002"
}
```

</details>

 We should consider issue https://github.com/0chain/0chain/issues/432 as a long term solution.