### PR TITLE
Fix round restarting bug that caused RRS generation slow

### DIFF
--- a/code/go/0chain.net/chaincore/node/n2n_request.go
+++ b/code/go/0chain.net/chaincore/node/n2n_request.go
@@ -419,9 +419,6 @@ func ToN2NSendEntityHandler(handler common.JSONResponderF) common.ReqRespHandler
 			w.Header().Set(HeaderRequestEntityName, v.EntityName)
 			buffer = bytes.NewBuffer(v.Data)
 			uri = r.FormValue("_puri")
-			logging.Logger.Debug("push pull",
-				zap.String("uri", uri),
-				zap.String("entity name", v.EntityName))
 		}
 		if options.Compress {
 			w.Header().Set("Content-Encoding", compDecomp.Encoding())

--- a/code/go/0chain.net/chaincore/node/node_pool.go
+++ b/code/go/0chain.net/chaincore/node/node_pool.go
@@ -77,7 +77,6 @@ func (np *Pool) start() {
 	np.startOnce.Do(func() {
 		go func() {
 			np.id = atomic.AddInt32(&poolID, 1)
-			logging.Logger.Warn("node pool start", zap.Int32("ID", np.id))
 
 			var nds []*Node
 
@@ -94,7 +93,6 @@ func (np *Pool) start() {
 					v.reply <- struct{}{}
 					cleanTimer = time.NewTimer(expireTime)
 				case <-cleanTimer.C:
-					logging.Logger.Debug("node pool cleaned")
 					np.startOnce = &sync.Once{}
 					return
 				}
@@ -136,7 +134,6 @@ func (np *Pool) updateNodesToC(nds []*Node) {
 	select {
 	case np.updateNodesC <- ndsWithReply:
 		<-ndsWithReply.reply
-		logging.Logger.Debug("update nodes to channel", zap.Int32("id", np.id))
 	case <-time.After(500 * time.Millisecond):
 		logging.Logger.Warn("update nodes to channel timeout")
 	}

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -633,15 +633,19 @@ func (r *Round) AddVRFShare(share *VRFShare, threshold int) bool {
 	defer r.mutex.Unlock()
 	if len(r.getVRFShares()) >= threshold {
 		//if we already have enough shares, do not add.
-		logging.Logger.Info("AddVRFShare Already at threshold. Returning false.")
+		logging.Logger.Info("add_vrf_share already at threshold. Returning false.")
 		return false
 	}
 	if _, ok := r.shares[share.party.GetKey()]; ok {
-		logging.Logger.Info("AddVRFShare Share is already there. Returning false.")
+		logging.Logger.Info("add_vrf_share share is already there. Returning false.")
 		return false
 	}
 	r.setState(RoundShareVRF)
 	r.shares[share.party.GetKey()] = share
+	logging.Logger.Debug("add_vrf_share",
+		zap.Int64("round", r.GetRoundNumber()),
+		zap.Int("round_vrf_num", len(r.getVRFShares())),
+		zap.Int("threshold", threshold))
 	return true
 }
 

--- a/code/go/0chain.net/miner/m_handler.go
+++ b/code/go/0chain.net/miner/m_handler.go
@@ -58,7 +58,7 @@ func SetupM2MSenders() {
 	options = &node.SendOptions{Timeout: node.TimeoutSmallMessage, MaxRelayLength: 0, CurrentRelayLength: 0, Compress: false}
 	VerificationTicketSender = node.SendEntityHandler("/v1/_m2m/block/verification_ticket", options)
 
-	options = &node.SendOptions{Timeout: node.TimeoutSmallMessage, MaxRelayLength: 0, CurrentRelayLength: 0, CODEC: node.CODEC_MSGPACK, Compress: true, Pull: true}
+	options = &node.SendOptions{Timeout: node.TimeoutSmallMessage, MaxRelayLength: 0, CurrentRelayLength: 0, CODEC: node.CODEC_MSGPACK, Compress: true}
 	BlockNotarizationSender = node.SendEntityHandler("/v1/_m2m/block/notarization", options)
 
 }

--- a/code/go/0chain.net/miner/m_handler.go
+++ b/code/go/0chain.net/miner/m_handler.go
@@ -133,7 +133,7 @@ func VRFShareHandler(ctx context.Context, entity datastore.Entity) (
 		bound = lfb.Round // use lower one
 	}
 	if vrfs.GetRoundNumber() < bound {
-		logging.Logger.Info("Rejecting VRFShare: old round",
+		logging.Logger.Info("Reject VRFShare: old round",
 			zap.Int64("vrfs_round", vrfs.GetRoundNumber()),
 			zap.Int64("lfb_ticket_round", tk.Round),
 			zap.Int64("lfb_round", lfb.Round),
@@ -145,12 +145,12 @@ func VRFShareHandler(ctx context.Context, entity datastore.Entity) (
 	if vrfs.Round < mc.GetCurrentRound() {
 		var mr = mc.GetMinerRound(vrfs.Round)
 		if mr == nil {
-			logging.Logger.Info("Rejecting VRFShare: missing miner round",
+			logging.Logger.Info("Reject VRFShare: missing miner round",
 				zap.Int64("vrfs_round_num", vrfs.GetRoundNumber()))
 			return nil, nil
 		}
 		if mr.Block == nil || !mr.Block.IsBlockNotarized() {
-			logging.Logger.Info("Rejecting VRFShare: missing HNB for the round"+
+			logging.Logger.Info("Reject VRFShare: missing HNB for the round"+
 				" or it's not notarized",
 				zap.Bool("is_not_notarized", mr.Block != nil),
 				zap.Int64("vrfs_round_num", vrfs.GetRoundNumber()))
@@ -159,7 +159,7 @@ func VRFShareHandler(ctx context.Context, entity datastore.Entity) (
 		// var hnb = mr.GetHeaviestNotarizedBlock()
 		var hnb = mr.Block
 		if hnb.GetStateStatus() != block.StateSuccessful {
-			logging.Logger.Info("Rejecting VRFShare: HNB state is not successful",
+			logging.Logger.Info("Reject VRFShare: HNB state is not successful",
 				zap.Int64("vrfs_round_num", vrfs.GetRoundNumber()),
 				zap.String("hash", hnb.Hash))
 			return nil, nil
@@ -169,12 +169,12 @@ func VRFShareHandler(ctx context.Context, entity datastore.Entity) (
 			party = node.GetSender(ctx)
 		)
 		if mb == nil {
-			logging.Logger.Info("Rejecting VRFShare: missing MB for the round",
+			logging.Logger.Info("Reject VRFShare: missing MB for the round",
 				zap.Int64("vrfs_round_num", vrfs.GetRoundNumber()))
 			return nil, nil
 		}
 		if party == nil {
-			logging.Logger.Info("Rejecting VRFShare: missing party",
+			logging.Logger.Info("Reject VRFShare: missing party",
 				zap.Int64("vrfs_round_num", vrfs.GetRoundNumber()))
 			return nil, nil
 		}
@@ -186,7 +186,7 @@ func VRFShareHandler(ctx context.Context, entity datastore.Entity) (
 			}
 		}
 		if found == nil {
-			logging.Logger.Info("Rejecting VRFShare: missing party in MB",
+			logging.Logger.Info("Reject VRFShare: missing party in MB",
 				zap.Int64("vrfs_round_num", vrfs.GetRoundNumber()))
 			return nil, nil
 		}
@@ -198,7 +198,7 @@ func VRFShareHandler(ctx context.Context, entity datastore.Entity) (
 		// send notarized block
 		go mb.Miners.SendTo(ctx, MinerNotarizedBlockSender(hnb), found.ID)
 
-		logging.Logger.Info("Rejecting VRFShare: push not. block message for the miner behind",
+		logging.Logger.Info("Reject VRFShare: push not. block message for the miner behind",
 			zap.Int64("vrfs_round_num", vrfs.GetRoundNumber()),
 			zap.String("to_miner_id", found.ID),
 			zap.String("to_miner_url", found.GetN2NURLBase()))
@@ -208,6 +208,10 @@ func VRFShareHandler(ctx context.Context, entity datastore.Entity) (
 	sender := node.GetSender(ctx)
 	vrfs.SetParty(sender)
 	if mr := mc.GetMinerRound(vrfs.Round); mr != nil {
+		if mr.IsVRFComplete() {
+			return nil, nil
+		}
+
 		if mr.VRFShareExist(vrfs) {
 			return nil, nil
 		}

--- a/code/go/0chain.net/miner/protocol_block_main.go
+++ b/code/go/0chain.net/miner/protocol_block_main.go
@@ -136,7 +136,7 @@ func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block,
 		}
 		if txnProcessor(ctx, txn) {
 			if idx >= mc.BlockSize || byteSize >= mc.MaxByteSize {
-				logging.Logger.Error("generate block (too big block size)",
+				logging.Logger.Debug("generate block (too big block size)",
 					zap.Bool("idx >= block size", idx >= mc.BlockSize),
 					zap.Bool("byteSize >= mc.NMaxByteSize", byteSize >= mc.MaxByteSize),
 					zap.Int32("idx", idx),

--- a/code/go/0chain.net/miner/protocol_bls.go
+++ b/code/go/0chain.net/miner/protocol_bls.go
@@ -415,12 +415,11 @@ func (mc *Chain) ThresholdNumBLSSigReceived(ctx context.Context, mr *Round, blsT
 	}
 
 	var rbOutput = encryption.Hash(groupSignature.GetHexString())
-	Logger.Info("receive bls sign", zap.Any("sigs", recSig),
-		zap.Any("from", recFrom),
-		zap.Any("group_signature", groupSignature.GetHexString()))
+	Logger.Info("receive bls sign",
+		zap.Int64("round", mr.GetRoundNumber()),
+		zap.Any("group_signature", groupSignature.GetHexString()),
+		zap.String("rboOutput", rbOutput))
 
-	// rbOutput := bs.CalcRandomBeacon(recSig, recFrom)
-	Logger.Debug("VRF ", zap.String("rboOutput", rbOutput), zap.Int64("Round", mr.Number))
 	mc.computeRBO(ctx, mr, rbOutput)
 }
 
@@ -443,8 +442,6 @@ func getVRFShareInfo(mr *Round) ([]string, []string) {
 	shares := mr.GetVRFShares()
 	for _, share := range shares {
 		n := share.GetParty()
-		Logger.Info("VRF Printing from shares: ", zap.Int("Miner Index = ", n.SetIndex), zap.Any("Share = ", share.Share))
-
 		recSig = append(recSig, share.Share)
 		recFrom = append(recFrom, ComputeBlsID(n.ID))
 	}

--- a/code/go/0chain.net/miner/protocol_bls.go
+++ b/code/go/0chain.net/miner/protocol_bls.go
@@ -259,8 +259,13 @@ func (mc *Chain) AddVRFShare(ctx context.Context, mr *Round, vrfs *round.VRFShar
 		return false
 	}
 
-	Logger.Info("DKG AddVRFShare", zap.Int64("Round", rn), zap.Int("RoundTimeoutCount", mr.GetTimeoutCount()),
-		zap.Int("Sender", vrfs.GetParty().SetIndex), zap.Int("vrf_timeoutcount", vrfs.GetRoundTimeoutCount()),
+	Logger.Info("DKG AddVRFShare",
+		zap.Int64("round", rn),
+		zap.Int("round_vrf_num", len(mr.GetVRFShares())),
+		zap.Int("threshold", blsThreshold),
+		zap.Int("sender", vrfs.GetParty().SetIndex),
+		zap.Int("round_timeout_count", mr.GetTimeoutCount()),
+		zap.Int("vrf_timeout_count", vrfs.GetRoundTimeoutCount()),
 		zap.String("vrf_share", vrfs.Share))
 
 	mr.AddTimeoutVote(vrfs.GetRoundTimeoutCount(), vrfs.GetParty().ID)
@@ -281,9 +286,7 @@ func (mc *Chain) AddVRFShare(ctx context.Context, mr *Round, vrfs *round.VRFShar
 
 	mr.AddVRFShare(vrfs, blsThreshold)
 
-	if len(mr.GetVRFShares()) >= blsThreshold {
-		mc.ThresholdNumBLSSigReceived(ctx, mr, blsThreshold)
-	}
+	mc.ThresholdNumBLSSigReceived(ctx, mr, blsThreshold)
 
 	return true
 }

--- a/code/go/0chain.net/miner/protocol_bls.go
+++ b/code/go/0chain.net/miner/protocol_bls.go
@@ -234,13 +234,23 @@ func (mc *Chain) AddVRFShare(ctx context.Context, mr *Round, vrfs *round.VRFShar
 		return false
 	}
 
-	if vrfs.GetRoundTimeoutCount() != mr.GetTimeoutCount() {
+	var (
+		vrfRTC  = vrfs.GetRoundTimeoutCount()
+		roundTC = mr.GetTimeoutCount()
+	)
+
+	if vrfRTC != roundTC {
 		//Keep VRF timeout and round timeout in sync. Same vrfs will comeback during soft timeouts
-		Logger.Info("TOC_FIX VRF Timeout > round timeout",
+		Logger.Info("TOC_FIX VRF Timeout != round timeout",
 			zap.Int("vrfs_timeout", vrfs.GetRoundTimeoutCount()),
 			zap.Int("round_timeout", mr.GetTimeoutCount()),
 			zap.Int64("round", mr.GetRoundNumber()),
 			zap.Int64("vrf round", vrfs.Round))
+
+		// add vrf to cache if the vrf share has timeout count > round's timeout count
+		if vrfRTC > roundTC {
+			mr.vrfSharesCache.add(vrfs)
+		}
 		return false
 	}
 

--- a/code/go/0chain.net/miner/protocol_receive.go
+++ b/code/go/0chain.net/miner/protocol_receive.go
@@ -24,7 +24,7 @@ func (mc *Chain) HandleVRFShare(ctx context.Context, msg *BlockMessage) {
 	// add the VRFShare
 	logging.Logger.Debug("handle vrf share",
 		zap.Int64("round", msg.VRFShare.Round),
-		zap.Int("round_timeout_count", msg.VRFShare.RoundTimeoutCount),
+		zap.Int("vrf_timeout_count", msg.VRFShare.GetRoundTimeoutCount()),
 		zap.Int("sender_index", msg.Sender.SetIndex),
 	)
 	mc.AddVRFShare(ctx, mr, msg.VRFShare)

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -1667,7 +1667,8 @@ func (mc *Chain) restartRound(ctx context.Context, rn int64) {
 
 			logging.Logger.Debug("restartRound - could not get HNB",
 				zap.Int64("round", xr.GetRoundNumber()),
-				zap.Int64("lfb_round", lfb.Round))
+				zap.Int64("lfb_round", lfb.Round),
+				zap.Int("soft_timeout", xr.GetSoftTimeoutCount()))
 
 			if xr.GetSoftTimeoutCount() >= mc.RoundRestartMult {
 				logging.Logger.Debug("restartRound - could not get HNB, redo vrf share",

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -1664,12 +1664,19 @@ func (mc *Chain) restartRound(ctx context.Context, rn int64) {
 		if xrhnb == nil ||
 			(xrhnb != nil && xrhnb.GetRoundRandomSeed() == 0) ||
 			(xrhnb != nil && xrhnb.GetRoundRandomSeed() != xr.GetRandomSeed()) {
-			logging.Logger.Debug("restartRound - could not get HNB, redo vrf share",
+
+			logging.Logger.Debug("restartRound - could not get HNB",
 				zap.Int64("round", xr.GetRoundNumber()),
 				zap.Int64("lfb_round", lfb.Round))
-			xr.Restart()
-			xr.IncrementTimeoutCount(mc.getRoundRandomSeed(i-1), mc.GetMiners(i))
-			mc.RedoVrfShare(ctx, xr)
+
+			if xr.GetSoftTimeoutCount() >= mc.RoundRestartMult {
+				logging.Logger.Debug("restartRound - could not get HNB, redo vrf share",
+					zap.Int64("round", xr.GetRoundNumber()),
+					zap.Int64("lfb_round", lfb.Round))
+				xr.Restart()
+				xr.IncrementTimeoutCount(mc.getRoundRandomSeed(i-1), mc.GetMiners(i))
+				mc.RedoVrfShare(ctx, xr)
+			}
 			return // the round has restarted <===================== [exit loop]
 		}
 

--- a/code/go/0chain.net/miner/round.go
+++ b/code/go/0chain.net/miner/round.go
@@ -55,10 +55,13 @@ func (v *vrfSharesCache) getAll() []*round.VRFShare {
 	return vrfShares
 }
 
-func (v *vrfSharesCache) clean() {
+// clean deletes shares that has round time out count <= the 'count' value
+func (v *vrfSharesCache) clean(count int) {
 	v.mutex.Lock()
-	for s := range v.vrfShares {
-		delete(v.vrfShares, s)
+	for s, vrf := range v.vrfShares {
+		if vrf.GetRoundTimeoutCount() <= count {
+			delete(v.vrfShares, s)
+		}
 	}
 	v.mutex.Unlock()
 }

--- a/code/go/0chain.net/miner/round.go
+++ b/code/go/0chain.net/miner/round.go
@@ -38,10 +38,11 @@ func newVRFSharesCache() *vrfSharesCache {
 func (v *vrfSharesCache) add(vrfShare *round.VRFShare) {
 	v.mutex.Lock()
 	defer v.mutex.Unlock()
-	if _, ok := v.vrfShares[vrfShare.GetParty().GetKey()]; ok {
+	k := vrfShare.GetParty().GetKey()
+	if _, ok := v.vrfShares[k]; ok {
 		return
 	}
-	v.vrfShares[vrfShare.Share] = vrfShare
+	v.vrfShares[k] = vrfShare
 }
 
 func (v *vrfSharesCache) getAll() []*round.VRFShare {

--- a/code/go/0chain.net/miner/round.go
+++ b/code/go/0chain.net/miner/round.go
@@ -178,3 +178,9 @@ func (r *Round) Clear() {
 func (r *Round) IsVRFComplete() bool {
 	return r.HasRandomSeed()
 }
+
+// Restart resets round and vrf shares cache
+func (r *Round) Restart() {
+	r.Round.Restart()
+	r.vrfSharesCache = newVRFSharesCache()
+}

--- a/code/go/0chain.net/smartcontract/minersc/miner.go
+++ b/code/go/0chain.net/smartcontract/minersc/miner.go
@@ -366,14 +366,6 @@ func (msc *MinerSmartContract) verifyMinerState(balances cstate.StateContextI,
 		logging.Logger.Info(msg + " allminerslist is empty")
 		return
 	}
-
-	logging.Logger.Info(msg)
-	for _, miner := range allMinersList.Nodes {
-		logging.Logger.Info("allminerslist",
-			zap.String("url", miner.N2NHost),
-			zap.String("ID", miner.ID))
-	}
-
 }
 
 func (msc *MinerSmartContract) GetMinersList(balances cstate.StateContextI) (


### PR DESCRIPTION
Fixes:
- #728 

Changes:
- Do not restart round if the round's soft timeout count is less than the `mc.RoundRestartMult`. 