### PR TITLE
Fix/sc txn errors

### DIFF
--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -177,7 +177,9 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, txn *transactio
 		if output, err = c.ExecuteSmartContract(ctx, txn, sctx); err != nil {
 			logging.Logger.Error("Error executing the SC", zap.Any("txn", txn),
 				zap.Error(err))
-			return
+			txn.TransactionOutput = err.Error()
+			txn.Status = transaction.TxnFail
+			return nil
 		}
 		txn.TransactionOutput = output
 		logging.Logger.Info("SC executed with output",

--- a/code/go/0chain.net/miner/protocol_block_main.go
+++ b/code/go/0chain.net/miner/protocol_block_main.go
@@ -96,7 +96,7 @@ func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block,
 					zap.Error(err))
 			}
 			failedStateCount++
-			return false
+			// return false
 		}
 
 		// Setting the score lower so the next time blocks are generated


### PR DESCRIPTION
This PR fixes the problem pointed out in https://github.com/0chain/zboxcli/issues/53, but is part of general solution that handles all smartcontract errors.
As the failed smartcontract transaction (+ it's error) become part of a block, the application should ensure that both the block generator as well as the block verifier gets same error while processing same transaction. Otherwise, the verification would fail and the block would be discarded.