### PR TITLE
Remove "0chain.net/chaincore/chain" dependancy from storagesc

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -364,7 +364,7 @@ func (sc *StorageSmartContract) commitBlobberRead(t *transaction.Transaction,
 		lastKnownCtr = lastCommittedRM.ReadMarker.ReadCounter
 	}
 
-	err = commitRead.ReadMarker.Verify(lastCommittedRM.ReadMarker)
+	err = commitRead.ReadMarker.Verify(lastCommittedRM.ReadMarker, balances)
 	if err != nil {
 		return "", common.NewErrorf("commit_blobber_read",
 			"can't verify read marker: %v", err)
@@ -410,7 +410,7 @@ func (sc *StorageSmartContract) commitBlobberRead(t *transaction.Transaction,
 	)
 
 	// if 3rd party pays
-	err = commitRead.ReadMarker.verifyAuthTicket(alloc, t.CreationDate)
+	err = commitRead.ReadMarker.verifyAuthTicket(alloc, t.CreationDate, balances)
 	if err != nil {
 		return "", common.NewError("commit_blobber_read", err.Error())
 	}
@@ -586,7 +586,7 @@ func (sc *StorageSmartContract) commitBlobberConnection(
 
 	detailsBytes, err := json.Marshal(details)
 
-	if !commitConnection.WriteMarker.VerifySignature(alloc.OwnerPublicKey) {
+	if !commitConnection.WriteMarker.VerifySignature(alloc.OwnerPublicKey, balances) {
 		return "", common.NewError("commit_connection_failed",
 			"Invalid signature for write marker")
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -383,7 +383,7 @@ func (sc *StorageSmartContract) verifyChallenge(t *transaction.Transaction,
 	)
 	for _, vt := range challResp.ValidationTickets {
 		if vt != nil {
-			if ok, err := vt.VerifySign(); !ok || err != nil {
+			if ok, err := vt.VerifySign(balances); !ok || err != nil {
 				continue
 			}
 

--- a/code/go/0chain.net/smartcontract/storagesc/free_allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/free_allocation_test.go
@@ -1,21 +1,22 @@
 package storagesc
 
 import (
-	"0chain.net/chaincore/chain"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+
 	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/mocks"
 	sci "0chain.net/chaincore/smartcontractinterface"
 	"0chain.net/chaincore/state"
 	"0chain.net/chaincore/transaction"
 	"0chain.net/core/common"
+	"0chain.net/core/encryption"
 	"0chain.net/core/util"
-	"encoding/hex"
-	"encoding/json"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"strconv"
-	"testing"
-	"time"
 )
 
 func TestAddFreeStorageAssigner(t *testing.T) {
@@ -385,6 +386,10 @@ func TestFreeAllocationRequest(t *testing.T) {
 		).Return(&allocation, nil).Once()
 
 		balances.On(
+			"GetSignatureScheme",
+		).Return(encryption.NewBLS0ChainScheme()).Once()
+
+		balances.On(
 			"AddMint", &state.Mint{
 				Minter:     ADDRESS,
 				ToClientID: ADDRESS,
@@ -702,6 +707,10 @@ func TestUpdateFreeStorageRequest(t *testing.T) {
 		).Return(&challengePool{}, nil).Once()
 
 		balances.On(
+			"GetSignatureScheme",
+		).Return(encryption.NewBLS0ChainScheme()).Once()
+
+		balances.On(
 			"InsertTrieNode",
 			freeStorageAssignerKey(ssc.ID, p.marker.Assigner),
 			&freeStorageAssigner{
@@ -872,7 +881,7 @@ func signFreeAllocationMarker(t *testing.T, frm freeStorageMarker) (string, stri
 	}
 	responseBytes, err := json.Marshal(&request)
 	require.NoError(t, err)
-	signatureScheme := chain.GetServerChain().GetSignatureScheme()
+	signatureScheme := encryption.NewBLS0ChainScheme()
 	err = signatureScheme.GenerateKeys()
 	require.NoError(t, err)
 	signature, err := signatureScheme.Sign(hex.EncodeToString(responseBytes))

--- a/code/go/0chain.net/smartcontract/storagesc/helper2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/helper2_test.go
@@ -1,6 +1,8 @@
 package storagesc
 
 import (
+	"time"
+
 	"0chain.net/chaincore/block"
 	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/state"
@@ -9,7 +11,6 @@ import (
 	"0chain.net/core/datastore"
 	"0chain.net/core/encryption"
 	"0chain.net/core/util"
-	"time"
 )
 
 type mockStateContext struct {
@@ -38,12 +39,14 @@ var (
 	storageScId = approvedMinters[2]
 )
 
-func (sc *mockStateContext) SetMagicBlock(_ *block.MagicBlock)                     { return }
-func (sc *mockStateContext) GetState() util.MerklePatriciaTrieI                    { return nil }
-func (sc *mockStateContext) GetTransaction() *transaction.Transaction              { return nil }
-func (sc *mockStateContext) GetSignedTransfers() []*state.SignedTransfer           { return nil }
-func (sc *mockStateContext) Validate() error                                       { return nil }
-func (sc *mockStateContext) GetSignatureScheme() encryption.SignatureScheme        { return nil }
+func (sc *mockStateContext) SetMagicBlock(_ *block.MagicBlock)           { return }
+func (sc *mockStateContext) GetState() util.MerklePatriciaTrieI          { return nil }
+func (sc *mockStateContext) GetTransaction() *transaction.Transaction    { return nil }
+func (sc *mockStateContext) GetSignedTransfers() []*state.SignedTransfer { return nil }
+func (sc *mockStateContext) Validate() error                             { return nil }
+func (sc *mockStateContext) GetSignatureScheme() encryption.SignatureScheme {
+	return encryption.NewBLS0ChainScheme()
+}
 func (sc *mockStateContext) AddSignedTransfer(_ *state.SignedTransfer)             { return }
 func (sc *mockStateContext) DeleteTrieNode(_ datastore.Key) (datastore.Key, error) { return "", nil }
 func (sc *mockStateContext) GetChainCurrentMagicBlock() *block.MagicBlock          { return nil }

--- a/code/go/0chain.net/smartcontract/storagesc/helper_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/helper_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"0chain.net/chaincore/chain"
 	chainState "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/smartcontractinterface"
 	"0chain.net/chaincore/state"
@@ -32,9 +31,6 @@ func toks(val state.Balance) string {
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
-	chain.ServerChain = new(chain.Chain)
-	chain.ServerChain.Config = new(chain.Config)
-	chain.ServerChain.ClientSignatureScheme = "bls0chain"
 
 	logging.Logger = zap.NewNop()
 }

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -11,7 +11,7 @@ import (
 
 	chainstate "0chain.net/chaincore/chain/state"
 
-	"0chain.net/chaincore/chain"
+	//"0chain.net/chaincore/chain"
 	"0chain.net/chaincore/node"
 	"0chain.net/chaincore/state"
 	"0chain.net/core/common"
@@ -1024,10 +1024,13 @@ type WriteMarker struct {
 	Signature              string           `json:"signature"`
 }
 
-func (wm *WriteMarker) VerifySignature(clientPublicKey string) bool {
+func (wm *WriteMarker) VerifySignature(
+	clientPublicKey string,
+	balances chainstate.StateContextI,
+) bool {
 	hashData := wm.GetHashData()
 	signatureHash := encryption.Hash(hashData)
-	signatureScheme := chain.GetServerChain().GetSignatureScheme()
+	signatureScheme := balances.GetSignatureScheme()
 	signatureScheme.SetPublicKey(clientPublicKey)
 	sigOK, err := signatureScheme.Verify(wm.Signature, signatureHash)
 	if err != nil {
@@ -1107,8 +1110,12 @@ func (at *AuthTicket) getHashData() string {
 	return hashData
 }
 
-func (at *AuthTicket) verify(alloc *StorageAllocation, now common.Timestamp,
-	clientID string) (err error) {
+func (at *AuthTicket) verify(
+	alloc *StorageAllocation,
+	now common.Timestamp,
+	clientID string,
+	balances chainstate.StateContextI,
+) (err error) {
 
 	if at.AllocationID != alloc.ID {
 		return common.NewError("invalid_read_marker",
@@ -1135,10 +1142,8 @@ func (at *AuthTicket) verify(alloc *StorageAllocation, now common.Timestamp,
 			"Invalid auth ticket. Timestamp in future")
 	}
 
-	var (
-		ssn = chain.GetServerChain().ClientSignatureScheme
-		ss  = encryption.GetSignatureScheme(ssn)
-	)
+	var ss = balances.GetSignatureScheme()
+
 	if err = ss.SetPublicKey(alloc.OwnerPublicKey); err != nil {
 		return common.NewErrorf("invalid_read_marker",
 			"setting owner public key: %v", err)
@@ -1169,10 +1174,10 @@ type ReadMarker struct {
 	AuthTicket      *AuthTicket      `json:"auth_ticket"`
 }
 
-func (rm *ReadMarker) VerifySignature(clientPublicKey string) bool {
+func (rm *ReadMarker) VerifySignature(clientPublicKey string, balances chainstate.StateContextI) bool {
 	hashData := rm.GetHashData()
 	signatureHash := encryption.Hash(hashData)
-	signatureScheme := chain.GetServerChain().GetSignatureScheme()
+	signatureScheme := balances.GetSignatureScheme()
 	signatureScheme.SetPublicKey(clientPublicKey)
 	sigOK, err := signatureScheme.Verify(rm.Signature, signatureHash)
 	if err != nil {
@@ -1184,9 +1189,11 @@ func (rm *ReadMarker) VerifySignature(clientPublicKey string) bool {
 	return true
 }
 
-func (rm *ReadMarker) verifyAuthTicket(alloc *StorageAllocation,
-	now common.Timestamp) (err error) {
-
+func (rm *ReadMarker) verifyAuthTicket(
+	alloc *StorageAllocation,
+	now common.Timestamp,
+	balances chainstate.StateContextI,
+) (err error) {
 	// owner downloads, pays itself, no ticket needed
 	if rm.PayerID == alloc.Owner {
 		return
@@ -1195,7 +1202,7 @@ func (rm *ReadMarker) verifyAuthTicket(alloc *StorageAllocation,
 	if rm.AuthTicket == nil {
 		return common.NewError("invalid_read_marker", "missing auth. ticket")
 	}
-	return rm.AuthTicket.verify(alloc, now, rm.PayerID)
+	return rm.AuthTicket.verify(alloc, now, rm.PayerID, balances)
 }
 
 func (rm *ReadMarker) GetHashData() string {
@@ -1205,8 +1212,7 @@ func (rm *ReadMarker) GetHashData() string {
 	return hashData
 }
 
-func (rm *ReadMarker) Verify(prevRM *ReadMarker) error {
-
+func (rm *ReadMarker) Verify(prevRM *ReadMarker, balances chainstate.StateContextI) error {
 	if rm.ReadCounter <= 0 || len(rm.BlobberID) == 0 || len(rm.ClientID) == 0 ||
 		rm.Timestamp == 0 {
 
@@ -1224,7 +1230,7 @@ func (rm *ReadMarker) Verify(prevRM *ReadMarker) error {
 		}
 	}
 
-	if ok := rm.VerifySignature(rm.ClientPublicKey); ok {
+	if ok := rm.VerifySignature(rm.ClientPublicKey, balances); ok {
 		return nil
 	}
 
@@ -1244,11 +1250,11 @@ type ValidationTicket struct {
 	Signature    string           `json:"signature"`
 }
 
-func (vt *ValidationTicket) VerifySign() (bool, error) {
+func (vt *ValidationTicket) VerifySign(balances chainstate.StateContextI) (bool, error) {
 	hashData := fmt.Sprintf("%v:%v:%v:%v:%v:%v", vt.ChallengeID, vt.BlobberID,
 		vt.ValidatorID, vt.ValidatorKey, vt.Result, vt.Timestamp)
 	hash := encryption.Hash(hashData)
-	signatureScheme := chain.GetServerChain().GetSignatureScheme()
+	signatureScheme := balances.GetSignatureScheme()
 	signatureScheme.SetPublicKey(vt.ValidatorKey)
 	verified, err := signatureScheme.Verify(vt.Signature, hash)
 	return verified, err
@@ -1260,7 +1266,7 @@ type StorageStats struct {
 	LastChallengedTime common.Timestamp        `json:"last_challenged_time"`
 }
 
-func (sn *StorageStats) GetKey(globalKey string) datastore.Key {
+func (sn *StorageStats) GetKey(_ string) datastore.Key {
 	return STORAGE_STATS_KEY
 }
 

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	chainstate "0chain.net/chaincore/chain/state"
-
-	//"0chain.net/chaincore/chain"
 	"0chain.net/chaincore/node"
 	"0chain.net/chaincore/state"
 	"0chain.net/core/common"


### PR DESCRIPTION
storagesc should not require a running chain, so should not import `"0chain.net/chaincore/chain"`. The problem is that in some places `chain.GetServerChain().GetSignatureScheme()` was used to get the signature scheme rather than `balances.GetSignatureScheme()`. This fixes that.

Some upcoming PRs will need this change, either because there is no chain (benchmarks https://github.com/0chain/0chain/pull/503 & https://github.com/0chain/0chain/pull/515) or to stop cyclic dependencies https://github.com/0chain/0chain/pull/528. 