### PR TITLE
Remove restrictions on cancelling allocations

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
@@ -230,36 +230,6 @@ func TestCancelAllocationRequest(t *testing.T) {
 		require.True(t, strings.Contains(err.Error(), ErrCancelFailed))
 		require.True(t, strings.Contains(err.Error(), ErrExpired))
 	})
-
-	t.Run(ErrNotEnoughFailiars, func(t *testing.T) {
-		var failersScYaml = scYaml
-		failersScYaml.FailedChallengesToCancel = 29
-
-		err := testCancelAllocation(t, allocation, *blobbers, blobberStakePools, failersScYaml,
-			otherWritePools, challengePoolBalance, challenges, blobberOffer, wpBalance, thisExpires, now)
-		require.Error(t, err)
-		require.True(t, strings.Contains(err.Error(), ErrCancelFailed))
-		require.True(t, strings.Contains(err.Error(), ErrNotEnoughFailiars))
-	})
-
-	t.Run("enough failiars", func(t *testing.T) {
-		var failersScYaml = scYaml
-		failersScYaml.FailedChallengesToCancel = 28
-
-		err := testCancelAllocation(t, allocation, *blobbers, blobberStakePools, failersScYaml,
-			otherWritePools, challengePoolBalance, challenges, blobberOffer, wpBalance, thisExpires, now)
-		require.Error(t, err)
-		require.True(t, strings.Contains(err.Error(), ErrCancelFailed))
-		require.True(t, strings.Contains(err.Error(), ErrNotEnoughFailiars))
-	})
-
-	t.Run(ErrNotEnoughLock, func(t *testing.T) {
-		var zeroChallengePoolBalance int64 = 0
-
-		err := testCancelAllocation(t, allocation, *blobbers, blobberStakePools, scYaml,
-			otherWritePools, zeroChallengePoolBalance, challenges, blobberOffer, wpBalance, thisExpires, now)
-		require.NoError(t, err)
-	})
 }
 
 func TestFinalizeAllocation(t *testing.T) {

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1224,19 +1224,6 @@ func (sc *StorageSmartContract) cancelAllocationRequest(
 		return "", common.NewError("alloc_cancel_failed",
 			"calculating rest challenges success/fail rates: "+err.Error())
 	}
-	// SC configurations
-	var conf *scConfig
-	if conf, err = sc.getConfig(balances, false); err != nil {
-		return "", common.NewError("alloc_cancel_failed",
-			"can't get SC configurations: "+err.Error())
-	}
-
-	if fctc := conf.FailedChallengesToCancel; fctc > 0 {
-		if alloc.Stats == nil || alloc.Stats.FailedChallenges < int64(fctc) {
-			return "", common.NewError("alloc_cancel_failed",
-				"not enough failed challenges of allocation to cancel")
-		}
-	}
 
 	// can cancel
 	// new values


### PR DESCRIPTION
Allocations can always be cancelled independently of challenges.