### PR TITLE
Conductor: Implement NotNotarisedBlockExtension test case

### DIFF
--- a/code/go/0chain.net/conductor/cases/not_notarised_block_extension.go
+++ b/code/go/0chain.net/conductor/cases/not_notarised_block_extension.go
@@ -1,0 +1,95 @@
+package cases
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"0chain.net/chaincore/block"
+	"0chain.net/conductor/config"
+)
+
+type (
+	// NotNotarisedBlockExtension represents implementation of the config.TestCase interface.
+	//
+	// 	Flow of this test case:
+	//		Leader extends not notarized prev_block
+	//		(T0) Leader_0: send Proposal0_0, extends not notarized prev_block
+	//		(T0) Leader_1: send Proposal1_0
+	//		(T0 + δ) Replica_0: reject Proposal0_, verify Proposal1_0
+	NotNotarisedBlockExtension struct {
+		mockedBlockHashToExtend string
+
+		result map[string]int // key - previous block's hash; value - verification status
+
+		wg *sync.WaitGroup
+	}
+)
+
+var (
+	// Ensure NotNotarisedBlockExtension implements config.TestCase interface.
+	_ config.TestCase = (*NotNotarisedBlockExtension)(nil)
+)
+
+// NewNotNotarisedBlockExtension creates initialised NotNotarisedBlockExtension.
+func NewNotNotarisedBlockExtension() *NotNotarisedBlockExtension {
+	wg := new(sync.WaitGroup)
+	wg.Add(2)
+	return &NotNotarisedBlockExtension{
+		result: make(map[string]int),
+		wg:     wg,
+	}
+}
+
+// Check implements config.TestCase interface.
+func (n *NotNotarisedBlockExtension) Check(ctx context.Context) (success bool, err error) {
+	prepared := make(chan struct{})
+	go func() {
+		n.wg.Wait()
+		prepared <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return false, errors.New("cases state is not prepared, context is done")
+
+	case <-prepared:
+		return n.check()
+	}
+}
+
+func (n *NotNotarisedBlockExtension) check() (success bool, err error) {
+	if n.mockedBlockHashToExtend == "" {
+		return false, errors.New("mocked block is nil")
+	}
+
+	for hash, status := range n.result {
+		switch {
+		case hash == n.mockedBlockHashToExtend && status == block.VerificationSuccessful:
+			msg := fmt.Sprintf("block with %s previous block hash have unexpected status: %d", hash, status)
+			return false, errors.New(msg)
+
+		case hash == n.mockedBlockHashToExtend && status == block.VerificationFailed:
+			return true, nil
+
+		case hash == n.mockedBlockHashToExtend && status == block.VerificationPending:
+			return false, errors.New("checked block has verification pending status")
+		}
+	}
+	return true, nil
+}
+
+// Configure implements config.TestCase interface.
+func (n *NotNotarisedBlockExtension) Configure(blob []byte) error {
+	defer n.wg.Done()
+	n.mockedBlockHashToExtend = string(blob)
+	return nil
+}
+
+// AddResult implements config.TestCase interface.
+func (n *NotNotarisedBlockExtension) AddResult(blob []byte) error {
+	defer n.wg.Done()
+	return json.Unmarshal(blob, &n.result)
+}

--- a/code/go/0chain.net/conductor/cases/not_notarised_block_extension.go
+++ b/code/go/0chain.net/conductor/cases/not_notarised_block_extension.go
@@ -68,8 +68,7 @@ func (n *NotNotarisedBlockExtension) check() (success bool, err error) {
 	for hash, status := range n.result {
 		switch {
 		case hash == n.mockedBlockHashToExtend && status == block.VerificationSuccessful:
-			msg := fmt.Sprintf("block with %s previous block hash have unexpected status: %d", hash, status)
-			return false, errors.New(msg)
+			return false, fmt.Errorf("block with %s previous block hash has unexpected status: %d", hash, status)
 
 		case hash == n.mockedBlockHashToExtend && status == block.VerificationFailed:
 			return true, nil

--- a/code/go/0chain.net/conductor/conductrpc/client.go
+++ b/code/go/0chain.net/conductor/conductrpc/client.go
@@ -155,3 +155,25 @@ func (c *client) state(me NodeID) (state *State, err error) {
 	}
 	return
 }
+
+func (c *client) configureTestCase(blob []byte) (err error) {
+	err = c.client.Call("Server.ConfigureTestCase", blob, &struct{}{})
+	if err == rpc.ErrShutdown {
+		if err = c.dial(); err != nil {
+			return
+		}
+		err = c.client.Call("Server.ConfigureTestCase", blob, &struct{}{})
+	}
+	return
+}
+
+func (c *client) addTestCaseResult(blob []byte) (err error) {
+	err = c.client.Call("Server.AddTestCaseResult", blob, &struct{}{})
+	if err == rpc.ErrShutdown {
+		if err = c.dial(); err != nil {
+			return
+		}
+		err = c.client.Call("Server.AddTestCaseResult", blob, &struct{}{})
+	}
+	return
+}

--- a/code/go/0chain.net/conductor/conductrpc/entity.go
+++ b/code/go/0chain.net/conductor/conductrpc/entity.go
@@ -173,6 +173,16 @@ func (e *Entity) ShareOrSignsShares(sosse *ShareOrSignsSharesEvent) (
 // global
 //
 
+// checks
+
+func (e *Entity) ConfigureTestCase(blob []byte) error {
+	return e.client.configureTestCase(blob)
+}
+
+func (e *Entity) AddTestCaseResult(blob []byte) error {
+	return e.client.addTestCaseResult(blob)
+}
+
 var global *Entity
 
 // Init creates global Entity and locks until unlocked.

--- a/code/go/0chain.net/conductor/conductrpc/server.go
+++ b/code/go/0chain.net/conductor/conductrpc/server.go
@@ -110,6 +110,8 @@ type Server struct {
 	// it work. E.g. the node has started and waits the conductor to enter BC.
 	onNodeReady chan NodeName
 
+	CurrentTest config.TestCase
+
 	onRoundEvent              chan *RoundEvent
 	onContributeMPKEvent      chan *ContributeMPKEvent
 	onShareOrSignsSharesEvent chan *ShareOrSignsSharesEvent
@@ -409,6 +411,18 @@ func (s *Server) State(id NodeID, state *State) (err error) {
 		return ErrShutdown
 	}
 	return
+}
+
+//
+// checks
+//
+
+func (s *Server) ConfigureTestCase(blob []byte, _ *struct{}) error {
+	return s.CurrentTest.Configure(blob)
+}
+
+func (s *Server) AddTestCaseResult(blob []byte, _ *struct{}) error {
+	return s.CurrentTest.AddResult(blob)
 }
 
 //

--- a/code/go/0chain.net/conductor/conductrpc/state.go
+++ b/code/go/0chain.net/conductor/conductrpc/state.go
@@ -47,6 +47,8 @@ type State struct {
 	Signatures *config.Bad
 	Publish    *config.Bad
 
+	ExtendNotNotarisedBlock *config.ExtendNotNotarisedBlock
+
 	// Blobbers related states
 	StorageTree    *config.Bad // blobber sends bad files/tree responses
 	ValidatorProof *config.Bad // blobber sends invalid proof to validators

--- a/code/go/0chain.net/conductor/config/byzantine.go
+++ b/code/go/0chain.net/conductor/config/byzantine.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -89,4 +90,41 @@ func (b *Bad) IsCompetingGroupMember(state Namer, id string) (ok bool) {
 		}
 	}
 	return // false
+}
+
+type (
+	// ExtendNotNotarisedBlock represents config for cases.NotNotarisedBlockExtension.
+	ExtendNotNotarisedBlock struct {
+		Enable bool  `json:"enable" yaml:"enable" mapstructure:"enable"`
+		Round  int64 `json:"round" yaml:"round" mapstructure:"round"`
+	}
+
+	// TestCaseCheck represents generic configuration for making tests checks.
+	TestCaseCheck struct {
+		WaitTimeStr string `mapstructure:"wait_time"`
+		WaitTime    time.Duration
+	}
+)
+
+// Decode decodes provided interface by executing mapstructure.Decode.
+func (c *ExtendNotNotarisedBlock) Decode(val interface{}) error {
+	var cfg ExtendNotNotarisedBlock
+	if err := mapstructure.Decode(val, &cfg); err != nil {
+		return err
+	}
+	*c = cfg
+	return nil
+}
+
+// Decode decodes provided interface by executing mapstructure.Decode.
+func (c *TestCaseCheck) Decode(val interface{}) (err error) {
+	var cfg TestCaseCheck
+	if err := mapstructure.Decode(val, &cfg); err != nil {
+		return err
+	}
+	if cfg.WaitTime, err = time.ParseDuration(cfg.WaitTimeStr); err != nil {
+		return err
+	}
+	*c = cfg
+	return nil
 }

--- a/code/go/0chain.net/conductor/config/execute.go
+++ b/code/go/0chain.net/conductor/config/execute.go
@@ -78,6 +78,12 @@ type Executor interface {
 	StorageTree(st *Bad) (err error)
 	ValidatorProof(vp *Bad) (err error)
 	Challenges(cs *Bad) (err error)
+
+	// ConfigureNotNotarisedBlockExtensionCheck prepares state for cases.NotNotarisedBlockExtension test case.
+	ConfigureNotNotarisedBlockExtensionCheck(*ExtendNotNotarisedBlock) (err error)
+
+	// MakeTestCaseCheck runs config.TestCase final check with TestCaseCheck configuration.
+	MakeTestCaseCheck(*TestCaseCheck) error
 }
 
 //

--- a/code/go/0chain.net/conductor/config/interfaces.go
+++ b/code/go/0chain.net/conductor/config/interfaces.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"context"
+)
+
+type (
+	// TestCase represents interfaces to perform checks.
+	TestCase interface {
+		// Configure takes encoded input that can be any type, and sets any needed preconditions for the TestCase.
+		Configure([]byte) error
+
+		// AddResult adds result that is needed to be checked.
+		AddResult([]byte) error
+
+		// Check runs main test case.
+		Check(ctx context.Context) (success bool, err error)
+	}
+)

--- a/code/go/0chain.net/conductor/config/registry.go
+++ b/code/go/0chain.net/conductor/config/registry.go
@@ -358,4 +358,22 @@ func init() {
 		return ex.Challenges(&cs)
 	})
 
+	// checks
+
+	register("configure_not_notarised_block_extension_test_case", func(name string,
+		ex Executor, val interface{}, tm time.Duration) (err error) {
+		cfg := &ExtendNotNotarisedBlock{}
+		if err := cfg.Decode(val); err != nil {
+			return err
+		}
+		return ex.ConfigureNotNotarisedBlockExtensionCheck(cfg)
+	})
+
+	register("make_test_case_check", func(name string, ex Executor, val interface{}, tm time.Duration) (err error) {
+		cfg := &TestCaseCheck{}
+		if err := cfg.Decode(val); err != nil {
+			return err
+		}
+		return ex.MakeTestCaseCheck(cfg)
+	})
 }

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -435,7 +435,7 @@ func (mc *Chain) signBlock(ctx context.Context, b *block.Block) (*block.BlockVer
 }
 
 /*UpdateFinalizedBlock - update the latest finalized block */
-func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
+func (mc *Chain) updateFinalizedBlock(ctx context.Context, b *block.Block) {
 	logging.Logger.Info("update finalized block", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Int64("lf_round", mc.GetLatestFinalizedBlock().Round), zap.Int64("current_round", mc.GetCurrentRound()), zap.Float64("weight", b.Weight()), zap.Float64("chain_weight", b.ChainWeight))
 	if config.Development() {
 		for _, t := range b.Txns {

--- a/code/go/0chain.net/miner/protocol_block_integration_tests.go
+++ b/code/go/0chain.net/miner/protocol_block_integration_tests.go
@@ -1,3 +1,4 @@
+//go:build integration_tests
 // +build integration_tests
 
 package miner
@@ -378,7 +379,7 @@ func (mc *Chain) isTestingNotNotarisedBlockExtension(round int64) bool {
 
 	// we need to collect all block's verification statuses from the first ranked replica
 	genNum := mc.GetGeneratorsNumOfRound(round)
-	rankedMiners := mc.GetRound(round).GetMinersByRank(mc.GetMiners(round))
+	rankedMiners := mc.GetRound(round).GetMinersByRank(mc.GetMiners(round).CopyNodes())
 	replicators := rankedMiners[genNum:]
 	return len(replicators) != 0 && replicators[0].ID == node.Self.ID
 }

--- a/code/go/0chain.net/miner/protocol_block_main.go
+++ b/code/go/0chain.net/miner/protocol_block_main.go
@@ -307,3 +307,8 @@ func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block,
 	node.Self.Underlying().Info.AvgBlockTxns = int(math.Round(bsHistogram.Mean()))
 	return nil
 }
+
+/*UpdateFinalizedBlock - update the latest finalized block */
+func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
+	mc.updateFinalizedBlock(ctx, b)
+}

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -301,7 +301,7 @@ func (mc *Chain) getClientState(
 	roundNumber int64,
 ) (*util.MerklePatriciaTrie, error) {
 	pround := mc.GetRound(roundNumber - 1)
-	pb := mc.GetBlockToExtend(ctx, pround)
+	pb := mc.getBlockToExtend(ctx, pround)
 	if pb == nil || pb.ClientState == nil {
 		return nil, fmt.Errorf("cannot get MPT from latest block %v", pb)
 	}
@@ -425,7 +425,7 @@ func (mc *Chain) startNewRound(ctx context.Context, mr *Round) {
 }
 
 // GetBlockToExtend - Get the block to extend from the given round.
-func (mc *Chain) GetBlockToExtend(ctx context.Context, r round.RoundI) (
+func (mc *Chain) getBlockToExtend(ctx context.Context, r round.RoundI) (
 	bnb *block.Block) {
 
 	if bnb = r.GetHeaviestNotarizedBlock(); bnb == nil {

--- a/code/go/0chain.net/miner/protocol_round_integration_tests.go
+++ b/code/go/0chain.net/miner/protocol_round_integration_tests.go
@@ -1,0 +1,61 @@
+// +build integration_tests
+
+package miner
+
+import (
+	"context"
+	"errors"
+	"log"
+
+	"0chain.net/chaincore/block"
+	"0chain.net/chaincore/node"
+	"0chain.net/chaincore/round"
+	crpc "0chain.net/conductor/conductrpc"
+)
+
+func (mc *Chain) GetBlockToExtend(ctx context.Context, r round.RoundI) *block.Block {
+	nextRound := mc.GetRound(r.GetRoundNumber() + 1)
+	if rank := nextRound.GetMinerRank(node.Self.Node); rank == 0 && isMockingNotNotarisedBlockExtension(r.GetRoundNumber()) {
+		if bl, err := configureNotNotarisedBlockExtensionTest(r); err != nil {
+			log.Printf("Conductor: NotNotarisedBlockExtension: error while configuring test case: %v", err)
+		} else {
+			return bl
+		}
+	}
+
+	return mc.getBlockToExtend(ctx, r)
+}
+
+func configureNotNotarisedBlockExtensionTest(r round.RoundI) (*block.Block, error) {
+	bl := getNotNotarisedBlock(r)
+	if bl == nil {
+		return nil, errors.New("not notarised block not found")
+	}
+	if err := crpc.Client().ConfigureTestCase([]byte(bl.Hash)); err != nil {
+		return nil, err
+	}
+
+	return bl, nil
+}
+
+func getNotNotarisedBlock(r round.RoundI) *block.Block {
+	var bl *block.Block
+	for _, prB := range r.GetProposedBlocks() {
+		var notarised bool
+		for _, notB := range r.GetNotarizedBlocks() {
+			if prB.Hash == notB.Hash {
+				notarised = true
+			}
+		}
+		if !notarised {
+			bl = prB
+			break
+		}
+	}
+	return bl
+}
+
+func isMockingNotNotarisedBlockExtension(round int64) bool {
+	cfg := crpc.Client().State().ExtendNotNotarisedBlock
+	return cfg != nil && cfg.Enable && cfg.Round == round
+}

--- a/code/go/0chain.net/miner/protocol_round_main.go
+++ b/code/go/0chain.net/miner/protocol_round_main.go
@@ -1,0 +1,14 @@
+// +build !integration_tests
+
+package miner
+
+import (
+	"context"
+
+	"0chain.net/chaincore/block"
+	"0chain.net/chaincore/round"
+)
+
+func (mc *Chain) GetBlockToExtend(ctx context.Context, r round.RoundI) *block.Block {
+	return mc.getBlockToExtend(ctx, r)
+}

--- a/docker.local/bin/start.conductor.sh
+++ b/docker.local/bin/start.conductor.sh
@@ -8,7 +8,7 @@ do
 done
 
 # go caches all build by default
-(cd ./code/go/0chain.net/conductor/conductor/ && go build)
+(cd ./code/go/0chain.net/conductor/conductor/ && go build -tags bn256 )
 # start the conductor
 ./code/go/0chain.net/conductor/conductor/conductor                     \
     -config "./docker.local/config/conductor.config.yaml"              \

--- a/docker.local/config/conductor.no-view-change.byzantine.yaml
+++ b/docker.local/config/conductor.no-view-change.byzantine.yaml
@@ -1,0 +1,19 @@
+enable:
+  - "attack round transfer"
+sets:
+  - name: "attack round transfer"
+    tests:
+      - "not notarised block extension"
+
+tests:
+  - name: "not notarised block extension"
+    flow:
+      - set_monitor: "miner-1"
+      - cleanup_bc: { }
+      - start: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - configure_not_notarised_block_extension_test_case:
+          enable: true
+          round: 30
+      - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - make_test_case_check:
+          wait_time: 5m


### PR DESCRIPTION
Implementing test case:

```
// Leader extends not notarized prev_block
(T0) Leader_0: send Proposal0_0, extends not notarized prev_block
(T0) Leader_1: send Proposal1_0
(T0 + δ) Replica_0: reject Proposal0_, verify Proposal1_0
```