### PR TITLE
Revert tx data error check

### DIFF
--- a/code/go/0chain.net/chaincore/transaction/entity.go
+++ b/code/go/0chain.net/chaincore/transaction/entity.go
@@ -106,13 +106,10 @@ func (t *Transaction) ValidateFee() error {
 		var smartContractData smartContractTransactionData
 		dataBytes := []byte(t.TransactionData)
 		err := json.Unmarshal(dataBytes, &smartContractData)
-		if err != nil {
-			logging.Logger.Error("unmarshal txn data failed", zap.Error(err))
-			return errors.New("invalid transaction data")
-		}
-
-		if _, ok := exemptedSCFunctions[smartContractData.FunctionName]; ok {
-			return nil
+		if err == nil {
+			if _, ok := exemptedSCFunctions[smartContractData.FunctionName]; ok {
+				return nil
+			}
 		}
 	}
 	if t.Fee < TXN_MIN_FEE {


### PR DESCRIPTION
[Pr506](https://github.com/0chain/0chain/pull/506/files#diff-f074193fa5441c8539654baa3af5ea323daaf00557d409a798c2a6fab3956d0aL107) fixed a bug where there was no error check to see if the transaction was properly formatted. This fix prevented exempted transactions not being recognised as exempt if they have badly formatted transaction data. Possibly resulting in fees being paid when they were not required.

Due to populate request this PR reverts this bug fix. So there is no error check to see if the [smartContractData](https://github.com/0chain/0chain/blob/9104ba3ad1f9115c2a73cd2f67552cb397feae0f/code/go/0chain.net/chaincore/transaction/entity.go#L86) field 
unmarshalled correctly, so that transactions with badly formated transaction data can execute without error.