### PR TITLE
Rrrooommmaaa/zcn test (#509)

### DIFF
--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -3,7 +3,6 @@ package chain
 import (
 	"container/ring"
 	"context"
-	"errors"
 	"fmt"
 	"math"
 	"sort"

--- a/code/go/0chain.net/chaincore/state/state.go
+++ b/code/go/0chain.net/chaincore/state/state.go
@@ -1,12 +1,13 @@
 package state
 
 import (
-	"0chain.net/core/encryption"
-	"0chain.net/core/logging"
-	"0chain.net/core/util"
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
+
+	"0chain.net/core/encryption"
+	"0chain.net/core/util"
 )
 
 //Balance - any quantity that is represented as an integer in the lowest denomination
@@ -38,6 +39,10 @@ func (s *State) GetHashBytes() []byte {
 /*Encode - implement SecureSerializableValueI interface */
 func (s *State) Encode() []byte {
 	buf := bytes.NewBuffer(nil)
+	// if s.TxnHashBytes are not set, the State can't be deserialized later
+	if s.TxnHashBytes == nil {
+		panic(errors.New("State isn't properly initialized"))
+	}
 	buf.Write(s.TxnHashBytes)
 	binary.Write(buf, binary.LittleEndian, s.Round)
 	binary.Write(buf, binary.LittleEndian, s.Balance)
@@ -51,7 +56,7 @@ func (s *State) Decode(data []byte) error {
 	var balance Balance
 	s.TxnHashBytes = make([]byte, 32)
 	if n, err := buf.Read(s.TxnHashBytes); err != nil || n != 32 {
-		logging.Logger.Error("invalid state")
+		return errors.New("invalid state")
 	}
 	binary.Read(buf, binary.LittleEndian, &origin)
 	binary.Read(buf, binary.LittleEndian, &balance)

--- a/code/go/0chain.net/chaincore/wallet/wallet_test.go
+++ b/code/go/0chain.net/chaincore/wallet/wallet_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -146,7 +147,9 @@ func saveWallets(mpt util.MerklePatriciaTrieI, wallets []*Wallet) {
 	if mpt != nil {
 		for _, w := range wallets {
 			balance := state.Balance(w.Balance)
-			if _, err := mpt.Insert(util.Path(w.ClientID), &state.State{Balance: balance}); err != nil {
+			s := state.State{Balance: balance}
+			s.SetTxnHash(strings.Repeat("00", 32))
+			if _, err := mpt.Insert(util.Path(w.ClientID), &s); err != nil {
 				panic(err)
 			}
 			_, err := getState(mpt, w.ClientID)

--- a/code/go/0chain.net/core/util/merkle_patricia_trie.go
+++ b/code/go/0chain.net/core/util/merkle_patricia_trie.go
@@ -139,14 +139,15 @@ func (mpt *MerklePatriciaTrie) Insert(path Path, value Serializable) (Key, error
 		return mpt.Delete(path)
 	}
 
+	valueCopy := &SecureSerializableValue{eval}
 	mpt.mutex.Lock()
 	defer mpt.mutex.Unlock()
 	var err error
 	var newRootHash Key
 	if mpt.Root == nil {
-		_, newRootHash, err = mpt.insertLeaf(nil, value, Path(""), path)
+		_, newRootHash, err = mpt.insertLeaf(nil, valueCopy, Path(""), path)
 	} else {
-		_, newRootHash, err = mpt.insert(value, mpt.Root, Path(""), path)
+		_, newRootHash, err = mpt.insert(valueCopy, mpt.Root, Path(""), path)
 	}
 	if err != nil {
 		return nil, err

--- a/code/go/0chain.net/core/util/merkle_patricia_trie_test.go
+++ b/code/go/0chain.net/core/util/merkle_patricia_trie_test.go
@@ -201,10 +201,8 @@ func doGetStateValue(t *testing.T, mpt MerklePatriciaTrieI,
 	if val == nil {
 		t.Fatalf("inserted value not found: %v %v", key, value)
 	}
-	var astate, ok = val.(*AState)
-	if !ok {
-		t.Fatalf("wrong state type: %T", val)
-	}
+	astate := AState{}
+	assert.NoError(t, astate.Decode(val.Encode()))
 	if astate.balance != value {
 		t.Fatalf("%s: wrong state value: %d, expected: %d", key, astate.balance,
 			value)
@@ -1667,6 +1665,24 @@ func TestMerklePatriciaTrie_MergeMPTChanges(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMerklePatriciaTrie_IntegrityAfterValueUpdate(t *testing.T) {
+	t.Parallel()
+	db := NewLevelNodeDB(NewMemoryNodeDB(), NewMemoryNodeDB(), false)
+	mpt := NewMerklePatriciaTrie(db, Sequence(0), nil)
+	txn := &Txn{"1"}
+
+	_, err := mpt.Insert(Path("00"), txn)
+	require.NoError(t, err)
+	checkIterationHash(t, mpt, "34a278944ef883d7c642a7b69b5675cf9d8cc5c60dd90d00adea1c4164425037")
+	_, changes, _, _ := mpt.GetChanges()
+	oldEncodedValue := changes[0].New.Encode()
+	txn.Data = "2"
+	checkIterationHash(t, mpt, "34a278944ef883d7c642a7b69b5675cf9d8cc5c60dd90d00adea1c4164425037")
+	_, changes, _, _ = mpt.GetChanges()
+	assert.Equal(t, 1, len(changes))
+	assert.Equal(t, oldEncodedValue, changes[0].New.Encode())
 }
 
 func TestMerklePatriciaTrie_Validate(t *testing.T) {

--- a/code/go/0chain.net/core/util/mpt_node.go
+++ b/code/go/0chain.net/core/util/mpt_node.go
@@ -116,7 +116,9 @@ func NewValueNode() *ValueNode {
 func (vn *ValueNode) Clone() Node {
 	clone := NewValueNode()
 	clone.OriginTrackerNode = vn.OriginTrackerNode.Clone()
-	clone.SetValue(vn.GetValue())
+	if vn.Value != nil {
+		clone.SetValue(vn.GetValue())
+	}
 	return clone
 }
 

--- a/code/go/0chain.net/miner/protocol_block_integration_tests.go
+++ b/code/go/0chain.net/miner/protocol_block_integration_tests.go
@@ -314,8 +314,8 @@ func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block,
 	logging.Logger.Info("generate block (assemble+update+sign)", zap.Int64("round", b.Round), zap.Int32("block_size", blockSize), zap.Int32("reused_txns", reusedTxns), zap.Duration("time", time.Since(start)),
 		zap.String("block", b.Hash), zap.String("prev_block", b.PrevHash), zap.String("state_hash", util.ToHex(b.ClientStateHash)), zap.Int8("state_status", b.GetStateStatus()),
 		zap.Float64("p_chain_weight", b.PrevBlock.ChainWeight), zap.Int32("iteration_count", count))
-	mc.StateSanityCheck(ctx, b)
-	go b.ComputeTxnMap()
+	block.StateSanityCheck(ctx, b)
+	b.ComputeTxnMap()
 	bsHistogram.Update(int64(len(b.Txns)))
 	node.Self.Underlying().Info.AvgBlockTxns = int(math.Round(bsHistogram.Mean()))
 	return nil

--- a/code/go/0chain.net/miner/protocol_block_main.go
+++ b/code/go/0chain.net/miner/protocol_block_main.go
@@ -274,7 +274,7 @@ func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block,
 		zap.Float64("p_chain_weight", b.PrevBlock.ChainWeight),
 		zap.Int32("iteration_count", count))
 	block.StateSanityCheck(ctx, b)
-	go b.ComputeTxnMap()
+	b.ComputeTxnMap()
 	bsHistogram.Update(int64(len(b.Txns)))
 	node.Self.Underlying().Info.AvgBlockTxns = int(math.Round(bsHistogram.Mean()))
 	return nil


### PR DESCRIPTION
* removed unused function

* don't expose uncalculated Block.TxnsMap

* store values in binary form throughout MPT

* compute TxnMap in-thread