### PR TITLE
Benchmark control tests

### DIFF
--- a/code/go/0chain.net/smartcontract/benchmark/benchmark.go
+++ b/code/go/0chain.net/smartcontract/benchmark/benchmark.go
@@ -23,6 +23,7 @@ const (
 	Vesting
 	VestingRest
 	MultiSig
+	Control
 	NumberOdfBenchmarkSources
 )
 
@@ -39,6 +40,7 @@ var (
 		"vesting",
 		"vesting_rest",
 		"multi_sig",
+		"control",
 	}
 
 	BenchmarkSourceCode = map[string]BenchmarkSource{
@@ -53,6 +55,7 @@ var (
 		BenchmarkSourceNames[Vesting]:          Vesting,
 		BenchmarkSourceNames[VestingRest]:      VestingRest,
 		BenchmarkSourceNames[MultiSig]:         MultiSig,
+		BenchmarkSourceNames[Control]:          Control,
 	}
 )
 
@@ -104,6 +107,8 @@ const (
 	Satisfactory            = Internal + "satisfactory"
 	TimeUnit                = Internal + "time_unit"
 	Colour                  = Internal + "colour"
+	ControlM                = Internal + "control_m"
+	ControlN                = Internal + "control_n"
 
 	OptionVerbose      = Options + "verbose"
 	OptionTestSuites   = Options + "test_suites"

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/command.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/command.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"time"
 
+	"0chain.net/smartcontract/benchmark/main/cmd/control"
+
 	"0chain.net/chaincore/node"
 	"0chain.net/core/logging"
 	bk "0chain.net/smartcontract/benchmark"
@@ -31,6 +33,7 @@ var benchmarkSources = map[bk.BenchmarkSource]func(data bk.BenchData, sigScheme 
 	bk.Vesting:          vestingsc.BenchmarkTests,
 	bk.VestingRest:      vestingsc.BenchmarkRestTests,
 	bk.MultiSig:         multisigsc.BenchmarkTests,
+	bk.Control:          control.BenchmarkTests,
 }
 
 func init() {

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/control/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/control/benchmark_setup.go
@@ -1,0 +1,97 @@
+package control
+
+import (
+	"encoding/json"
+	"strconv"
+
+	cstate "0chain.net/chaincore/chain/state"
+	"0chain.net/core/datastore"
+	"0chain.net/core/encryption"
+	bk "0chain.net/smartcontract/benchmark"
+	"github.com/spf13/viper"
+)
+
+var (
+	controlMKey = datastore.Key("6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7" + encryption.Hash("control_all"))
+)
+
+func getControlMKey(index int) datastore.Key {
+	return datastore.Key("6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7" +
+		encryption.Hash("control_m"+strconv.Itoa(index)))
+}
+
+func getControlNKey(index int) datastore.Key {
+	return datastore.Key("6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7" +
+		encryption.Hash("control_n"+strconv.Itoa(index)))
+}
+
+type item struct {
+	Field int64 `json:"field"`
+}
+
+func (i *item) Encode() []byte {
+	var b, err = json.Marshal(i)
+	if err != nil {
+		panic(err) // must never happens
+	}
+	return b
+}
+
+func (i *item) Decode(p []byte) error {
+	return json.Unmarshal(p, i)
+}
+
+type itemArray struct {
+	Fields []int64 `json:"fields"`
+}
+
+func (is *itemArray) Encode() []byte {
+	var b, err = json.Marshal(is)
+	if err != nil {
+		panic(err) // must never happens
+	}
+	return b
+}
+
+func (is *itemArray) Decode(p []byte) error {
+	return json.Unmarshal(p, is)
+}
+
+func AddControlObjects(
+	balances cstate.StateContextI,
+) {
+	m := viper.GetInt(bk.ControlM)
+	n := viper.GetInt(bk.ControlN)
+	if m == 0 || n > m {
+		return
+	}
+	fields := make([]int64, m, m)
+	for i := 0; i < m; i++ {
+		fields[i] = int64(i)
+	}
+
+	_, err := balances.InsertTrieNode(controlMKey, &itemArray{
+		Fields: fields,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	for i := 0; i < n; i++ {
+		_, err := balances.InsertTrieNode(getControlNKey(i), &item{
+			Field: int64(i),
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	for i := 0; i < n; i++ {
+		_, err := balances.InsertTrieNode(getControlNKey(i), &item{
+			Field: int64(i),
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/control/benchmark_tests.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/control/benchmark_tests.go
@@ -1,0 +1,121 @@
+package control
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"0chain.net/smartcontract/minersc"
+
+	"0chain.net/core/common"
+
+	"github.com/spf13/viper"
+
+	cstate "0chain.net/chaincore/chain/state"
+	"0chain.net/chaincore/transaction"
+	bk "0chain.net/smartcontract/benchmark"
+)
+
+type BenchTest struct {
+	name     string
+	endpoint func(
+		cstate.StateContextI,
+	) error
+	txn   *transaction.Transaction
+	input []byte
+}
+
+func (bt BenchTest) Name() string {
+	return bt.name
+}
+
+func (bt BenchTest) Transaction() *transaction.Transaction {
+	return &transaction.Transaction{}
+}
+
+func (bt BenchTest) Run(balances cstate.StateContextI, _ *testing.B) {
+	err := bt.endpoint(balances)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func BenchmarkTests(
+	_ bk.BenchData, _ bk.SignatureScheme,
+) bk.TestSuite {
+	var tests = []BenchTest{
+		{
+			name:     "control.array." + strconv.Itoa(viper.GetInt(bk.ControlM)),
+			endpoint: controlArray,
+		},
+		{
+			name:     "control.individual." + strconv.Itoa(viper.GetInt(bk.ControlN)),
+			endpoint: controlIndividual,
+		},
+		{
+			name:     "control.all_miners." + strconv.Itoa(viper.GetInt(bk.NumMiners)),
+			endpoint: allMiners,
+		},
+	}
+	var testsI []bk.BenchTestI
+	for _, test := range tests {
+		testsI = append(testsI, test)
+	}
+	return bk.TestSuite{
+		Source:     bk.Storage,
+		Benchmarks: testsI,
+	}
+}
+
+func controlIndividual(balances cstate.StateContextI) error {
+	m := viper.GetInt(bk.ControlM)
+	n := viper.GetInt(bk.ControlN)
+	if m == 0 || n > m {
+		return nil
+	}
+
+	var itArray []item
+	for i := 0; i < n; i++ {
+		var it item
+		val, err := balances.GetTrieNode(getControlNKey(i))
+		if err != nil {
+			return err
+		}
+		if err := it.Decode(val.Encode()); err != nil {
+			return fmt.Errorf("%w: %s", common.ErrDecoding, err)
+		}
+		itArray = append(itArray, it)
+	}
+	return nil
+}
+
+func controlArray(balances cstate.StateContextI) error {
+	m := viper.GetInt(bk.ControlM)
+	n := viper.GetInt(bk.ControlN)
+	if m == 0 || n > m {
+		return nil
+	}
+
+	var ia itemArray
+	val, err := balances.GetTrieNode(controlMKey)
+	if err != nil {
+		return err
+	}
+	if err := ia.Decode(val.Encode()); err != nil {
+		return fmt.Errorf("%w: %s", common.ErrDecoding, err)
+	}
+	return nil
+}
+
+func allMiners(balances cstate.StateContextI) error {
+	nodesBytes, err := balances.GetTrieNode(minersc.AllMinersKey)
+	if err != nil {
+		return err
+	}
+
+	nodesList := &minersc.MinerNodes{}
+	if err = nodesList.Decode(nodesBytes.Encode()); err != nil {
+		return err
+	}
+	return nil
+}

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"encoding/hex"
 
+	"0chain.net/smartcontract/benchmark/main/cmd/control"
+
 	"0chain.net/smartcontract/benchmark/main/cmd/log"
 
 	"0chain.net/smartcontract/multisigsc"
@@ -149,6 +151,9 @@ func setUpMpt(
 	vestingsc.AddVestingPools(clients, balances)
 	log.Println("added vesting pools")
 	minersc.AddPhaseNode(balances)
+	log.Println("added phase node")
+	control.AddControlObjects(balances)
+	log.Println("added control objects")
 
 	return pMpt, balances.GetState().GetRoot(), benchmark.BenchData{
 		Clients:     clients,

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
@@ -112,12 +112,14 @@ func setUpMpt(
 	log.Println("created balances")
 	_ = storagesc.SetMockConfig(balances)
 	log.Println("created storage config")
-	validators := storagesc.AddMockValidators(balances)
+	validators := storagesc.AddMockValidators(publicKeys, balances)
 	log.Println("added validators")
 	blobbers := storagesc.AddMockBlobbers(balances)
 	log.Println("added blobbers")
 	stakePools := storagesc.GetMockStakePools(clients, balances)
 	log.Println("added stake pools")
+	storagesc.GetMockValidatorStakePools(clients, balances)
+	log.Println("added validator stake pools")
 	storagesc.AddMockAllocations(
 		clients, publicKeys, stakePools, blobbers, validators, balances,
 	)

--- a/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
+++ b/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
@@ -17,7 +17,7 @@ simulation:
   num_free_storage_assigners: 10
   num_vesting_destinations_client: 10
   num_write_redeem_allocation: 10
-  num_challenges_blobber: 10
+  num_challenges_blobber: 100
 
 options:
   verbose: true
@@ -124,7 +124,7 @@ internal:
   available_keys: 10
   now: 100000
   signature_scheme: bls0chain # don't change only bls0chian works
-  start_tokens: 100000000000
+  start_tokens: 100000000000000
   bad: 50ms
   worry: 10ms
   satisfactory: 1ms

--- a/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
+++ b/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
@@ -22,20 +22,9 @@ simulation:
 options:
   verbose: true
   test_suites:
-    - "control"
+    - "storage"
+    - "storage_rest"
   omitted_tests:
-    - "miner.payFees"
-    - "storage.cancel_allocation"
-    - "storage.finalize_allocation"
-    - "storage.free_allocation_request"
-    - "storage.free_update_allocation"
-    - "storage.new_allocation_request_preferred"
-    - "storage.new_allocation_request_random"
-    - "storage.update_allocation_request"
-    - "storage_rest.allocation_min_lock"
-    - "storage_rest.getStakePoolStat"
-    - "storage_rest.getUserStakePoolStat"
-    - "storage.generate_challenges"
 
 smart_contracts:
   minersc:
@@ -82,6 +71,7 @@ smart_contracts:
     failed_challenges_to_cancel: 0
     max_total_free_allocation: 10000
     max_individual_free_allocation: 170
+    max_challenges_per_generation: 100
     readpool:
       min_lock: 0.3
       min_lock_period: 1m

--- a/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
+++ b/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
@@ -1,7 +1,7 @@
 simulation:
-  num_clients: 100
-  num_miners: 100
-  num_active_miners: 25
+  num_clients: 1000
+  num_miners: 1000
+  num_active_miners: 100
   nun_sharders: 100
   num_active_sharders: 25
   num_allocations: 1000
@@ -22,17 +22,7 @@ simulation:
 options:
   verbose: true
   test_suites:
-    - "storage"
-    - "storage_rest"
-    - "miner"
-    - "miner_rest"
-    - "faucet"
-    - "faucet_rest"
-    - "interest_pool"
-    - "interest_pool_rest"
-    - "vesting"
-    - "vesting_rest"
-    - "multi_sig"
+    - "control"
   omitted_tests:
     - "miner.payFees"
     - "storage.cancel_allocation"
@@ -140,3 +130,5 @@ internal:
   satisfactory: 1ms
   time_unit: 1ms
   colour: true
+  control_m: 250000
+  control_n: 900

--- a/code/go/0chain.net/smartcontract/benchmark/main/readme.md
+++ b/code/go/0chain.net/smartcontract/benchmark/main/readme.md
@@ -8,8 +8,7 @@ MPT database is enough to give a realistic benchmark.
 
 To run
 ```bash
-go build -tags bn256
-./main benchmark | column -t -s,
+go build -tags bn256 && ./main benchmark | column -t -s,
 ```
 
 To run only a subset of the test suits

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
@@ -3,6 +3,7 @@ package storagesc
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -221,13 +222,13 @@ func BenchmarkTests(
 					Hash: encryption.Hash("mock transaction hash"),
 				},
 				ClientID: data.Clients[0],
-				Value:    100 * viper.GetInt64(bk.StorageMinAllocSize),
+				Value:    viper.GetInt64(bk.StorageMinAllocSize) * 1e10,
 			},
 			input: func() []byte {
 				bytes, _ := json.Marshal(&updateAllocationRequest{
 					ID:           getMockAllocationId(0),
 					OwnerID:      data.Clients[0],
-					Size:         100 * viper.GetInt64(bk.StorageMinAllocSize),
+					Size:         10000000,
 					Expiration:   common.Timestamp(viper.GetDuration(bk.StorageMinAllocDuration).Seconds()),
 					SetImmutable: true,
 				})
@@ -346,7 +347,7 @@ func BenchmarkTests(
 				ClientID:     data.Clients[1],
 				ToClientID:   ADDRESS,
 				CreationDate: common.Timestamp(viper.GetInt64(bk.Now)),
-				Value:        100 * viper.GetInt64(bk.StorageMinAllocSize),
+				Value:        int64(viper.GetFloat64(bk.StorageMaxIndividualFreeAllocation) * 1e10),
 			},
 			input: func() []byte {
 				var request = struct {
@@ -598,7 +599,7 @@ func BenchmarkTests(
 				bytes, _ := json.Marshal(&stakePoolRequest{
 					BlobberID: getMockBlobberId(0),
 					//PoolID:    getMockStakePoolId(0, 0, data.Clients),
-					PoolID: getMockStakePoolId(0, 0),
+					PoolID: getMockBlobberStakePoolId(0, 0),
 				})
 				return bytes
 			}(),
@@ -613,7 +614,7 @@ func BenchmarkTests(
 			input: func() []byte {
 				bytes, _ := json.Marshal(&stakePoolRequest{
 					BlobberID: getMockBlobberId(0),
-					PoolID:    getMockStakePoolId(0, 0),
+					PoolID:    getMockBlobberStakePoolId(0, 0),
 				})
 				return bytes
 			}(),
@@ -625,11 +626,44 @@ func BenchmarkTests(
 			input: func() []byte {
 				bytes, _ := json.Marshal(&stakePoolRequest{
 					BlobberID: getMockBlobberId(0),
-					PoolID:    getMockStakePoolId(0, 0),
+					PoolID:    getMockBlobberStakePoolId(0, 0),
 				})
 				return bytes
 			}(),
 		},
+		{
+			name:     "storage.challenge_response",
+			endpoint: ssc.verifyChallenge,
+			txn: &transaction.Transaction{
+				ClientID: getMockBlobberId(0),
+			},
+			input: func() []byte {
+				var validationTickets []*ValidationTicket
+				vt := &ValidationTicket{
+					ChallengeID:  getMockChallengeId(0, 0),
+					BlobberID:    getMockBlobberId(0),
+					ValidatorID:  getMockValidatorId(0),
+					ValidatorKey: data.PublicKeys[0],
+					Result:       true,
+					Message:      "mock message",
+					MessageCode:  "mock message code",
+					Timestamp:    now,
+					Signature:    "",
+				}
+				validationTickets = append(validationTickets, vt)
+				hash := encryption.Hash(fmt.Sprintf("%v:%v:%v:%v:%v:%v", vt.ChallengeID, vt.BlobberID,
+					vt.ValidatorID, vt.ValidatorKey, vt.Result, vt.Timestamp))
+				_ = sigScheme.SetPublicKey(data.PublicKeys[0])
+				sigScheme.SetPrivateKey(data.PrivateKeys[0])
+				vt.Signature, _ = sigScheme.Sign(hash)
+				bytes, _ := json.Marshal(&ChallengeResponse{
+					ID:                getMockChallengeId(0, 0),
+					ValidationTickets: validationTickets,
+				})
+				return bytes
+			}(),
+		},
+
 		{
 			name:     "storage.update_settings",
 			endpoint: ssc.updateSettings,


### PR DESCRIPTION
This adds some simple control tests to the benchmark program. One gets an array of size `contrl_m`  from the MPT, the other gets `contorl_n` int64 objects from the MPT.

Added a benchmark for challenge_resopnse, which was earlier omitted.