### PR TITLE
Fix txn_output json from TransactionConfirmationHandler response 

### DIFF
--- a/code/go/0chain.net/sharder/handler_main.go
+++ b/code/go/0chain.net/sharder/handler_main.go
@@ -4,6 +4,7 @@ package sharder
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"0chain.net/core/datastore"
@@ -15,6 +16,7 @@ import (
 /*TransactionConfirmationHandler - given a transaction hash, confirm it's presence in a block */
 func TransactionConfirmationHandler(ctx context.Context, r *http.Request) (interface{}, error) {
 	hash := r.FormValue("hash")
+	fmt.Println("Hash", hash)
 	if hash == "" {
 		return nil, common.InvalidRequest("transaction hash (parameter hash) is required")
 	}
@@ -22,14 +24,24 @@ func TransactionConfirmationHandler(ctx context.Context, r *http.Request) (inter
 	if content == "" {
 		content = "confirmation"
 	}
+
 	transactionConfirmationEntityMetadata := datastore.GetEntityMetadata("txn_confirmation")
+	fmt.Println("txn meta", transactionConfirmationEntityMetadata)
+
 	ctx = persistencestore.WithEntityConnection(ctx, transactionConfirmationEntityMetadata)
+	fmt.Println("ctx", ctx)
+
 	defer persistencestore.Close(ctx)
+
 	sc := GetSharderChain()
+	fmt.Println("Sharder chain", sc)
 	confirmation, err := sc.GetTransactionConfirmation(ctx, hash)
+	fmt.Println("confirmation", confirmation)
+
 	if content == "confirmation" {
 		return confirmation, err
 	}
+
 	data := make(map[string]interface{}, 2)
 	if err == nil {
 		data["confirmation"] = confirmation

--- a/code/go/0chain.net/sharder/transaction.go
+++ b/code/go/0chain.net/sharder/transaction.go
@@ -39,6 +39,8 @@ func (sc *Chain) GetTransactionSummary(ctx context.Context, hash string) (*trans
 func (sc *Chain) GetTransactionConfirmation(ctx context.Context, hash string) (*transaction.Confirmation, error) {
 	var ts *transaction.TransactionSummary
 	t, err := sc.BlockTxnCache.Get(hash)
+	fmt.Println("BlockTxnCache", t, err)
+
 	if err != nil {
 		ts, err = sc.GetTransactionSummary(ctx, hash)
 		if err != nil {
@@ -49,6 +51,7 @@ func (sc *Chain) GetTransactionConfirmation(ctx context.Context, hash string) (*
 	}
 	confirmation := datastore.GetEntityMetadata("txn_confirmation").Instance().(*transaction.Confirmation)
 	confirmation.Hash = hash
+	fmt.Println("GetEntityMetadata", confirmation)
 	bhash, err := sc.GetBlockHash(ctx, ts.Round)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I'm writing my first Go PR to try and fix this issue #415.

To fix it, I wanted to run unit tests for the handler, update the code and then run the tests again, to make sure it is fine.
As there were no unit test for the handler, I wrote one, copying from other tests the best I can, although I have a very shallow understanding of the whole 0chain code.

I have been able to fmt.Println through the code to create a block, create a test sharder chain and add the block to the chain. But when reaching [this line](https://github.com/0chain/0chain/blob/fix-txnconfirmation-resp-json/code/go/0chain.net/sharder/transaction.go#L41-L42), on the `sc.BlockTxnCache.Get(hash)` call, I get the following error:

`missing key: key not found`

What am I missing?