### PR TITLE
Fix LFMB sync isse

### DIFF
--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -1501,6 +1501,7 @@ func (c *Chain) LatestOwnFinalizedBlockRound() int64 {
 }
 
 // SetLatestFinalizedBlock - set the latest finalized block.
+// TODO: this should be called when UpdateMagicBlock is called successfully
 func (c *Chain) SetLatestFinalizedMagicBlock(b *block.Block) {
 
 	if b == nil || b.MagicBlock == nil {
@@ -1531,7 +1532,9 @@ func (c *Chain) SetLatestFinalizedMagicBlock(b *block.Block) {
 	c.magicBlockStartingRounds[b.MagicBlock.StartingRound] = b
 	c.lfmbMutex.Unlock()
 
-	c.updateLatestFinalizedMagicBlock(context.Background(), b)
+	if latest == nil || b.StartingRound >= latest.StartingRound {
+		c.updateLatestFinalizedMagicBlock(context.Background(), b)
+	}
 }
 
 // GetLatestFinalizedMagicBlock will returns a copy of the latest finalized magic block

--- a/code/go/0chain.net/go.mod
+++ b/code/go/0chain.net/go.mod
@@ -43,7 +43,7 @@ require (
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.4.0
-	gorm.io/datatypes v1.0.3
+	gorm.io/datatypes v1.0.3 // indirect
 	gorm.io/driver/postgres v1.2.1
 	gorm.io/gorm v1.22.2
 )

--- a/code/go/0chain.net/miner/chain.go
+++ b/code/go/0chain.net/miner/chain.go
@@ -13,6 +13,7 @@ import (
 	"0chain.net/chaincore/block"
 	"0chain.net/chaincore/chain"
 	"0chain.net/chaincore/client"
+	"0chain.net/chaincore/config"
 	"0chain.net/chaincore/node"
 	"0chain.net/chaincore/round"
 	"0chain.net/chaincore/state"
@@ -301,6 +302,9 @@ func (mc *Chain) SaveClients(clients []*client.Client) error {
 // ViewChange on finalized (!) block. Miners check magic blocks during
 // generation and notarization. A finalized block should be trusted.
 func (mc *Chain) ViewChange(ctx context.Context, b *block.Block) (err error) {
+	if !config.DevConfiguration.ViewChange {
+		return
+	}
 
 	var (
 		mb  = b.MagicBlock

--- a/code/go/0chain.net/miner/chain.go
+++ b/code/go/0chain.net/miner/chain.go
@@ -339,6 +339,8 @@ func (mc *Chain) ViewChange(ctx context.Context, b *block.Block) (err error) {
 		return common.NewErrorf("view_change", "updating MB: %v", err)
 	}
 
+	mc.SetLatestFinalizedMagicBlock(b)
+
 	go mc.PruneRoundStorage(mc.getPruneCountRoundStorage(),
 		mc.roundDkg, mc.MagicBlockStorage)
 

--- a/code/go/0chain.net/miner/protocol_view_change.go
+++ b/code/go/0chain.net/miner/protocol_view_change.go
@@ -908,6 +908,9 @@ func (mc *Chain) updateMagicBlocks(mbs ...*block.Block) {
 // previous MB and corresponding DKG. The previous MB can be useless in
 // some cases but this method just makes sure it is.
 func (mc *Chain) SetupLatestAndPreviousMagicBlocks(ctx context.Context) {
+	if !config.DevConfiguration.ViewChange {
+		return
+	}
 
 	logging.Logger.Info("setup latest and previous fmbs")
 	lfmb := mc.GetLatestFinalizedMagicBlock(ctx)

--- a/code/go/0chain.net/sharder/protocol_block.go
+++ b/code/go/0chain.net/sharder/protocol_block.go
@@ -92,15 +92,22 @@ func (sc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
 	sc.DeleteRoundsBelow(b.Round)
 }
 
-func (sc *Chain) ViewChange(ctx context.Context, b *block.Block) (err error) {
-
-	var mb = b.MagicBlock
-
-	if mb == nil {
-		return // no MB, no VC
+func (sc *Chain) ViewChange(ctx context.Context, b *block.Block) error {
+	if !config.DevConfiguration.ViewChange {
+		return nil
 	}
 
-	return sc.UpdateMagicBlock(mb)
+	mb := b.MagicBlock
+	if mb == nil {
+		return nil // no MB, no VC
+	}
+
+	if err := sc.UpdateMagicBlock(mb); err != nil {
+		return err
+	}
+
+	sc.SetLatestFinalizedMagicBlock(b)
+	return nil
 }
 
 // The hasRelatedMagicBlock reports true if the Chain has MB related to the


### PR DESCRIPTION
Fix #742 

The latest finalized magic block should not be changed when `vc:false`, even if it is changed, it should be synced with the mb in `chain.MagicBlockStorage` so that the nodes' active status can be updated correctly.