### PR TITLE
Split StateContextI

### DIFF
--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -140,6 +140,17 @@ func (c *Chain) NewStateContext(b *block.Block, s util.MerklePatriciaTrieI,
 		c.GetSignatureScheme)
 }
 
+func (c *Chain) NewRestStateContext(b *block.Block, s util.MerklePatriciaTrieI,
+	txn *transaction.Transaction) (balances bcstate.RestStateContextI) {
+
+	return bcstate.NewRestStateContext(b, s, c.clientStateDeserializer,
+		txn,
+		c.GetBlockSharders,
+		c.GetLatestFinalizedMagicBlock,
+		c.GetCurrentMagicBlock,
+		c.GetSignatureScheme)
+}
+
 func (c *Chain) updateState(ctx context.Context, b *block.Block, txn *transaction.Transaction) (
 	err error) {
 

--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -53,6 +53,7 @@ type StateContextI interface {
 }
 
 type ReadOnlyStateContextI interface {
+	GetBlock() *block.Block
 	GetTrieNode(key datastore.Key) (util.Serializable, error)
 }
 

--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -53,12 +53,12 @@ type StateContextI interface {
 }
 
 type ReadOnlyStateContextI interface {
-	GetBlock() *block.Block
 	GetTrieNode(key datastore.Key) (util.Serializable, error)
 }
 
 type RestStateContextI interface {
 	ReadOnlyStateContextI
+	GetBlock() *block.Block
 }
 
 //StateContext - a context object used to manipulate global state

--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -52,6 +52,15 @@ type StateContextI interface {
 	GetSignatureScheme() encryption.SignatureScheme
 }
 
+type ReadOnlyStateContextI interface {
+	GetBlock() *block.Block
+	GetTrieNode(key datastore.Key) (util.Serializable, error)
+}
+
+type RestStateContextI interface {
+	ReadOnlyStateContextI
+}
+
 //StateContext - a context object used to manipulate global state
 type StateContext struct {
 	block                         *block.Block
@@ -65,6 +74,10 @@ type StateContext struct {
 	getLastestFinalizedMagicBlock func() *block.Block
 	getChainCurrentMagicBlock     func() *block.MagicBlock
 	getSignature                  func() encryption.SignatureScheme
+}
+
+type RestStateContext struct {
+	*StateContext
 }
 
 // NewStateContext - create a new state context
@@ -89,6 +102,25 @@ func NewStateContext(
 		getLastestFinalizedMagicBlock: getLastestFinalizedMagicBlock,
 		getChainCurrentMagicBlock:     getChainCurrentMagicBlock,
 		getSignature:                  getChainSignature,
+	}
+}
+
+func NewRestStateContext(
+	b *block.Block,
+	s util.MerklePatriciaTrieI,
+	csd state.DeserializerI,
+	t *transaction.Transaction,
+	getSharderFunc func(*block.Block) []string,
+	getLastestFinalizedMagicBlock func() *block.Block,
+	getChainCurrentMagicBlock func() *block.MagicBlock,
+	getChainSignature func() encryption.SignatureScheme,
+) (
+	balances RestStateContextI,
+) {
+	return &RestStateContext{
+		StateContext: NewStateContext(
+			b, s, csd, t, getSharderFunc, getLastestFinalizedMagicBlock, getChainCurrentMagicBlock, getChainSignature,
+		),
 	}
 }
 

--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -58,7 +58,6 @@ type ReadOnlyStateContextI interface {
 
 type RestStateContextI interface {
 	ReadOnlyStateContextI
-	GetBlock() *block.Block
 }
 
 //StateContext - a context object used to manipulate global state

--- a/code/go/0chain.net/chaincore/chain/state_handler.go
+++ b/code/go/0chain.net/chaincore/chain/state_handler.go
@@ -63,7 +63,7 @@ func (c *Chain) GetSCRestOutput(ctx context.Context, r *http.Request) (interface
 		return nil, common.NewError("empty_lfb", "empty latest finalized block or state")
 	}
 	clientState := CreateTxnMPT(lfb.ClientState) // begin transaction
-	sctx := c.NewStateContext(lfb, clientState, &transaction.Transaction{})
+	sctx := c.NewRestStateContext(lfb, clientState, &transaction.Transaction{})
 	resp, err := smartcontract.ExecuteRestAPI(ctx, scAddress, scRestPath, r.URL.Query(), sctx)
 
 	if err != nil {

--- a/code/go/0chain.net/chaincore/chain/state_handler_test.go
+++ b/code/go/0chain.net/chaincore/chain/state_handler_test.go
@@ -1366,7 +1366,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 			wantStatus:     http.StatusNotFound,
 		},
 		{
-			name:  "Storagesc_/getStakePoolStat_No_Config_404",
+			name:  "Storagesc_/getStakePoolStat_No_Config_500",
 			chain: serverChain,
 			args: args{
 				w: httptest.NewRecorder(),
@@ -1378,10 +1378,10 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 				}(),
 			},
 			setValidConfig: true,
-			wantStatus:     http.StatusNotFound,
+			wantStatus:     http.StatusInternalServerError,
 		},
 		{
-			name: "Storagesc_/getStakePoolStat_No_Blobber_404",
+			name: "Storagesc_/getStakePoolStat_No_Blobber_500",
 			chain: func() *chain.Chain {
 				blob, err := json.Marshal(&scConfig{})
 				if err != nil {
@@ -1466,7 +1466,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 			wantStatus:     http.StatusNotFound,
 		},
 		{
-			name:  "Storagesc_/getUserStakePoolStat_No_Config_404",
+			name:  "Storagesc_/getUserStakePoolStat_No_Config_500",
 			chain: serverChain,
 			args: args{
 				w: httptest.NewRecorder(),
@@ -1478,7 +1478,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 				}(),
 			},
 			setValidConfig: true,
-			wantStatus:     http.StatusNotFound,
+			wantStatus:     http.StatusInternalServerError,
 		},
 		{
 			name: "Storagesc_/getUserStakePoolStat_No_User_Stake_Pool_404",

--- a/code/go/0chain.net/chaincore/chain/state_handler_test.go
+++ b/code/go/0chain.net/chaincore/chain/state_handler_test.go
@@ -1366,7 +1366,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 			wantStatus:     http.StatusNotFound,
 		},
 		{
-			name:  "Storagesc_/getStakePoolStat_No_Config_500",
+			name:  "Storagesc_/getStakePoolStat_No_Config_404",
 			chain: serverChain,
 			args: args{
 				w: httptest.NewRecorder(),
@@ -1378,10 +1378,10 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 				}(),
 			},
 			setValidConfig: true,
-			wantStatus:     http.StatusInternalServerError,
+			wantStatus:     http.StatusNotFound,
 		},
 		{
-			name: "Storagesc_/getStakePoolStat_No_Blobber_500",
+			name: "Storagesc_/getStakePoolStat_No_Blobber_404",
 			chain: func() *chain.Chain {
 				blob, err := json.Marshal(&scConfig{})
 				if err != nil {
@@ -1466,7 +1466,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 			wantStatus:     http.StatusNotFound,
 		},
 		{
-			name:  "Storagesc_/getUserStakePoolStat_No_Config_500",
+			name:  "Storagesc_/getUserStakePoolStat_No_Config_404",
 			chain: serverChain,
 			args: args{
 				w: httptest.NewRecorder(),
@@ -1478,7 +1478,7 @@ func TestChain_HandleSCRest_Status(t *testing.T) {
 				}(),
 			},
 			setValidConfig: true,
-			wantStatus:     http.StatusInternalServerError,
+			wantStatus:     http.StatusNotFound,
 		},
 		{
 			name: "Storagesc_/getUserStakePoolStat_No_User_Stake_Pool_404",

--- a/code/go/0chain.net/chaincore/smartcontract/handler.go
+++ b/code/go/0chain.net/chaincore/smartcontract/handler.go
@@ -21,7 +21,7 @@ import (
 var ContractMap = map[string]sci.SmartContractInterface{}
 
 //ExecuteRestAPI - executes the rest api on the smart contract
-func ExecuteRestAPI(ctx context.Context, scAdress string, restpath string, params url.Values, balances c_state.StateContextI) (interface{}, error) {
+func ExecuteRestAPI(ctx context.Context, scAdress string, restpath string, params url.Values, balances c_state.RestStateContextI) (interface{}, error) {
 	scI := getSmartContract(scAdress)
 	if scI != nil {
 		//add bc context here

--- a/code/go/0chain.net/chaincore/smartcontractinterface/interface.go
+++ b/code/go/0chain.net/chaincore/smartcontractinterface/interface.go
@@ -11,7 +11,7 @@ import (
 
 const Seperator = ":"
 
-type SmartContractRestHandler func(ctx context.Context, params url.Values, balances c_state.StateContextI) (interface{}, error)
+type SmartContractRestHandler func(ctx context.Context, params url.Values, balances c_state.RestStateContextI) (interface{}, error)
 
 type SmartContract struct {
 	ID                          string

--- a/code/go/0chain.net/smartcontract/faucetsc/benchmark_rest_tests.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/benchmark_rest_tests.go
@@ -17,7 +17,7 @@ type RestBenchTest struct {
 	endpoint func(
 		context.Context,
 		url.Values,
-		cstate.StateContextI,
+		cstate.RestStateContextI,
 	) (interface{}, error)
 	params url.Values
 }

--- a/code/go/0chain.net/smartcontract/faucetsc/handler.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/handler.go
@@ -22,7 +22,7 @@ const (
 	noClient        = "can't get client"
 )
 
-func (fc *FaucetSmartContract) personalPeriodicLimit(_ context.Context, params url.Values, balances c_state.StateContextI) (interface{}, error) {
+func (fc *FaucetSmartContract) personalPeriodicLimit(_ context.Context, params url.Values, balances c_state.RestStateContextI) (interface{}, error) {
 	gn, err := fc.getGlobalNode(balances)
 	if err != nil {
 		return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, noLimitsMsg, noGlobalNodeMsg)
@@ -43,7 +43,7 @@ func (fc *FaucetSmartContract) personalPeriodicLimit(_ context.Context, params u
 	return resp, nil
 }
 
-func (fc *FaucetSmartContract) globalPeriodicLimit(_ context.Context, _ url.Values, balances c_state.StateContextI) (interface{}, error) {
+func (fc *FaucetSmartContract) globalPeriodicLimit(_ context.Context, _ url.Values, balances c_state.RestStateContextI) (interface{}, error) {
 	gn, err := fc.getGlobalNode(balances)
 	if err != nil || gn == nil {
 		return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, noLimitsMsg, noGlobalNodeMsg)
@@ -60,7 +60,7 @@ func (fc *FaucetSmartContract) globalPeriodicLimit(_ context.Context, _ url.Valu
 	return resp, nil
 }
 
-func (fc *FaucetSmartContract) pourAmount(_ context.Context, _ url.Values, balances c_state.StateContextI) (interface{}, error) {
+func (fc *FaucetSmartContract) pourAmount(_ context.Context, _ url.Values, balances c_state.RestStateContextI) (interface{}, error) {
 	gn, err := fc.getGlobalNode(balances)
 	if err != nil {
 		return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, "can't get pour amount", noGlobalNodeMsg)
@@ -71,7 +71,7 @@ func (fc *FaucetSmartContract) pourAmount(_ context.Context, _ url.Values, balan
 func (fc *FaucetSmartContract) getConfigHandler(
 	_ context.Context,
 	_ url.Values,
-	balances c_state.StateContextI,
+	balances c_state.RestStateContextI,
 ) (interface{}, error) {
 	gn, err := fc.getGlobalNode(balances)
 	if err != nil && err != util.ErrValueNotPresent {

--- a/code/go/0chain.net/smartcontract/faucetsc/sc.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/sc.go
@@ -172,7 +172,7 @@ func (fc *FaucetSmartContract) refill(t *transaction.Transaction, balances c_sta
 	return "", common.NewError("broke", "it seems you're broke and can't transfer money")
 }
 
-func (fc *FaucetSmartContract) getUserNode(id string, globalKey string, balances c_state.StateContextI) (*UserNode, error) {
+func (fc *FaucetSmartContract) getUserNode(id string, globalKey string, balances c_state.ReadOnlyStateContextI) (*UserNode, error) {
 	un := &UserNode{ID: id}
 	us, err := balances.GetTrieNode(un.GetKey(globalKey))
 	if err != nil {
@@ -197,7 +197,7 @@ func (fc *FaucetSmartContract) getUserVariables(t *transaction.Transaction, gn *
 	return un
 }
 
-func (fc *FaucetSmartContract) getGlobalNode(balances c_state.StateContextI) (*GlobalNode, error) {
+func (fc *FaucetSmartContract) getGlobalNode(balances c_state.ReadOnlyStateContextI) (*GlobalNode, error) {
 	gn := &GlobalNode{ID: fc.ID}
 	gv, err := balances.GetTrieNode(gn.GetKey())
 	if err != nil {

--- a/code/go/0chain.net/smartcontract/interestpoolsc/benchmark_rest_tests.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/benchmark_rest_tests.go
@@ -17,7 +17,7 @@ type RestBenchTest struct {
 	endpoint func(
 		context.Context,
 		url.Values,
-		cstate.StateContextI,
+		cstate.RestStateContextI,
 	) (interface{}, error)
 	params url.Values
 }

--- a/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/handler.go
@@ -13,8 +13,8 @@ import (
 	c_state "0chain.net/chaincore/chain/state"
 )
 
-func (ip *InterestPoolSmartContract) getConfig(_ context.Context, _ url.Values, balances c_state.StateContextI) (interface{}, error) {
-	gn := ip.getGlobalNode(balances, "funcName")
+func (ip *InterestPoolSmartContract) getConfig(_ context.Context, _ url.Values, balances c_state.RestStateContextI) (interface{}, error) {
+	gn := ip.getGlobalNodeReadOnly(balances, "funcName")
 	const pfx = "smart_contracts.interestpoolsc."
 	return &smartcontract.StringMap{
 		Fields: map[string]string{
@@ -26,7 +26,7 @@ func (ip *InterestPoolSmartContract) getConfig(_ context.Context, _ url.Values, 
 	}, nil
 }
 
-func (ip *InterestPoolSmartContract) getPoolsStats(_ context.Context, params url.Values, balances c_state.StateContextI) (interface{}, error) {
+func (ip *InterestPoolSmartContract) getPoolsStats(_ context.Context, params url.Values, balances c_state.RestStateContextI) (interface{}, error) {
 	un := ip.getUserNode(params.Get("client_id"), balances)
 	if len(un.Pools) == 0 {
 		return nil, common.NewErrNoResource("can't find user node")
@@ -58,6 +58,6 @@ func (ip *InterestPoolSmartContract) getPoolStats(pool *interestPool, t time.Tim
 	return stat, nil
 }
 
-func (ip *InterestPoolSmartContract) getLockConfig(_ context.Context, _ url.Values, balances c_state.StateContextI) (interface{}, error) {
-	return ip.getGlobalNode(balances, "updateVariables"), nil
+func (ip *InterestPoolSmartContract) getLockConfig(_ context.Context, _ url.Values, balances c_state.RestStateContextI) (interface{}, error) {
+	return ip.getGlobalNodeReadOnly(balances, "updateVariables"), nil
 }

--- a/code/go/0chain.net/smartcontract/minersc/benchmark_rest_tests.go
+++ b/code/go/0chain.net/smartcontract/minersc/benchmark_rest_tests.go
@@ -17,7 +17,7 @@ type RestBenchTest struct {
 	endpoint func(
 		context.Context,
 		url.Values,
-		cstate.StateContextI,
+		cstate.RestStateContextI,
 	) (interface{}, error)
 	params url.Values
 }

--- a/code/go/0chain.net/smartcontract/minersc/dkg.go
+++ b/code/go/0chain.net/smartcontract/minersc/dkg.go
@@ -202,7 +202,7 @@ func (msc *MinerSmartContract) moveToStart(balances cstate.StateContextI,
 }
 
 // GetPhaseNode gets phase nodes from client state
-func GetPhaseNode(statectx cstate.StateContextI) (
+func GetPhaseNode(statectx cstate.ReadOnlyStateContextI) (
 	*PhaseNode, error) {
 
 	pn := &PhaseNode{}

--- a/code/go/0chain.net/smartcontract/minersc/globals.go
+++ b/code/go/0chain.net/smartcontract/minersc/globals.go
@@ -442,7 +442,7 @@ func getStringMapFromViper() map[string]string {
 	return globals
 }
 
-func getGlobalSettingsBytes(balances cstate.StateContextI) ([]byte, error) {
+func getGlobalSettingsBytes(balances cstate.ReadOnlyStateContextI) ([]byte, error) {
 	val, err := balances.GetTrieNode(GLOBALS_KEY)
 	if err != nil {
 		return nil, err
@@ -450,7 +450,7 @@ func getGlobalSettingsBytes(balances cstate.StateContextI) ([]byte, error) {
 	return val.Encode(), nil
 }
 
-func getGlobalSettings(balances cstate.StateContextI) (*GlobalSettings, error) {
+func getGlobalSettings(balances cstate.ReadOnlyStateContextI) (*GlobalSettings, error) {
 	var err error
 	var poolb []byte
 	if poolb, err = getGlobalSettingsBytes(balances); err != nil {

--- a/code/go/0chain.net/smartcontract/minersc/handler.go
+++ b/code/go/0chain.net/smartcontract/minersc/handler.go
@@ -22,7 +22,7 @@ const (
 
 // user oriented pools requests handler
 func (msc *MinerSmartContract) GetUserPoolsHandler(ctx context.Context,
-	params url.Values, balances cstate.StateContextI) (
+	params url.Values, balances cstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (
@@ -59,7 +59,7 @@ func (msc *MinerSmartContract) GetUserPoolsHandler(ctx context.Context,
 //REST API Handlers
 
 //GetNodepoolHandler API to provide nodepool information for registered miners
-func (msc *MinerSmartContract) GetNodepoolHandler(ctx context.Context, params url.Values, statectx cstate.StateContextI) (interface{}, error) {
+func (msc *MinerSmartContract) GetNodepoolHandler(ctx context.Context, params url.Values, statectx cstate.RestStateContextI) (interface{}, error) {
 
 	regMiner := NewMinerNode()
 	err := regMiner.decodeFromValues(params)
@@ -75,7 +75,7 @@ func (msc *MinerSmartContract) GetNodepoolHandler(ctx context.Context, params ur
 	return npi, nil
 }
 
-func (msc *MinerSmartContract) GetMinerListHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (msc *MinerSmartContract) GetMinerListHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	allMinersList, err := msc.GetMinersList(balances)
 	if err != nil {
 		return "", common.NewErrInternal("can't get miners list", err.Error())
@@ -85,7 +85,7 @@ func (msc *MinerSmartContract) GetMinerListHandler(ctx context.Context, params u
 
 const cantGetShardersListMsg = "can't get sharders list"
 
-func (msc *MinerSmartContract) GetSharderListHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (msc *MinerSmartContract) GetSharderListHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	allShardersList, err := getAllShardersList(balances)
 	if err != nil {
 		return "", common.NewErrInternal(cantGetShardersListMsg, err.Error())
@@ -93,7 +93,7 @@ func (msc *MinerSmartContract) GetSharderListHandler(ctx context.Context, params
 	return allShardersList, nil
 }
 
-func (msc *MinerSmartContract) GetSharderKeepListHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (msc *MinerSmartContract) GetSharderKeepListHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	allShardersList, err := getShardersKeepList(balances)
 	if err != nil {
 		return "", common.NewErrInternal(cantGetShardersListMsg, err.Error())
@@ -101,7 +101,7 @@ func (msc *MinerSmartContract) GetSharderKeepListHandler(ctx context.Context, pa
 	return allShardersList, nil
 }
 
-func (msc *MinerSmartContract) GetDKGMinerListHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (msc *MinerSmartContract) GetDKGMinerListHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	dkgMinersList, err := getDKGMinersList(balances)
 	if err != nil {
 		return "", common.NewErrInternal("can't get miners dkg list", err.Error())
@@ -109,7 +109,7 @@ func (msc *MinerSmartContract) GetDKGMinerListHandler(ctx context.Context, param
 	return dkgMinersList, nil
 }
 
-func (msc *MinerSmartContract) GetMinersMpksListHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (msc *MinerSmartContract) GetMinersMpksListHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	msc.mutexMinerMPK.Lock()
 	defer msc.mutexMinerMPK.Unlock()
 	mpks, err := getMinersMPKs(balances)
@@ -120,7 +120,7 @@ func (msc *MinerSmartContract) GetMinersMpksListHandler(ctx context.Context, par
 	return mpks, nil
 }
 
-func (msc *MinerSmartContract) GetGroupShareOrSignsHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (msc *MinerSmartContract) GetGroupShareOrSignsHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	sos, err := getGroupShareOrSigns(balances)
 	if err != nil {
 		return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true)
@@ -129,7 +129,7 @@ func (msc *MinerSmartContract) GetGroupShareOrSignsHandler(ctx context.Context, 
 	return sos, nil
 }
 
-func (msc *MinerSmartContract) GetPhaseHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (msc *MinerSmartContract) GetPhaseHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	pn, err := GetPhaseNode(balances)
 	if err != nil {
 		return "", common.NewErrNoResource("can't get phase node", err.Error())
@@ -137,7 +137,7 @@ func (msc *MinerSmartContract) GetPhaseHandler(ctx context.Context, params url.V
 	return pn, nil
 }
 
-func (msc *MinerSmartContract) GetMagicBlockHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (msc *MinerSmartContract) GetMagicBlockHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	mb, err := getMagicBlock(balances)
 	if err != nil {
 		return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true)
@@ -155,7 +155,7 @@ new zwallet commands
 func (msc *MinerSmartContract) getGlobalsHandler(
 	_ context.Context,
 	_ url.Values,
-	balances cstate.StateContextI,
+	balances cstate.RestStateContextI,
 ) (interface{}, error) {
 	globals, err := getGlobalSettings(balances)
 
@@ -171,7 +171,7 @@ func (msc *MinerSmartContract) getGlobalsHandler(
 }
 
 func (msc *MinerSmartContract) nodeStatHandler(ctx context.Context,
-	params url.Values, balances cstate.StateContextI) (
+	params url.Values, balances cstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (
@@ -187,7 +187,7 @@ func (msc *MinerSmartContract) nodeStatHandler(ctx context.Context,
 }
 
 func (msc *MinerSmartContract) nodePoolStatHandler(ctx context.Context,
-	params url.Values, balances cstate.StateContextI) (
+	params url.Values, balances cstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (
@@ -214,7 +214,7 @@ func (msc *MinerSmartContract) nodePoolStatHandler(ctx context.Context,
 func (msc *MinerSmartContract) configHandler(
 	_ context.Context,
 	_ url.Values,
-	balances cstate.StateContextI,
+	balances cstate.RestStateContextI,
 ) (interface{}, error) {
 	gn, err := getGlobalNode(balances)
 	if err != nil {

--- a/code/go/0chain.net/smartcontract/minersc/miner.go
+++ b/code/go/0chain.net/smartcontract/minersc/miner.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (msc *MinerSmartContract) doesMinerExist(pkey datastore.Key,
-	balances cstate.StateContextI) bool {
+	balances cstate.ReadOnlyStateContextI) bool {
 
 	mbits, err := balances.GetTrieNode(pkey)
 	if err != nil && err != util.ErrValueNotPresent {
@@ -376,7 +376,7 @@ func (msc *MinerSmartContract) verifyMinerState(balances cstate.StateContextI,
 
 }
 
-func (msc *MinerSmartContract) GetMinersList(balances cstate.StateContextI) (
+func (msc *MinerSmartContract) GetMinersList(balances cstate.ReadOnlyStateContextI) (
 	all *MinerNodes, err error) {
 
 	lockAllMiners.Lock()
@@ -385,7 +385,7 @@ func (msc *MinerSmartContract) GetMinersList(balances cstate.StateContextI) (
 }
 
 // getMinerNode
-func getMinerNode(id string, state cstate.StateContextI) (*MinerNode, error) {
+func getMinerNode(id string, state cstate.ReadOnlyStateContextI) (*MinerNode, error) {
 	mn := NewMinerNode()
 	mn.ID = id
 	ms, err := state.GetTrieNode(mn.GetKey())

--- a/code/go/0chain.net/smartcontract/minersc/models.go
+++ b/code/go/0chain.net/smartcontract/minersc/models.go
@@ -1205,7 +1205,7 @@ func (dmn *DKGMinerNodes) GetHashBytes() []byte {
 }
 
 // getMinersList returns miners list
-func getMinersList(state cstate.StateContextI) (*MinerNodes, error) {
+func getMinersList(state cstate.ReadOnlyStateContextI) (*MinerNodes, error) {
 	minerNodes, err := getNodesList(state, AllMinersKey)
 	if err != nil {
 		if err != util.ErrValueNotPresent {
@@ -1226,7 +1226,7 @@ func updateMinersList(state cstate.StateContextI, miners *MinerNodes) error {
 }
 
 // getDKGMinersList gets dkg miners list
-func getDKGMinersList(state cstate.StateContextI) (*DKGMinerNodes, error) {
+func getDKGMinersList(state cstate.ReadOnlyStateContextI) (*DKGMinerNodes, error) {
 	dkgMiners := NewDKGMinerNodes()
 	allMinersDKGBytes, err := state.GetTrieNode(DKGMinersKey)
 	if err != nil {
@@ -1251,7 +1251,7 @@ func updateDKGMinersList(state cstate.StateContextI, dkgMiners *DKGMinerNodes) e
 	return err
 }
 
-func getMinersMPKs(state cstate.StateContextI) (*block.Mpks, error) {
+func getMinersMPKs(state cstate.ReadOnlyStateContextI) (*block.Mpks, error) {
 	mpksBytes, err := state.GetTrieNode(MinersMPKKey)
 	if err != nil {
 		return nil, err
@@ -1270,7 +1270,7 @@ func updateMinersMPKs(state cstate.StateContextI, mpks *block.Mpks) error {
 	return err
 }
 
-func getMagicBlock(state cstate.StateContextI) (*block.MagicBlock, error) {
+func getMagicBlock(state cstate.ReadOnlyStateContextI) (*block.MagicBlock, error) {
 	magicBlockBytes, err := state.GetTrieNode(MagicBlockKey)
 	if err != nil {
 		return nil, err
@@ -1289,7 +1289,7 @@ func updateMagicBlock(state cstate.StateContextI, magicBlock *block.MagicBlock) 
 	return err
 }
 
-func getGroupShareOrSigns(state cstate.StateContextI) (*block.GroupSharesOrSigns, error) {
+func getGroupShareOrSigns(state cstate.ReadOnlyStateContextI) (*block.GroupSharesOrSigns, error) {
 	var gsos = block.NewGroupSharesOrSigns()
 	groupBytes, err := state.GetTrieNode(GroupShareOrSignsKey)
 	if err != nil {
@@ -1309,7 +1309,7 @@ func updateGroupShareOrSigns(state cstate.StateContextI, gsos *block.GroupShares
 }
 
 // getShardersKeepList returns the sharder list
-func getShardersKeepList(balances cstate.StateContextI) (*MinerNodes, error) {
+func getShardersKeepList(balances cstate.ReadOnlyStateContextI) (*MinerNodes, error) {
 	sharders, err := getNodesList(balances, ShardersKeepKey)
 	if err != nil {
 		if err != util.ErrValueNotPresent {
@@ -1327,7 +1327,7 @@ func updateShardersKeepList(state cstate.StateContextI, sharders *MinerNodes) er
 }
 
 // getAllShardersKeepList returns the sharder list
-func getAllShardersList(balances cstate.StateContextI) (*MinerNodes, error) {
+func getAllShardersList(balances cstate.ReadOnlyStateContextI) (*MinerNodes, error) {
 	sharders, err := getNodesList(balances, AllShardersKey)
 	if err != nil {
 		if err != util.ErrValueNotPresent {
@@ -1343,7 +1343,7 @@ func updateAllShardersList(state cstate.StateContextI, sharders *MinerNodes) err
 	return err
 }
 
-func getNodesList(balances cstate.StateContextI, key datastore.Key) (*MinerNodes, error) {
+func getNodesList(balances cstate.ReadOnlyStateContextI, key datastore.Key) (*MinerNodes, error) {
 	nodesBytes, err := balances.GetTrieNode(key)
 	if err != nil {
 		return nil, err

--- a/code/go/0chain.net/smartcontract/minersc/sc.go
+++ b/code/go/0chain.net/smartcontract/minersc/sc.go
@@ -186,7 +186,7 @@ func getHostnameAndPort(burl string) (string, int, error) {
 }
 
 func getGlobalNode(
-	balances cstate.StateContextI,
+	balances cstate.ReadOnlyStateContextI,
 ) (gn *GlobalNode, err error) {
 	gn = new(GlobalNode)
 	var p util.Serializable
@@ -208,7 +208,7 @@ func getGlobalNode(
 	return gn, nil
 }
 
-func (msc *MinerSmartContract) getUserNode(id string, balances cstate.StateContextI) (*UserNode, error) {
+func (msc *MinerSmartContract) getUserNode(id string, balances cstate.ReadOnlyStateContextI) (*UserNode, error) {
 	un := NewUserNode()
 	un.ID = id
 	us, err := balances.GetTrieNode(un.GetKey())

--- a/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
@@ -397,7 +397,7 @@ func testCancelAllocation(
 	require.EqualValues(t, len(allAllocationsBefore.List)-1, len(allAllocationsAfter.List))
 
 	var newScYaml = &scConfig{}
-	newScYaml, err = ssc.getConfig(ctx, false)
+	newScYaml, err = ssc.getConfigReadOnly(ctx)
 	require.NoError(t, err)
 	newAllb, err := ssc.getBlobbersList(ctx)
 	require.NoError(t, err)
@@ -455,7 +455,7 @@ func testFinalizeAllocation(
 	require.EqualValues(t, len(allAllocationsBefore.List)-1, len(allAllocationsAfter.List))
 
 	var newScYaml = &scConfig{}
-	newScYaml, err = ssc.getConfig(ctx, false)
+	newScYaml, err = ssc.getConfigReadOnly(ctx)
 	require.NoError(t, err)
 	newAllb, err := ssc.getBlobbersList(ctx)
 	require.NoError(t, err)

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -18,7 +18,7 @@ import (
 
 // getAllocation by ID
 func (sc *StorageSmartContract) getAllocation(allocID string,
-	balances chainstate.StateContextI) (alloc *StorageAllocation, err error) {
+	balances chainstate.ReadOnlyStateContextI) (alloc *StorageAllocation, err error) {
 
 	alloc = new(StorageAllocation)
 	alloc.ID = allocID
@@ -34,7 +34,7 @@ func (sc *StorageSmartContract) getAllocation(allocID string,
 }
 
 func (sc *StorageSmartContract) getAllocationsList(clientID string,
-	balances chainstate.StateContextI) (*Allocations, error) {
+	balances chainstate.ReadOnlyStateContextI) (*Allocations, error) {
 
 	allocationList := &Allocations{}
 	var clientAlloc ClientAllocation
@@ -264,7 +264,7 @@ func sizeInGB(size int64) float64 {
 
 // exclude blobbers with not enough token in stake pool to fit the size
 func (sc *StorageSmartContract) filterBlobbersByFreeSpace(now common.Timestamp,
-	size int64, balances chainstate.StateContextI) (filter filterBlobberFunc) {
+	size int64, balances chainstate.ReadOnlyStateContextI) (filter filterBlobberFunc) {
 
 	return filterBlobberFunc(func(b *StorageNode) (kick bool) {
 		var sp, err = sc.getStakePool(b.ID, balances)
@@ -288,7 +288,7 @@ func (sc *StorageSmartContract) newAllocationRequest(
 ) (string, error) {
 	var conf *scConfig
 	var err error
-	if conf, err = sc.getConfig(balances, true); err != nil {
+	if conf, err = sc.getConfig(balances); err != nil {
 		return "", common.NewErrorf("allocation_creation_failed",
 			"can't get config: %v", err)
 	}
@@ -407,11 +407,11 @@ func (sc *StorageSmartContract) selectBlobbers(
 	allBlobbersList StorageNodes,
 	sa *StorageAllocation,
 	randomSeed int64,
-	balances chainstate.StateContextI,
+	balances chainstate.ReadOnlyStateContextI,
 ) ([]*StorageNode, int64, error) {
 	var err error
 	var conf *scConfig
-	if conf, err = sc.getConfig(balances, true); err != nil {
+	if conf, err = sc.getConfigReadOnly(balances); err != nil {
 		return nil, 0, fmt.Errorf("can't get config: %v", err)
 	}
 
@@ -920,7 +920,7 @@ func (sc *StorageSmartContract) updateAllocationRequest(
 	balances chainstate.StateContextI,
 ) (resp string, err error) {
 	var conf *scConfig
-	if conf, err = sc.getConfig(balances, false); err != nil {
+	if conf, err = sc.getConfig(balances); err != nil {
 		return "", common.NewError("allocation_updating_failed",
 			"can't get SC configurations: "+err.Error())
 	}
@@ -1353,7 +1353,7 @@ func (sc *StorageSmartContract) finishAllocation(
 ) (err error) {
 	// SC configurations
 	var conf *scConfig
-	if conf, err = sc.getConfig(balances, false); err != nil {
+	if conf, err = sc.getConfig(balances); err != nil {
 		return common.NewError("fini_alloc_failed",
 			"can't get SC configurations: "+err.Error())
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_rest_tests.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_rest_tests.go
@@ -23,7 +23,7 @@ type RestBenchTest struct {
 	endpoint func(
 		context.Context,
 		url.Values,
-		cstate.StateContextI,
+		cstate.RestStateContextI,
 	) (interface{}, error)
 	params url.Values
 }

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -14,7 +14,7 @@ import (
 
 const blobberHealthTime = 60 * 60 // 1 Hour
 
-func (sc *StorageSmartContract) getBlobbersList(balances cstate.StateContextI) (*StorageNodes, error) {
+func (sc *StorageSmartContract) getBlobbersList(balances cstate.ReadOnlyStateContextI) (*StorageNodes, error) {
 	allBlobbersList := &StorageNodes{}
 	allBlobbersBytes, err := balances.GetTrieNode(ALL_BLOBBERS_KEY)
 	if allBlobbersBytes == nil {
@@ -28,7 +28,7 @@ func (sc *StorageSmartContract) getBlobbersList(balances cstate.StateContextI) (
 }
 
 func (sc *StorageSmartContract) getBlobberBytes(blobberID string,
-	balances cstate.StateContextI) (b []byte, err error) {
+	balances cstate.ReadOnlyStateContextI) (b []byte, err error) {
 
 	var (
 		blobber      StorageNode
@@ -46,7 +46,7 @@ func (sc *StorageSmartContract) getBlobberBytes(blobberID string,
 }
 
 func (sc *StorageSmartContract) getBlobber(blobberID string,
-	balances cstate.StateContextI) (blobber *StorageNode, err error) {
+	balances cstate.ReadOnlyStateContextI) (blobber *StorageNode, err error) {
 
 	var b []byte
 	if b, err = sc.getBlobberBytes(blobberID, balances); err != nil {
@@ -167,7 +167,7 @@ func (sc *StorageSmartContract) addBlobber(t *transaction.Transaction,
 	input []byte, balances cstate.StateContextI,
 ) (string, error) {
 	// get smart contract configuration
-	conf, err := sc.getConfig(balances, true)
+	conf, err := sc.getConfig(balances)
 	if err != nil {
 		return "", common.NewError("add_or_update_blobber_failed",
 			"can't get config: "+err.Error())
@@ -218,7 +218,7 @@ func (sc *StorageSmartContract) updateBlobberSettings(t *transaction.Transaction
 	input []byte, balances cstate.StateContextI,
 ) (resp string, err error) {
 	// get smart contract configuration
-	conf, err := sc.getConfig(balances, true)
+	conf, err := sc.getConfig(balances)
 	if err != nil {
 		return "", common.NewError("update_blobber_settings_failed",
 			"can't get config: "+err.Error())

--- a/code/go/0chain.net/smartcontract/storagesc/blobber_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber_test.go
@@ -99,7 +99,7 @@ func TestStorageSmartContract_addBlobber_invalidParams(t *testing.T) {
 
 	setConfig(t, balances)
 
-	var conf, err = ssc.getConfig(balances, false)
+	var conf, err = ssc.getConfigReadOnly(balances)
 	require.NoError(t, err)
 
 	terms.ChallengeCompletionTime = conf.MaxChallengeCompletionTime +
@@ -153,7 +153,7 @@ func TestStorageSmartContract_addBlobber_updateSettings(t *testing.T) {
 
 	var blob = newClient(0, balances)
 	blob.terms = avgTerms
-	blob.cap = 2*GB
+	blob.cap = 2 * GB
 
 	_, err = blob.callAddBlobber(t, ssc, tp, balances)
 	require.NoError(t, err)

--- a/code/go/0chain.net/smartcontract/storagesc/block_reward.go
+++ b/code/go/0chain.net/smartcontract/storagesc/block_reward.go
@@ -10,7 +10,7 @@ func (ssc *StorageSmartContract) payBlobberBlockRewards(
 	balances cstate.StateContextI,
 ) (err error) {
 	var conf *scConfig
-	if conf, err = ssc.getConfig(balances, true); err != nil {
+	if conf, err = ssc.getConfig(balances); err != nil {
 		return common.NewError("blobber_block_rewards_failed",
 			"cannot get smart contract configurations: "+err.Error())
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -79,7 +79,7 @@ func (sc *StorageSmartContract) blobberReward(t *transaction.Transaction,
 	balances c_state.StateContextI) (err error) {
 
 	var conf *scConfig
-	if conf, err = sc.getConfig(balances, true); err != nil {
+	if conf, err = sc.getConfig(balances); err != nil {
 		return fmt.Errorf("can't get SC configurations: %v", err.Error())
 	}
 
@@ -213,7 +213,7 @@ func (sc *StorageSmartContract) blobberPenalty(t *transaction.Transaction,
 	balances c_state.StateContextI) (err error) {
 
 	var conf *scConfig
-	if conf, err = sc.getConfig(balances, true); err != nil {
+	if conf, err = sc.getConfig(balances); err != nil {
 		return fmt.Errorf("can't get SC configurations: %v", err.Error())
 	}
 
@@ -560,7 +560,7 @@ func (sc *StorageSmartContract) generateChallenges(t *transaction.Transaction,
 
 	// SC configurations
 	var conf *scConfig
-	if conf, err = sc.getConfig(balances, false); err != nil {
+	if conf, err = sc.getConfig(balances); err != nil {
 		return common.NewErrorf("generate_challenges",
 			"can't get SC configurations: %v", err)
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/challengepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challengepool.go
@@ -1,12 +1,13 @@
 package storagesc
 
 import (
-	"0chain.net/smartcontract"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
+
+	"0chain.net/smartcontract"
 
 	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/state"
@@ -167,7 +168,7 @@ type challengePoolStat struct {
 
 // getChallengePoolBytes of a client
 func (ssc *StorageSmartContract) getChallengePoolBytes(
-	allocationID datastore.Key, balances cstate.StateContextI) (b []byte,
+	allocationID datastore.Key, balances cstate.ReadOnlyStateContextI) (b []byte,
 	err error) {
 
 	var val util.Serializable
@@ -180,7 +181,7 @@ func (ssc *StorageSmartContract) getChallengePoolBytes(
 
 // getChallengePool of current client
 func (ssc *StorageSmartContract) getChallengePool(allocationID datastore.Key,
-	balances cstate.StateContextI) (cp *challengePool, err error) {
+	balances cstate.ReadOnlyStateContextI) (cp *challengePool, err error) {
 
 	var poolb []byte
 	poolb, err = ssc.getChallengePoolBytes(allocationID, balances)
@@ -248,7 +249,7 @@ func (ssc *StorageSmartContract) createChallengePool(t *transaction.Transaction,
 
 // statistic for all locked tokens of a challenge pool
 func (ssc *StorageSmartContract) getChallengePoolStatHandler(
-	ctx context.Context, params url.Values, balances cstate.StateContextI) (
+	ctx context.Context, params url.Values, balances cstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (

--- a/code/go/0chain.net/smartcontract/storagesc/config.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config.go
@@ -485,28 +485,20 @@ func (ssc *StorageSmartContract) setupConfig(
 
 func (ssc *StorageSmartContract) getConfigReadOnly(
 	balances chainState.RestStateContextI,
-) (conf *scConfig, err error) {
-	var val util.Serializable
-	val, err = balances.GetTrieNode(scConfigKey(ssc.ID))
+) (*scConfig, error) {
+	val, err := balances.GetTrieNode(scConfigKey(ssc.ID))
 	if err != nil {
-		if err != util.ErrValueNotPresent {
-			return nil, err
-		}
-		return getConfiguredConfig()
+		return nil, err
 	}
 	confb := val.Encode()
-	if err != nil && err != util.ErrValueNotPresent {
-		return
+	if err != nil {
+		return nil, err
 	}
-	if err == util.ErrValueNotPresent {
-		return getConfiguredConfig()
-	}
-
-	conf = new(scConfig)
+	conf := new(scConfig)
 	if err = conf.Decode(confb); err != nil {
 		return nil, fmt.Errorf("%w: %s", common.ErrDecoding, err)
 	}
-	return
+	return conf, nil
 }
 
 // getConfig

--- a/code/go/0chain.net/smartcontract/storagesc/config_settigns.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config_settigns.go
@@ -594,7 +594,7 @@ func (ssc *StorageSmartContract) commitSettingChanges(
 	balances chainState.StateContextI,
 ) (resp string, err error) {
 	var conf *scConfig
-	if conf, err = ssc.getConfig(balances, true); err != nil {
+	if conf, err = ssc.getConfig(balances); err != nil {
 		return "", common.NewError("update_settings",
 			"can't get config: "+err.Error())
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/expose_mpt.go
+++ b/code/go/0chain.net/smartcontract/storagesc/expose_mpt.go
@@ -1,20 +1,21 @@
 package storagesc
 
 import (
-	"0chain.net/chaincore/chain/state"
-	"0chain.net/core/common"
 	"context"
 	"net/url"
+
+	"0chain.net/chaincore/chain/state"
+	"0chain.net/core/common"
 )
 
 func (ssc *StorageSmartContract) GetMptKey(
 	_ context.Context,
 	params url.Values,
-	balances state.StateContextI,
+	balances state.RestStateContextI,
 ) (interface{}, error) {
 	var err error
 	var conf *scConfig
-	if conf, err = ssc.getConfig(balances, false); err != nil {
+	if conf, err = ssc.getConfigReadOnly(balances); err != nil {
 		return nil, common.NewError("get_mpt_key",
 			"can't get SC configurations: "+err.Error())
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/free_allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/free_allocation.go
@@ -142,7 +142,7 @@ func (ssc *StorageSmartContract) addFreeStorageAssigner(
 
 	var conf *scConfig
 	var err error
-	if conf, err = ssc.getConfig(balances, true); err != nil {
+	if conf, err = ssc.getConfig(balances); err != nil {
 		return "", common.NewErrorf("add_free_storage_assigner",
 			"can't get config: %v", err)
 	}
@@ -220,7 +220,7 @@ func (ssc *StorageSmartContract) freeAllocationRequest(
 	}
 
 	var conf *scConfig
-	if conf, err = ssc.getConfig(balances, true); err != nil {
+	if conf, err = ssc.getConfig(balances); err != nil {
 		return "", common.NewErrorf("free_allocation_failed",
 			"can't get config: %v", err)
 	}
@@ -312,7 +312,7 @@ func (ssc *StorageSmartContract) updateFreeStorageRequest(
 	}
 
 	var conf *scConfig
-	if conf, err = ssc.getConfig(balances, true); err != nil {
+	if conf, err = ssc.getConfig(balances); err != nil {
 		return "", common.NewErrorf("update_free_storage_request",
 			"can't get config: %v", err)
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -1,11 +1,12 @@
 package storagesc
 
 import (
-	"0chain.net/smartcontract"
 	"context"
 	"fmt"
 	"net/url"
 	"time"
+
+	"0chain.net/smartcontract"
 
 	"0chain.net/core/logging"
 
@@ -19,7 +20,7 @@ const cantGetBlobberMsg = "can't get blobber"
 
 // GetBlobberHandler returns Blobber object from its individual stored value.
 func (ssc *StorageSmartContract) GetBlobberHandler(ctx context.Context,
-	params url.Values, balances cstate.StateContextI) (
+	params url.Values, balances cstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var blobberID = params.Get("blobber_id")
@@ -38,7 +39,7 @@ func (ssc *StorageSmartContract) GetBlobberHandler(ctx context.Context,
 // GetBlobbersHandler returns list of all blobbers alive (e.g. excluding
 // blobbers with zero capacity).
 func (ssc *StorageSmartContract) GetBlobbersHandler(ctx context.Context,
-	params url.Values, balances cstate.StateContextI) (interface{}, error) {
+	params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 
 	blobbers, err := ssc.getBlobbersList(balances)
 	if err != nil {
@@ -48,7 +49,7 @@ func (ssc *StorageSmartContract) GetBlobbersHandler(ctx context.Context,
 }
 
 func (ssc *StorageSmartContract) GetAllocationsHandler(ctx context.Context,
-	params url.Values, balances cstate.StateContextI) (interface{}, error) {
+	params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 
 	clientID := params.Get("client")
 	allocations, err := ssc.getAllocationsList(clientID, balances)
@@ -74,7 +75,7 @@ func (ssc *StorageSmartContract) GetAllocationsHandler(ctx context.Context,
 }
 
 func (ssc *StorageSmartContract) GetAllocationMinLockHandler(ctx context.Context,
-	params url.Values, balances cstate.StateContextI) (interface{}, error) {
+	params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 
 	var err error
 	var creationDate = common.Timestamp(time.Now().Unix())
@@ -119,7 +120,7 @@ func (ssc *StorageSmartContract) GetAllocationMinLockHandler(ctx context.Context
 
 const cantGetAllocation = "can't get allocation"
 
-func (ssc *StorageSmartContract) AllocationStatsHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (ssc *StorageSmartContract) AllocationStatsHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	allocationID := params.Get("allocation")
 	allocationObj := &StorageAllocation{}
 	allocationObj.ID = allocationID
@@ -136,7 +137,7 @@ func (ssc *StorageSmartContract) AllocationStatsHandler(ctx context.Context, par
 }
 
 func (ssc *StorageSmartContract) LatestReadMarkerHandler(ctx context.Context,
-	params url.Values, balances cstate.StateContextI) (
+	params url.Values, balances cstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (
@@ -169,7 +170,7 @@ func (ssc *StorageSmartContract) LatestReadMarkerHandler(ctx context.Context,
 
 }
 
-func (ssc *StorageSmartContract) OpenChallengeHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+func (ssc *StorageSmartContract) OpenChallengeHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (interface{}, error) {
 	blobberID := params.Get("blobber")
 
 	// return "404", if blobber not registered
@@ -199,7 +200,7 @@ func (ssc *StorageSmartContract) OpenChallengeHandler(ctx context.Context, param
 	return &blobberChallengeObj, nil
 }
 
-func (ssc *StorageSmartContract) GetChallengeHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (retVal interface{}, retErr error) {
+func (ssc *StorageSmartContract) GetChallengeHandler(ctx context.Context, params url.Values, balances cstate.RestStateContextI) (retVal interface{}, retErr error) {
 	defer func() {
 		if retErr != nil {
 			logging.Logger.Error("/getchallenge failed with error - " + retErr.Error())

--- a/code/go/0chain.net/smartcontract/storagesc/readpool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/readpool.go
@@ -247,7 +247,7 @@ func (rp *readPool) stat(now common.Timestamp) allocationPoolsStat {
 
 // getReadPoolBytes of a client
 func (ssc *StorageSmartContract) getReadPoolBytes(clientID datastore.Key,
-	balances cstate.StateContextI) (b []byte, err error) {
+	balances cstate.ReadOnlyStateContextI) (b []byte, err error) {
 
 	var val util.Serializable
 	val, err = balances.GetTrieNode(readPoolKey(ssc.ID, clientID))
@@ -259,7 +259,7 @@ func (ssc *StorageSmartContract) getReadPoolBytes(clientID datastore.Key,
 
 // getReadPool of current client
 func (ssc *StorageSmartContract) getReadPool(clientID datastore.Key,
-	balances cstate.StateContextI) (rp *readPool, err error) {
+	balances cstate.ReadOnlyStateContextI) (rp *readPool, err error) {
 
 	var poolb []byte
 	if poolb, err = ssc.getReadPoolBytes(clientID, balances); err != nil {
@@ -327,7 +327,7 @@ func (ssc *StorageSmartContract) readPoolLock(t *transaction.Transaction,
 	// configs
 
 	var conf *readPoolConfig
-	if conf, err = ssc.getReadPoolConfig(balances, true); err != nil {
+	if conf, err = ssc.getReadPoolConfig(balances); err != nil {
 		return "", common.NewError("read_pool_lock_failed",
 			"can't get configs: "+err.Error())
 	}
@@ -516,7 +516,7 @@ func (ssc *StorageSmartContract) readPoolUnlock(t *transaction.Transaction,
 
 // statistic for an allocation/blobber (used by blobbers)
 func (ssc *StorageSmartContract) getReadPoolAllocBlobberStatHandler(
-	ctx context.Context, params url.Values, balances cstate.StateContextI) (
+	ctx context.Context, params url.Values, balances cstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (
@@ -554,7 +554,7 @@ const cantReadPoolMsg = "can't get read pool"
 
 // statistic for all locked tokens of the read pool
 func (ssc *StorageSmartContract) getReadPoolStatHandler(ctx context.Context,
-	params url.Values, balances cstate.StateContextI) (
+	params url.Values, balances cstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool.go
@@ -1,13 +1,14 @@
 package storagesc
 
 import (
-	"0chain.net/smartcontract"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
 	"sort"
+
+	"0chain.net/smartcontract"
 
 	chainstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/state"
@@ -769,7 +770,7 @@ func (stat *stakePoolStat) decode(input []byte) error {
 
 // getUserStakePoolBytes of a client
 func (ssc *StorageSmartContract) getUserStakePoolBytes(clientID datastore.Key,
-	balances chainstate.StateContextI) (b []byte, err error) {
+	balances chainstate.ReadOnlyStateContextI) (b []byte, err error) {
 
 	var val util.Serializable
 	val, err = balances.GetTrieNode(userStakePoolsKey(ssc.ID, clientID))
@@ -781,7 +782,7 @@ func (ssc *StorageSmartContract) getUserStakePoolBytes(clientID datastore.Key,
 
 // getUserStakePool of given client
 func (ssc *StorageSmartContract) getUserStakePool(clientID datastore.Key,
-	balances chainstate.StateContextI) (usp *userStakePools, err error) {
+	balances chainstate.ReadOnlyStateContextI) (usp *userStakePools, err error) {
 
 	var poolb []byte
 	if poolb, err = ssc.getUserStakePoolBytes(clientID, balances); err != nil {
@@ -820,7 +821,7 @@ func (ssc *StorageSmartContract) getOrCreateUserStakePool(
 
 // getStakePoolBytes of a blobber
 func (ssc *StorageSmartContract) getStakePoolBytes(blobberID datastore.Key,
-	balances chainstate.StateContextI) (b []byte, err error) {
+	balances chainstate.ReadOnlyStateContextI) (b []byte, err error) {
 
 	var val util.Serializable
 	val, err = balances.GetTrieNode(stakePoolKey(ssc.ID, blobberID))
@@ -832,7 +833,7 @@ func (ssc *StorageSmartContract) getStakePoolBytes(blobberID datastore.Key,
 
 // getStakePool of given blobber
 func (ssc *StorageSmartContract) getStakePool(blobberID datastore.Key,
-	balances chainstate.StateContextI) (sp *stakePool, err error) {
+	balances chainstate.ReadOnlyStateContextI) (sp *stakePool, err error) {
 
 	var poolb []byte
 	if poolb, err = ssc.getStakePoolBytes(blobberID, balances); err != nil {
@@ -922,7 +923,7 @@ func (ssc *StorageSmartContract) stakePoolLock(t *transaction.Transaction,
 	input []byte, balances chainstate.StateContextI) (resp string, err error) {
 
 	var conf *scConfig
-	if conf, err = ssc.getConfig(balances, true); err != nil {
+	if conf, err = ssc.getConfig(balances); err != nil {
 		return "", common.NewErrorf("stake_pool_lock_failed",
 			"can't get SC configurations: %v", err)
 	}
@@ -1012,7 +1013,7 @@ func (ssc *StorageSmartContract) stakePoolUnlock(t *transaction.Transaction,
 			"can't decode request: %v", err)
 	}
 
-	if conf, err = ssc.getConfig(balances, true); err != nil {
+	if conf, err = ssc.getConfig(balances); err != nil {
 		return "", common.NewErrorf("stake_pool_unlock_failed",
 			"can't get SC configurations: %v", err)
 	}
@@ -1092,7 +1093,7 @@ func (ssc *StorageSmartContract) stakePoolPayInterests(
 		conf *scConfig
 	)
 
-	if conf, err = ssc.getConfig(balances, true); err != nil {
+	if conf, err = ssc.getConfig(balances); err != nil {
 		return "", common.NewError("stake_pool_take_rewards_failed",
 			"can't get SC configurations: "+err.Error())
 	}
@@ -1140,7 +1141,7 @@ const cantGetStakePoolMsg = "can't get related stake pool"
 
 // statistic for all locked tokens of a stake pool
 func (ssc *StorageSmartContract) getStakePoolStatHandler(ctx context.Context,
-	params url.Values, balances chainstate.StateContextI) (
+	params url.Values, balances chainstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (
@@ -1150,7 +1151,7 @@ func (ssc *StorageSmartContract) getStakePoolStatHandler(ctx context.Context,
 		sp        *stakePool
 	)
 
-	if conf, err = ssc.getConfig(balances, false); err != nil {
+	if conf, err = ssc.getConfigReadOnly(balances); err != nil {
 		return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, cantGetConfigErrMsg)
 	}
 
@@ -1171,7 +1172,7 @@ type userPoolStat struct {
 
 // user oriented statistic
 func (ssc *StorageSmartContract) getUserStakePoolStatHandler(ctx context.Context,
-	params url.Values, balances chainstate.StateContextI) (
+	params url.Values, balances chainstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (
@@ -1181,7 +1182,7 @@ func (ssc *StorageSmartContract) getUserStakePoolStatHandler(ctx context.Context
 		usp      *userStakePools
 	)
 
-	if conf, err = ssc.getConfig(balances, false); err != nil {
+	if conf, err = ssc.getConfigReadOnly(balances); err != nil {
 		return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, cantGetConfigErrMsg)
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/validator.go
+++ b/code/go/0chain.net/smartcontract/storagesc/validator.go
@@ -51,7 +51,7 @@ func (sc *StorageSmartContract) addValidator(t *transaction.Transaction, input [
 	}
 
 	var conf *scConfig
-	if conf, err = sc.getConfig(balances, true); err != nil {
+	if conf, err = sc.getConfig(balances); err != nil {
 		return "", common.NewErrorf("add_vaidator",
 			"can't get SC configurations: %v", err)
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/writepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/writepool.go
@@ -142,7 +142,7 @@ func (wp *writePool) allocUntil(allocID string, until common.Timestamp) (
 
 // getWritePoolBytes of a client
 func (ssc *StorageSmartContract) getWritePoolBytes(clientID datastore.Key,
-	balances chainState.StateContextI) (b []byte, err error) {
+	balances chainState.ReadOnlyStateContextI) (b []byte, err error) {
 
 	var val util.Serializable
 	val, err = balances.GetTrieNode(writePoolKey(ssc.ID, clientID))
@@ -154,7 +154,7 @@ func (ssc *StorageSmartContract) getWritePoolBytes(clientID datastore.Key,
 
 // getWritePool of current client
 func (ssc *StorageSmartContract) getWritePool(clientID datastore.Key,
-	balances chainState.StateContextI) (wp *writePool, err error) {
+	balances chainState.ReadOnlyStateContextI) (wp *writePool, err error) {
 
 	var poolb []byte
 	if poolb, err = ssc.getWritePoolBytes(clientID, balances); err != nil {
@@ -242,7 +242,7 @@ func (ssc *StorageSmartContract) writePoolLock(t *transaction.Transaction,
 	input []byte, balances chainState.StateContextI) (resp string, err error) {
 
 	var conf *writePoolConfig
-	if conf, err = ssc.getWritePoolConfig(balances, true); err != nil {
+	if conf, err = ssc.getWritePoolConfig(balances); err != nil {
 		return "", common.NewError("write_pool_lock_failed",
 			"can't get configs: "+err.Error())
 	}
@@ -456,7 +456,7 @@ func (ssc *StorageSmartContract) writePoolUnlock(t *transaction.Transaction,
 
 // statistic for an allocation/blobber (used by blobbers)
 func (ssc *StorageSmartContract) getWritePoolAllocBlobberStatHandler(
-	ctx context.Context, params url.Values, balances chainState.StateContextI) (
+	ctx context.Context, params url.Values, balances chainState.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (
@@ -494,7 +494,7 @@ const cantGetWritePoolMsg = "can't get write pool"
 
 // statistic for all locked tokens of the write pool
 func (ssc *StorageSmartContract) getWritePoolStatHandler(ctx context.Context,
-	params url.Values, balances chainState.StateContextI) (
+	params url.Values, balances chainState.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (

--- a/code/go/0chain.net/smartcontract/vestingsc/benchmark_rest_tests.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/benchmark_rest_tests.go
@@ -17,7 +17,7 @@ type RestBenchTest struct {
 	endpoint func(
 		context.Context,
 		url.Values,
-		cstate.StateContextI,
+		cstate.RestStateContextI,
 	) (interface{}, error)
 	params url.Values
 }

--- a/code/go/0chain.net/smartcontract/vestingsc/config.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/config.go
@@ -175,7 +175,7 @@ func (vsc *VestingSmartContract) updateConfig(
 //
 
 func (vsc *VestingSmartContract) getConfigBytes(
-	balances chainstate.StateContextI,
+	balances chainstate.RestStateContextI,
 ) (b []byte, err error) {
 	var val util.Serializable
 	val, err = balances.GetTrieNode(scConfigKey(vsc.ID))
@@ -207,7 +207,7 @@ func getConfiguredConfig() (conf *config, err error) {
 }
 
 func (vsc *VestingSmartContract) getConfig(
-	balances chainstate.StateContextI,
+	balances chainstate.RestStateContextI,
 ) (conf *config, err error) {
 	var confb []byte
 	confb, err = vsc.getConfigBytes(balances)
@@ -235,7 +235,7 @@ func (vsc *VestingSmartContract) getConfig(
 func (vsc *VestingSmartContract) getConfigHandler(
 	ctx context.Context,
 	params url.Values,
-	balances chainstate.StateContextI,
+	balances chainstate.RestStateContextI,
 ) (interface{}, error) {
 	res, err := vsc.getConfig(balances)
 	if err != nil {

--- a/code/go/0chain.net/smartcontract/vestingsc/list.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/list.go
@@ -1,13 +1,14 @@
 package vestingsc
 
 import (
-	"0chain.net/core/common"
-	"0chain.net/smartcontract"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"sort"
+
+	"0chain.net/core/common"
+	"0chain.net/smartcontract"
 
 	chainstate "0chain.net/chaincore/chain/state"
 	"0chain.net/core/datastore"
@@ -99,7 +100,7 @@ func (cp *clientPools) save(vscKey, clientID datastore.Key,
 //
 
 func (vsc *VestingSmartContract) getClientPoolsBytes(clientID datastore.Key,
-	balances chainstate.StateContextI) (_ []byte, err error) {
+	balances chainstate.RestStateContextI) (_ []byte, err error) {
 
 	var val util.Serializable
 	val, err = balances.GetTrieNode(clientPoolsKey(vsc.ID, clientID))
@@ -111,7 +112,7 @@ func (vsc *VestingSmartContract) getClientPoolsBytes(clientID datastore.Key,
 }
 
 func (vsc *VestingSmartContract) getClientPools(clientID datastore.Key,
-	balances chainstate.StateContextI) (cp *clientPools, err error) {
+	balances chainstate.RestStateContextI) (cp *clientPools, err error) {
 
 	var listb []byte
 	if listb, err = vsc.getClientPoolsBytes(clientID, balances); err != nil {
@@ -127,7 +128,7 @@ func (vsc *VestingSmartContract) getClientPools(clientID datastore.Key,
 }
 
 func (vsc *VestingSmartContract) getOrCreateClientPools(clientID datastore.Key,
-	balances chainstate.StateContextI) (cp *clientPools, err error) {
+	balances chainstate.RestStateContextI) (cp *clientPools, err error) {
 
 	cp, err = vsc.getClientPools(clientID, balances)
 	if err != nil && err != util.ErrValueNotPresent {
@@ -146,7 +147,7 @@ func (vsc *VestingSmartContract) getOrCreateClientPools(clientID datastore.Key,
 //
 
 func (vsc *VestingSmartContract) getClientPoolsHandler(ctx context.Context,
-	params url.Values, balances chainstate.StateContextI) (
+	params url.Values, balances chainstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (

--- a/code/go/0chain.net/smartcontract/vestingsc/vesting.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/vesting.go
@@ -518,7 +518,7 @@ type info struct {
 //
 
 func (vsc *VestingSmartContract) getPoolBytes(poolID datastore.Key,
-	balances chainstate.StateContextI) (_ []byte, err error) {
+	balances chainstate.RestStateContextI) (_ []byte, err error) {
 
 	var val util.Serializable
 	if val, err = balances.GetTrieNode(poolID); err != nil {
@@ -529,7 +529,7 @@ func (vsc *VestingSmartContract) getPoolBytes(poolID datastore.Key,
 }
 
 func (vsc *VestingSmartContract) getPool(poolID datastore.Key,
-	balances chainstate.StateContextI) (vp *vestingPool, err error) {
+	balances chainstate.RestStateContextI) (vp *vestingPool, err error) {
 
 	var poolb []byte
 	if poolb, err = vsc.getPoolBytes(poolID, balances); err != nil {
@@ -833,7 +833,7 @@ func (vsc *VestingSmartContract) trigger(t *transaction.Transaction,
 //
 
 func (vsc *VestingSmartContract) getPoolInfoHandler(ctx context.Context,
-	params url.Values, balances chainstate.StateContextI) (
+	params url.Values, balances chainstate.RestStateContextI) (
 	resp interface{}, err error) {
 
 	var (

--- a/code/go/0chain.net/smartcontract/zcnsc/handler.go
+++ b/code/go/0chain.net/smartcontract/zcnsc/handler.go
@@ -1,9 +1,10 @@
 package zcnsc
 
 import (
-	"0chain.net/smartcontract"
 	"context"
 	"net/url"
+
+	"0chain.net/smartcontract"
 
 	cState "0chain.net/chaincore/chain/state"
 )
@@ -11,7 +12,7 @@ import (
 func (zcn *ZCNSmartContract) getAuthorizerNodes(
 	_ context.Context,
 	_ url.Values,
-	balances cState.StateContextI,
+	balances cState.RestStateContextI,
 ) (interface{}, error) {
 	an, err := GetAuthorizerNodes(balances)
 	if err != nil {

--- a/code/go/0chain.net/smartcontract/zcnsc/models.go
+++ b/code/go/0chain.net/smartcontract/zcnsc/models.go
@@ -1,16 +1,17 @@
 package zcnsc
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
 	"0chain.net/chaincore/chain"
 	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/config"
 	"0chain.net/chaincore/state"
 	"0chain.net/chaincore/tokenpool"
 	"0chain.net/chaincore/transaction"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"time"
 
 	"0chain.net/core/common"
 	"0chain.net/core/datastore"
@@ -477,7 +478,7 @@ func (an *AuthorizerNodes) updateAuthorizer(node *AuthorizerNode) (err error) {
 	return
 }
 
-func GetAuthorizerNodes(balances cstate.StateContextI) (*AuthorizerNodes, error) {
+func GetAuthorizerNodes(balances cstate.RestStateContextI) (*AuthorizerNodes, error) {
 	authNodes := &AuthorizerNodes{}
 	authNodesBytes, err := balances.GetTrieNode(AllAuthorizerKey)
 	if authNodesBytes == nil {


### PR DESCRIPTION
Currently, there is one [StateContextI](https://github.com/0chain/0chain/blob/staging/code/go/0chain.net/chaincore/chain/state/state_context.go#L32) interface that is used everywhere. This splits it up into three interfaces to better match its uses in various locations.

1. `StateContextI`: This is the pre-existing version that is used in smart contracts and in the chain for control operations. This could be split up further later if needed.
2. `RestStateContextI`: Methods that are needed for REST API endpoints. In particular, we can't change the state in these endpoints so these methods have no meaning. Also shortly we will introduce the EventDB and the StatsDB which will accessible from the REST endpoints but not smart contracts.
3. `ReadOnlyStateContextI`: Methods common to both smart-contracts and REST endpoints.

https://github.com/0chain/0chain/issues/657