### PR TITLE
Conductor: implementing ResendProposedBlock test case

### DIFF
--- a/code/go/0chain.net/conductor/cases/breaking_single_block.go
+++ b/code/go/0chain.net/conductor/cases/breaking_single_block.go
@@ -69,7 +69,7 @@ func (n *BreakingSingleBlock) check() (success bool, err error) {
 		return false, errors.New("unexpected finalised block hash")
 	}
 
-	for _, bi := range n.res.Blocks {
+	for _, bi := range n.res.blocks() {
 		if bi.Hash == n.cfg.SecondSentBlockHash {
 			switch {
 			case bi.Notarised:

--- a/code/go/0chain.net/conductor/cases/misc.go
+++ b/code/go/0chain.net/conductor/cases/misc.go
@@ -12,27 +12,35 @@ type (
 		GeneratorsNum      int          `json:"generators_num"`
 		RankedMiners       []string     `json:"ranked_miners"`
 		FinalisedBlockHash string       `json:"finalised_block_hash"`
-		Blocks             []*BlockInfo `json:"blocks"`
+		ProposedBlocks     []*BlockInfo `json:"proposed_blocks"`
+		NotarisedBlocks    []*BlockInfo `json:"notarised_blocks"`
 	}
 
 	// BlockInfo represents simple struct for reports containing round's information
 	// needed for making tests checks.
 	BlockInfo struct {
-		Hash               string `json:"hash"`
-		PrevHash           string `json:"prev_hash"`
-		Notarised          bool   `json:"notarised"`
-		VerificationStatus int    `json:"verification_status"`
-		Rank               int    `json:"rank"`
+		Hash                string                    `json:"hash"`
+		PrevHash            string                    `json:"prev_hash"`
+		Notarised           bool                      `json:"notarised"`
+		VerificationStatus  int                       `json:"verification_status"`
+		Rank                int                       `json:"rank"`
+		VerificationTickets []*VerificationTicketInfo `json:"verification_tickets"`
+	}
+
+	// VerificationTicketInfo represents simple struct for reports containing verification ticket's information
+	// needed for making tests checks.
+	VerificationTicketInfo struct {
+		VerifierID string `json:"verifier_id"`
 	}
 )
 
-// getNotarisedBlocks looks for notarising blocks in the RoundInfo.Blocks.
-func (r *RoundInfo) getNotarisedBlocks() []*BlockInfo {
-	blocks := make([]*BlockInfo, 0)
-	for _, bl := range r.Blocks {
-		if bl.Notarised {
-			blocks = append(blocks, bl)
-		}
+func (r *RoundInfo) blocks() map[string]*BlockInfo {
+	blocks := make(map[string]*BlockInfo)
+	for _, bl := range r.ProposedBlocks {
+		blocks[bl.Hash] = bl
+	}
+	for _, bl := range r.NotarisedBlocks {
+		blocks[bl.Hash] = bl
 	}
 	return blocks
 }
@@ -66,7 +74,7 @@ func (r *RoundInfo) getNodeID(generator bool, typeRank int) string {
 // getBlockWithRank returns BlockInfo for the block with provided rank.
 // If node with provided parameters is not found, returns nil.
 func (r *RoundInfo) getBlockWithRank(rank int) *BlockInfo {
-	for _, bi := range r.Blocks {
+	for _, bi := range r.blocks() {
 		if bi.Rank == rank {
 			return bi
 		}

--- a/code/go/0chain.net/conductor/cases/not_notarised_block_extension.go
+++ b/code/go/0chain.net/conductor/cases/not_notarised_block_extension.go
@@ -63,7 +63,7 @@ func (n *NotNotarisedBlockExtension) check() (success bool, err error) {
 		return false, errors.New("mocked block is nil")
 	}
 
-	for _, b := range n.result.Blocks {
+	for _, b := range n.result.blocks() {
 		prevBlockHash, status := b.PrevHash, b.VerificationStatus
 		switch {
 		case prevBlockHash == n.mockedBlockHashToExtend && status == block.VerificationSuccessful:

--- a/code/go/0chain.net/conductor/cases/notarising_non_existent_block.go
+++ b/code/go/0chain.net/conductor/cases/notarising_non_existent_block.go
@@ -59,7 +59,7 @@ func (n *NotarisingNonExistentBlock) Check(ctx context.Context) (success bool, e
 }
 
 func (n *NotarisingNonExistentBlock) check() (success bool, err error) {
-	notBlocks := n.res.getNotarisedBlocks()
+	notBlocks := n.res.NotarisedBlocks
 	if len(notBlocks) != 1 || notBlocks[0].Rank != 0 {
 		return false, errors.New("notarised block is unexpected, expected 1 block from the first ranked leader")
 	}

--- a/code/go/0chain.net/conductor/cases/resend_proposed_block.go
+++ b/code/go/0chain.net/conductor/cases/resend_proposed_block.go
@@ -1,0 +1,96 @@
+package cases
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"0chain.net/conductor/config"
+)
+
+type (
+	// ResendProposedBlock represents implementation of the config.TestCase interface.
+	//
+	// 	Flow of this test case:
+	//		Miner sends previous proposed block used in notarized round with one/several blocks notarized in it to propose in new round
+	//		(T0) Leader_0: send Proposal0_0 (after getting first Notarisation)
+	//		(T0) Leader_1: send Proposal0_1
+	//		(T0 + δ + Δ) Replica_j: send VerificationTicket1_j
+	//		(T0 + 2δ + Δ) Replica_j: send Notarization0_1
+	//		(T0 + 3δ + Δ) Leader_1: resend Proposal0_0 (after getting Proposal0_0)
+	//		(T0 + 4δ + Δ) Replica_j: reject Proposal0_0
+	ResendProposedBlock struct {
+		resentBlockHash string
+
+		result *RoundInfo
+
+		wg *sync.WaitGroup
+	}
+)
+
+var (
+	// Ensure NotNotarisedBlockExtension implements config.TestCase interface.
+	_ config.TestCase = (*ResendProposedBlock)(nil)
+)
+
+// NewResendProposedBlock creates initialised ResendProposedBlock.
+func NewResendProposedBlock() *ResendProposedBlock {
+	wg := new(sync.WaitGroup)
+	wg.Add(2)
+	return &ResendProposedBlock{
+		wg: wg,
+	}
+}
+
+// Check implements config.TestCase interface.
+func (n *ResendProposedBlock) Check(ctx context.Context) (success bool, err error) {
+	prepared := make(chan struct{})
+	go func() {
+		n.wg.Wait()
+		prepared <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return false, errors.New("cases state is not prepared, context is done")
+
+	case <-prepared:
+		return n.check()
+	}
+}
+
+func (n *ResendProposedBlock) check() (success bool, err error) {
+	if n.resentBlockHash == "" {
+		return false, errors.New("resent block hash is empty")
+	}
+
+	blocks := make(map[string]*BlockInfo)
+	for _, b := range n.result.ProposedBlocks {
+		_, ok := blocks[b.Hash]
+		if ok && b.Hash == n.resentBlockHash {
+			return false, errors.New("resent block is duplicated in stored round blocks")
+		}
+		blocks[b.Hash] = b
+	}
+
+	resentBlock, ok := blocks[n.resentBlockHash]
+	if ok && len(resentBlock.VerificationTickets) != 0 {
+		return false, errors.New("resent block has verification tickets")
+	}
+
+	return true, nil
+}
+
+// Configure implements config.TestCase interface.
+func (n *ResendProposedBlock) Configure(blob []byte) error {
+	defer n.wg.Done()
+	n.resentBlockHash = string(blob)
+	return nil
+}
+
+// AddResult implements config.TestCase interface.
+func (n *ResendProposedBlock) AddResult(blob []byte) error {
+	defer n.wg.Done()
+	n.result = new(RoundInfo)
+	return n.result.Decode(blob)
+}

--- a/code/go/0chain.net/conductor/cases/send_insufficient_blocks.go
+++ b/code/go/0chain.net/conductor/cases/send_insufficient_blocks.go
@@ -60,7 +60,7 @@ func (n *SendInsufficientProposals) Check(ctx context.Context) (success bool, er
 }
 
 func (n *SendInsufficientProposals) check() (success bool, err error) {
-	for _, bl := range n.res.Blocks {
+	for _, bl := range n.res.blocks() {
 		if bl.Hash == n.firstGenBlockHash {
 			if !bl.Notarised {
 				err = errors.New("first generator's block was not notarised")

--- a/code/go/0chain.net/conductor/conductor/executor.go
+++ b/code/go/0chain.net/conductor/conductor/executor.go
@@ -722,7 +722,7 @@ func (r *Runner) verbosePrintByGoodBad(label string, bad *config.Bad) {
 //
 
 // ConfigureNotNotarisedBlockExtensionCheck implements config.Executor interface.
-func (r *Runner) ConfigureNotNotarisedBlockExtensionCheck(cfg *config.ExtendNotNotarisedBlock) (err error) {
+func (r *Runner) ConfigureNotNotarisedBlockExtensionCheck(cfg *config.DefaultTestCase) (err error) {
 	if r.verbose {
 		log.Print(" [INF] configure \"not notarised block extension check\"")
 	}
@@ -740,7 +740,7 @@ func (r *Runner) ConfigureNotNotarisedBlockExtensionCheck(cfg *config.ExtendNotN
 }
 
 // ConfigureSendDifferentBlocksFromFirstGenerator implements config.Executor interface.
-func (r *Runner) ConfigureSendDifferentBlocksFromFirstGenerator(cfg *config.SendDifferentBlocksFromFirstGenerator) (err error) {
+func (r *Runner) ConfigureSendDifferentBlocksFromFirstGenerator(cfg *config.DefaultTestCase) (err error) {
 	if r.verbose {
 		log.Print(" [INF] configure \"send different blocks from first generator\"")
 	}
@@ -758,7 +758,7 @@ func (r *Runner) ConfigureSendDifferentBlocksFromFirstGenerator(cfg *config.Send
 }
 
 // ConfigureSendDifferentBlocksFromAllGenerators implements config.Executor interface.
-func (r *Runner) ConfigureSendDifferentBlocksFromAllGenerators(cfg *config.SendDifferentBlocksFromAllGenerators) (err error) {
+func (r *Runner) ConfigureSendDifferentBlocksFromAllGenerators(cfg *config.DefaultTestCase) (err error) {
 	if r.verbose {
 		log.Print(" [INF] configure \"send different blocks from all generators\"")
 	}
@@ -776,7 +776,7 @@ func (r *Runner) ConfigureSendDifferentBlocksFromAllGenerators(cfg *config.SendD
 }
 
 // ConfigureBreakingSingleBlock implements config.Executor interface.
-func (r *Runner) ConfigureBreakingSingleBlock(cfg *config.BreakingSingleBlock) (err error) {
+func (r *Runner) ConfigureBreakingSingleBlock(cfg *config.DefaultTestCase) (err error) {
 	if r.verbose {
 		log.Print(" [INF] configure \"breaking single block\"")
 	}
@@ -794,7 +794,7 @@ func (r *Runner) ConfigureBreakingSingleBlock(cfg *config.BreakingSingleBlock) (
 }
 
 // ConfigureSendInsufficientProposals implements config.Executor interface.
-func (r *Runner) ConfigureSendInsufficientProposals(cfg *config.SendInsufficientProposals) (err error) {
+func (r *Runner) ConfigureSendInsufficientProposals(cfg *config.DefaultTestCase) (err error) {
 	if r.verbose {
 		log.Print(" [INF] configure \"send insufficient proposals\"")
 	}
@@ -827,7 +827,7 @@ func (r *Runner) ConfigureVerifyingNonExistentBlockTestCase(cfg *config.Verifyin
 	if err := r.server.EnableServerStatsCollector(); err != nil {
 		return fmt.Errorf("error while enabling server stats collector: %v", err)
 	}
-	r.server.CurrentTest = cases.NewVerifyingNonExistentBlock(cfg.Hash, cfg.Round, r.server.NodesServerStatsCollector)
+	r.server.CurrentTest = cases.NewVerifyingNonExistentBlock(cfg.Hash, int(cfg.OnRound), r.server.NodesServerStatsCollector)
 
 	return
 }
@@ -849,6 +849,24 @@ func (r *Runner) ConfigureNotarisingNonExistentBlockTestCase(cfg *config.Notaris
 		return fmt.Errorf("error while enabling server stats collector: %v", err)
 	}
 	r.server.CurrentTest = cases.NewNotarisingNonExistentBlock(r.server.NodesServerStatsCollector)
+
+	return
+}
+
+// ConfigureResendProposedBlock implements config.Executor interface.
+func (r *Runner) ConfigureResendProposedBlock(cfg *config.ResendProposedBlock) (err error) {
+	if r.verbose {
+		log.Print(" [INF] configure \"resend proposed block\"")
+	}
+
+	err = r.server.UpdateAllStates(func(state *conductrpc.State) {
+		state.ResendProposedBlock = cfg
+	})
+	if err != nil {
+		return fmt.Errorf("error while configuring \"resend proposed block\" test case: %v", err)
+	}
+
+	r.server.CurrentTest = cases.NewResendProposedBlock()
 
 	return
 }

--- a/code/go/0chain.net/conductor/conductrpc/state.go
+++ b/code/go/0chain.net/conductor/conductrpc/state.go
@@ -47,13 +47,14 @@ type State struct {
 	Signatures *config.Bad
 	Publish    *config.Bad
 
-	ExtendNotNotarisedBlock               *config.ExtendNotNotarisedBlock
-	SendDifferentBlocksFromFirstGenerator *config.SendDifferentBlocksFromFirstGenerator
-	SendDifferentBlocksFromAllGenerators  *config.SendDifferentBlocksFromAllGenerators
-	BreakingSingleBlock                   *config.BreakingSingleBlock
-	SendInsufficientProposals             *config.SendInsufficientProposals
+	ExtendNotNotarisedBlock               *config.DefaultTestCase
+	SendDifferentBlocksFromFirstGenerator *config.DefaultTestCase
+	SendDifferentBlocksFromAllGenerators  *config.DefaultTestCase
+	BreakingSingleBlock                   *config.DefaultTestCase
+	SendInsufficientProposals             *config.DefaultTestCase
 	VerifyingNonExistentBlock             *config.VerifyingNonExistentBlock
 	NotarisingNonExistentBlock            *config.NotarisingNonExistentBlock
+	ResendProposedBlock                   *config.ResendProposedBlock
 
 	// Blobbers related states
 	StorageTree    *config.Bad // blobber sends bad files/tree responses

--- a/code/go/0chain.net/conductor/config/execute.go
+++ b/code/go/0chain.net/conductor/config/execute.go
@@ -80,27 +80,30 @@ type Executor interface {
 	Challenges(cs *Bad) (err error)
 
 	// ConfigureNotNotarisedBlockExtensionCheck prepares state for cases.NotNotarisedBlockExtension test case.
-	ConfigureNotNotarisedBlockExtensionCheck(*ExtendNotNotarisedBlock) (err error)
+	ConfigureNotNotarisedBlockExtensionCheck(*DefaultTestCase) (err error)
 
 	// ConfigureSendDifferentBlocksFromFirstGenerator prepares state for cases.SendDifferentBlocksFromFirstGenerator test case.
-	ConfigureSendDifferentBlocksFromFirstGenerator(*SendDifferentBlocksFromFirstGenerator) (err error)
+	ConfigureSendDifferentBlocksFromFirstGenerator(*DefaultTestCase) (err error)
 
 	// ConfigureSendDifferentBlocksFromAllGenerators prepares state for
 	// cases.SendDifferentBlocksFromAllGenerators test case.
-	ConfigureSendDifferentBlocksFromAllGenerators(*SendDifferentBlocksFromAllGenerators) (err error)
+	ConfigureSendDifferentBlocksFromAllGenerators(*DefaultTestCase) (err error)
 
 	// ConfigureBreakingSingleBlock prepares state for cases.BreakingSingleBlock test case.
-	ConfigureBreakingSingleBlock(cfg *BreakingSingleBlock) (err error)
+	ConfigureBreakingSingleBlock(cfg *DefaultTestCase) (err error)
 
 	// ConfigureSendInsufficientProposals prepares state for
 	// cases.SendInsufficientProposals test case.
-	ConfigureSendInsufficientProposals(*SendInsufficientProposals) (err error)
+	ConfigureSendInsufficientProposals(*DefaultTestCase) (err error)
 
 	// ConfigureVerifyingNonExistentBlockTestCase prepares state for cases.VerifyingNonExistentBlock test case.
 	ConfigureVerifyingNonExistentBlockTestCase(*VerifyingNonExistentBlock) (err error)
 
 	// ConfigureNotarisingNonExistentBlockTestCase prepares state for cases.NotarisingNonExistentBlock test case.
-	ConfigureNotarisingNonExistentBlockTestCase(block *NotarisingNonExistentBlock) (err error)
+	ConfigureNotarisingNonExistentBlockTestCase(*NotarisingNonExistentBlock) (err error)
+
+	// ConfigureResendProposedBlock prepares state for cases.ResendProposedBlock test case.
+	ConfigureResendProposedBlock(*ResendProposedBlock) (err error)
 
 	// MakeTestCaseCheck runs config.TestCase final check with TestCaseCheck configuration.
 	MakeTestCaseCheck(*TestCaseCheck) error

--- a/code/go/0chain.net/conductor/config/registry.go
+++ b/code/go/0chain.net/conductor/config/registry.go
@@ -362,7 +362,7 @@ func init() {
 
 	register("configure_not_notarised_block_extension_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &ExtendNotNotarisedBlock{}
+		cfg := &DefaultTestCase{}
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
@@ -371,7 +371,7 @@ func init() {
 
 	register("configure_send_different_blocks_from_first_generator_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &SendDifferentBlocksFromFirstGenerator{}
+		cfg := &DefaultTestCase{}
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
@@ -380,7 +380,7 @@ func init() {
 
 	register("configure_send_different_blocks_from_all_generators_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &SendDifferentBlocksFromAllGenerators{}
+		cfg := &DefaultTestCase{}
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
@@ -389,7 +389,7 @@ func init() {
 
 	register("configure_breaking_single_block", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &BreakingSingleBlock{}
+		cfg := &DefaultTestCase{}
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
@@ -398,7 +398,7 @@ func init() {
 
 	register("configure_send_insufficient_proposals_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &SendInsufficientProposals{}
+		cfg := &DefaultTestCase{}
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
@@ -421,6 +421,15 @@ func init() {
 			return err
 		}
 		return ex.ConfigureNotarisingNonExistentBlockTestCase(cfg)
+	})
+
+	register("configure_resend_proposed_block_test_case", func(name string,
+		ex Executor, val interface{}, tm time.Duration) (err error) {
+		cfg := &ResendProposedBlock{}
+		if err := cfg.Decode(val); err != nil {
+			return err
+		}
+		return ex.ConfigureResendProposedBlock(cfg)
 	})
 
 	register("make_test_case_check", func(name string, ex Executor, val interface{}, tm time.Duration) (err error) {

--- a/code/go/0chain.net/miner/m_handler.go
+++ b/code/go/0chain.net/miner/m_handler.go
@@ -371,11 +371,9 @@ func VerificationTicketReceiptHandler(ctx context.Context, entity datastore.Enti
 	return nil, nil
 }
 
-// NotarizationReceiptHandler - handles the receipt of a notarization
+// notarizationReceiptHandler - handles the receipt of a notarization
 // for a block.
-func NotarizationReceiptHandler(ctx context.Context, entity datastore.Entity) (
-	interface{}, error) {
-
+func notarizationReceiptHandler(ctx context.Context, entity datastore.Entity) (interface{}, error) {
 	var notarization, ok = entity.(*Notarization)
 	if !ok {
 		return nil, common.InvalidRequest("Invalid Entity")

--- a/code/go/0chain.net/miner/m_handler_integration_tests.go
+++ b/code/go/0chain.net/miner/m_handler_integration_tests.go
@@ -4,8 +4,12 @@
 package miner
 
 import (
+	"context"
+	"log"
+
 	"0chain.net/chaincore/node"
 	"0chain.net/conductor/conductrpc/stats/middleware"
+	"0chain.net/core/datastore"
 )
 
 // SetupX2MResponders - setup responders.
@@ -20,4 +24,24 @@ func SetupX2MResponders() {
 		},
 	)
 	setupHandlers(handlers)
+}
+
+// NotarizationReceiptHandler - handles the receipt of a notarization
+// for a block.
+func NotarizationReceiptHandler(ctx context.Context, entity datastore.Entity) (interface{}, error) {
+	not, ok := entity.(*Notarization)
+	if !ok {
+		log.Panicf("unexpected type")
+	}
+
+	if isDelayingBlock(not.Round) {
+		go func() {
+			for bl := range delayedBlock {
+				GetMinerChain().sendBlock(context.Background(), bl)
+				close(delayedBlock)
+			}
+		}()
+	}
+
+	return notarizationReceiptHandler(ctx, entity)
 }

--- a/code/go/0chain.net/miner/m_handler_main.go
+++ b/code/go/0chain.net/miner/m_handler_main.go
@@ -7,3 +7,9 @@ package miner
 func SetupX2MResponders() {
 	setupHandlers(x2mRespondersMap())
 }
+
+// NotarizationReceiptHandler - handles the receipt of a notarization
+// for a block.
+func NotarizationReceiptHandler(ctx context.Context, entity datastore.Entity) (interface{}, error) {
+	return notarizationReceiptHandler(ctx, entity)
+}

--- a/docker.local/config/conductor.no-view-change.byzantine.yaml
+++ b/docker.local/config/conductor.no-view-change.byzantine.yaml
@@ -1,5 +1,6 @@
 enable:
   - "attack round transfer"
+  - "resend past messages"
 sets:
   - name: "attack round transfer"
     tests:
@@ -10,6 +11,9 @@ sets:
       - "send insufficient proposals"
       - "verifying non existent block"
       - "notarising non existent block"
+  - name: "resend past messages"
+    tests:
+      - "resend proposed block"
 
 tests:
   - name: "not notarised block extension"
@@ -18,8 +22,10 @@ tests:
       - cleanup_bc: { }
       - start: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - configure_not_notarised_block_extension_test_case:
-          enable: true
-          round: 30
+          test_report:
+            round: 30
+            by_generator: false
+            by_node_with_type_rank: 0
       - make_test_case_check:
           wait_time: 5m
 
@@ -28,7 +34,8 @@ tests:
       - cleanup_bc: { }
       - start: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - configure_send_different_blocks_from_first_generator_test_case:
-          round: 30
+          test_report:
+            round: 30
       - make_test_case_check:
           wait_time: 5m
 
@@ -37,7 +44,8 @@ tests:
       - cleanup_bc: { }
       - start: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - configure_send_different_blocks_from_all_generators_test_case:
-          round: 30
+          test_report:
+            round: 30
       - make_test_case_check:
           wait_time: 5m
 
@@ -46,7 +54,10 @@ tests:
       - cleanup_bc: { }
       - start: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - configure_breaking_single_block:
-          round: 30
+          test_report:
+            round: 30
+            by_generator: false
+            by_node_with_type_rank: 0
       - make_test_case_check:
           wait_time: 5m
 
@@ -59,7 +70,10 @@ tests:
           DKG_AFFIX: "7_miners_1_sharder_"
       - start: [ "miner-1", "miner-2", "miner-3", "miner-4", "miner-5", "miner-6",  "miner-7", "sharder-1"]
       - configure_send_insufficient_proposals_test_case:
-          round: 30
+          test_report:
+            round: 30
+            by_generator: false
+            by_node_with_type_rank: 0
       - make_test_case_check:
           wait_time: 5m
 
@@ -69,7 +83,8 @@ tests:
       - cleanup_bc: {}
       - start_lock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
       - configure_verifying_non_existent_block_test_case:
-          round: 30
+          test_report:
+            round: 30
           hash: "d0cab02dd0f094eaa2d136fa335d4fbb7858832caebc416982187b2c9b58cecc"
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
       - wait_round:
@@ -83,10 +98,26 @@ tests:
       - cleanup_bc: { }
       - start_lock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - configure_notarising_non_existent_block_test_case:
-          round: 30
+          test_report:
+            round: 30
+            by_generator: false
+            by_node_with_type_rank: 1
           hash: "d0cab02dd0f094eaa2d136fa335d4fbb7858832caebc416982187b2c9b58cecc"
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
           round: 50
+      - make_test_case_check:
+          wait_time: 5m
+
+  - name: "resend proposed block"
+    flow:
+      - set_monitor: "sharder-1"
+      - cleanup_bc: { }
+      - start: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - configure_resend_proposed_block_test_case:
+          test_report:
+            round: 30
+            by_generator: true
+            by_node_with_type_rank: 1
       - make_test_case_check:
           wait_time: 5m


### PR DESCRIPTION
```
// Miner sends previous proposed block used in notarized round with one/several blocks notarized in it to propose in new round
(T0) Leader_0: send Proposal0_0 (after getting first Notarisation)
(T0) Leader_1: send Proposal0_1
(T0 + δ + Δ) Replica_j: send VerificationTicket1_j
(T0 + 2δ + Δ) Replica_j: send Notarization0_1
(T0 + 3δ + Δ) Leader_1: resend Proposal0_0 (after getting Proposal0_0)
(T0 + 4δ + Δ) Replica_j: reject Proposal0_0
```