### PR TITLE
Conductor: Implement ResendNotarizasion test case

### DIFF
--- a/code/go/0chain.net/conductor/cases/breaking_single_block.go
+++ b/code/go/0chain.net/conductor/cases/breaking_single_block.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"0chain.net/chaincore/block"
-	"0chain.net/conductor/config"
 )
 
 type (
@@ -35,7 +34,7 @@ type (
 
 var (
 	// Ensure BreakingSingleBlock implements config.TestCase interface.
-	_ config.TestCase = (*BreakingSingleBlock)(nil)
+	_ TestCase = (*BreakingSingleBlock)(nil)
 )
 
 // NewBreakingSingleBlock creates initialised BreakingSingleBlock.

--- a/code/go/0chain.net/conductor/cases/interface.go
+++ b/code/go/0chain.net/conductor/cases/interface.go
@@ -1,4 +1,4 @@
-package config
+package cases
 
 import (
 	"context"

--- a/code/go/0chain.net/conductor/cases/misc.go
+++ b/code/go/0chain.net/conductor/cases/misc.go
@@ -14,6 +14,7 @@ type (
 		FinalisedBlockHash string       `json:"finalised_block_hash"`
 		ProposedBlocks     []*BlockInfo `json:"proposed_blocks"`
 		NotarisedBlocks    []*BlockInfo `json:"notarised_blocks"`
+		IsFinalised        bool         `json:"is_finalised"`
 	}
 
 	// BlockInfo represents simple struct for reports containing round's information

--- a/code/go/0chain.net/conductor/cases/not_notarised_block_extension.go
+++ b/code/go/0chain.net/conductor/cases/not_notarised_block_extension.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 
 	"0chain.net/chaincore/block"
-	"0chain.net/conductor/config"
 )
 
 type (
@@ -29,7 +28,7 @@ type (
 
 var (
 	// Ensure NotNotarisedBlockExtension implements config.TestCase interface.
-	_ config.TestCase = (*NotNotarisedBlockExtension)(nil)
+	_ TestCase = (*NotNotarisedBlockExtension)(nil)
 )
 
 // NewNotNotarisedBlockExtension creates initialised NotNotarisedBlockExtension.

--- a/code/go/0chain.net/conductor/cases/notarising_non_existent_block.go
+++ b/code/go/0chain.net/conductor/cases/notarising_non_existent_block.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"0chain.net/conductor/conductrpc/stats"
-	"0chain.net/conductor/config"
 )
 
 type (
@@ -28,7 +27,7 @@ type (
 
 var (
 	// Ensure NotarisingNonExistentBlock implements config.TestCase interface.
-	_ config.TestCase = (*NotarisingNonExistentBlock)(nil)
+	_ TestCase = (*NotarisingNonExistentBlock)(nil)
 )
 
 // NewNotarisingNonExistentBlock creates initialised NotarisingNonExistentBlock.

--- a/code/go/0chain.net/conductor/cases/resend_notarisation.go
+++ b/code/go/0chain.net/conductor/cases/resend_notarisation.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-
-	"0chain.net/conductor/config"
 )
 
 type (
@@ -28,7 +26,7 @@ type (
 
 var (
 	// Ensure ResendNotarisation implements config.TestCase interface.
-	_ config.TestCase = (*ResendNotarisation)(nil)
+	_ TestCase = (*ResendNotarisation)(nil)
 )
 
 // NewResendNotarisation creates initialised ResendNotarisation.
@@ -65,9 +63,8 @@ func (n *ResendNotarisation) check() (success bool, err error) {
 }
 
 // Configure implements config.TestCase interface.
-func (n *ResendNotarisation) Configure(blob []byte) error {
+func (n *ResendNotarisation) Configure(_ []byte) error {
 	panic("configuration for this test case is not allowed")
-	return nil
 }
 
 // AddResult implements config.TestCase interface.

--- a/code/go/0chain.net/conductor/cases/resend_notarisation.go
+++ b/code/go/0chain.net/conductor/cases/resend_notarisation.go
@@ -1,0 +1,78 @@
+package cases
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"0chain.net/conductor/config"
+)
+
+type (
+	// ResendNotarisation represents implementation of the config.TestCase interface.
+	//
+	//	Flow of this test case:
+	//		Miner sends previous notarization used in notarized/finalized round in new round
+	//		(T0) Replica_j: obtain Notarization0_0
+	//		(T1) Leader_1: send Proposal1_0
+	//		(T1 + δ + Δ) Replica_j: send VerificationTicket1_j
+	//		(T1 + 2δ + Δ) Replica_j: send Notarization1_1
+	//		(T1 + 3δ + Δ Replica_j: send Notarisation0_0
+	//		(T1 + 4δ + Δ) Replica_j+1: reject Notarization0_0
+	ResendNotarisation struct {
+		result *RoundInfo
+
+		wg *sync.WaitGroup
+	}
+)
+
+var (
+	// Ensure ResendNotarisation implements config.TestCase interface.
+	_ config.TestCase = (*ResendNotarisation)(nil)
+)
+
+// NewResendNotarisation creates initialised ResendNotarisation.
+func NewResendNotarisation() *ResendNotarisation {
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	return &ResendNotarisation{
+		wg: wg,
+	}
+}
+
+// Check implements config.TestCase interface.
+func (n *ResendNotarisation) Check(ctx context.Context) (success bool, err error) {
+	prepared := make(chan struct{})
+	go func() {
+		n.wg.Wait()
+		prepared <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return false, errors.New("cases state is not prepared, context is done")
+
+	case <-prepared:
+		return n.check()
+	}
+}
+
+func (n *ResendNotarisation) check() (success bool, err error) {
+	if !n.result.IsFinalised {
+		err = errors.New("round is not finalised")
+	}
+	return n.result.IsFinalised, err
+}
+
+// Configure implements config.TestCase interface.
+func (n *ResendNotarisation) Configure(blob []byte) error {
+	panic("configuration for this test case is not allowed")
+	return nil
+}
+
+// AddResult implements config.TestCase interface.
+func (n *ResendNotarisation) AddResult(blob []byte) error {
+	defer n.wg.Done()
+	n.result = new(RoundInfo)
+	return n.result.Decode(blob)
+}

--- a/code/go/0chain.net/conductor/cases/resend_proposed_block.go
+++ b/code/go/0chain.net/conductor/cases/resend_proposed_block.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-
-	"0chain.net/conductor/config"
 )
 
 type (
@@ -30,7 +28,7 @@ type (
 
 var (
 	// Ensure NotNotarisedBlockExtension implements config.TestCase interface.
-	_ config.TestCase = (*ResendProposedBlock)(nil)
+	_ TestCase = (*ResendProposedBlock)(nil)
 )
 
 // NewResendProposedBlock creates initialised ResendProposedBlock.

--- a/code/go/0chain.net/conductor/cases/send_diff_blocks.go
+++ b/code/go/0chain.net/conductor/cases/send_diff_blocks.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"strconv"
 	"sync"
-
-	"0chain.net/conductor/config"
 )
 
 type (
@@ -50,10 +48,10 @@ type (
 
 var (
 	// Ensure SendDifferentBlocksFromAllGenerators implements config.TestCase interface.
-	_ config.TestCase = (*SendDifferentBlocksFromAllGenerators)(nil)
+	_ TestCase = (*SendDifferentBlocksFromAllGenerators)(nil)
 
 	// Ensure SendDifferentBlocksFromFirstGenerator implements config.TestCase interface.
-	_ config.TestCase = (*SendDifferentBlocksFromFirstGenerator)(nil)
+	_ TestCase = (*SendDifferentBlocksFromFirstGenerator)(nil)
 )
 
 // NewSendDifferentBlocksFromAllGenerators creates initialised SendDifferentBlocksFromAllGenerators.

--- a/code/go/0chain.net/conductor/cases/send_insufficient_blocks.go
+++ b/code/go/0chain.net/conductor/cases/send_insufficient_blocks.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
-
-	"0chain.net/conductor/config"
 )
 
 type (
@@ -30,7 +28,7 @@ type (
 
 var (
 	// Ensure SendInsufficientProposals implements config.TestCase interface.
-	_ config.TestCase = (*SendInsufficientProposals)(nil)
+	_ TestCase = (*SendInsufficientProposals)(nil)
 )
 
 // NewSendInsufficientProposals creates initialised SendInsufficientProposals.

--- a/code/go/0chain.net/conductor/cases/verifying_non_existent_block.go
+++ b/code/go/0chain.net/conductor/cases/verifying_non_existent_block.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"0chain.net/conductor/conductrpc/stats"
-	"0chain.net/conductor/config"
 )
 
 type (
@@ -29,7 +28,7 @@ type (
 
 var (
 	// Ensure VerifyingNonExistentBlock implements config.TestCase interface.
-	_ config.TestCase = (*VerifyingNonExistentBlock)(nil)
+	_ TestCase = (*VerifyingNonExistentBlock)(nil)
 )
 
 // NewVerifyingNonExistentBlock creates initialised VerifyingNonExistentBlock.

--- a/code/go/0chain.net/conductor/conductor/executor.go
+++ b/code/go/0chain.net/conductor/conductor/executor.go
@@ -871,6 +871,24 @@ func (r *Runner) ConfigureResendProposedBlock(cfg *config.ResendProposedBlock) (
 	return
 }
 
+// ConfigureResendNotarisation implements config.Executor interface.
+func (r *Runner) ConfigureResendNotarisation(cfg *config.ResendNotarisation) (err error) {
+	if r.verbose {
+		log.Print(" [INF] configure \"resend notarisation\"")
+	}
+
+	err = r.server.UpdateAllStates(func(state *conductrpc.State) {
+		state.ResendNotarisation = cfg
+	})
+	if err != nil {
+		return fmt.Errorf("error while configuring \"resend notarisation\" test case: %v", err)
+	}
+
+	r.server.CurrentTest = cases.NewResendNotarisation()
+
+	return
+}
+
 // MakeTestCaseCheck implements config.Executor interface.
 func (r *Runner) MakeTestCaseCheck(cfg *config.TestCaseCheck) error {
 	if r.verbose {

--- a/code/go/0chain.net/conductor/conductrpc/server.go
+++ b/code/go/0chain.net/conductor/conductrpc/server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"0chain.net/conductor/cases"
 	"0chain.net/conductor/conductrpc/stats"
 	"0chain.net/conductor/config"
 )
@@ -112,7 +113,7 @@ type Server struct {
 	// it work. E.g. the node has started and waits the conductor to enter BC.
 	onNodeReady chan NodeName
 
-	CurrentTest config.TestCase
+	CurrentTest cases.TestCase
 
 	onRoundEvent              chan *RoundEvent
 	onContributeMPKEvent      chan *ContributeMPKEvent

--- a/code/go/0chain.net/conductor/conductrpc/state.go
+++ b/code/go/0chain.net/conductor/conductrpc/state.go
@@ -2,6 +2,7 @@ package conductrpc
 
 import (
 	"0chain.net/conductor/config"
+	"0chain.net/conductor/config/cases"
 )
 
 //
@@ -47,15 +48,15 @@ type State struct {
 	Signatures *config.Bad
 	Publish    *config.Bad
 
-	ExtendNotNotarisedBlock               *config.DefaultTestCase
-	SendDifferentBlocksFromFirstGenerator *config.DefaultTestCase
-	SendDifferentBlocksFromAllGenerators  *config.DefaultTestCase
-	BreakingSingleBlock                   *config.DefaultTestCase
-	SendInsufficientProposals             *config.DefaultTestCase
-	VerifyingNonExistentBlock             *config.VerifyingNonExistentBlock
-	NotarisingNonExistentBlock            *config.NotarisingNonExistentBlock
-	ResendProposedBlock                   *config.ResendProposedBlock
-	ResendNotarisation                    *config.ResendNotarisation
+	ExtendNotNotarisedBlock               *cases.NotNotarisedBlockExtension
+	SendDifferentBlocksFromFirstGenerator *cases.SendDifferentBlocksFromFirstGenerator
+	SendDifferentBlocksFromAllGenerators  *cases.SendDifferentBlocksFromAllGenerators
+	BreakingSingleBlock                   *cases.BreakingSingleBlock
+	SendInsufficientProposals             *cases.SendInsufficientProposals
+	VerifyingNonExistentBlock             *cases.VerifyingNonExistentBlock
+	NotarisingNonExistentBlock            *cases.NotarisingNonExistentBlock
+	ResendProposedBlock                   *cases.ResendProposedBlock
+	ResendNotarisation                    *cases.ResendNotarisation
 
 	// Blobbers related states
 	StorageTree    *config.Bad // blobber sends bad files/tree responses

--- a/code/go/0chain.net/conductor/conductrpc/state.go
+++ b/code/go/0chain.net/conductor/conductrpc/state.go
@@ -55,6 +55,7 @@ type State struct {
 	VerifyingNonExistentBlock             *config.VerifyingNonExistentBlock
 	NotarisingNonExistentBlock            *config.NotarisingNonExistentBlock
 	ResendProposedBlock                   *config.ResendProposedBlock
+	ResendNotarisation                    *config.ResendNotarisation
 
 	// Blobbers related states
 	StorageTree    *config.Bad // blobber sends bad files/tree responses

--- a/code/go/0chain.net/conductor/config/byzantine.go
+++ b/code/go/0chain.net/conductor/config/byzantine.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -94,133 +93,12 @@ func (b *Bad) IsCompetingGroupMember(state Namer, id string) (ok bool) {
 }
 
 type (
-	// TestCaseConfigurator represents interface for test cases configuration.
-	TestCaseConfigurator interface {
-		IsTesting(round int64, generator bool, typeRank int) bool
-	}
-
-	// DefaultTestCase represents default configuration for test cases.
-	DefaultTestCase struct {
-		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
-	}
-
-	// VerifyingNonExistentBlock represents config for cases.VerifyingNonExistentBlock.
-	VerifyingNonExistentBlock struct {
-		Hash       string `json:"hash" yaml:"hash" mapstructure:"hash"`
-		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
-
-		IgnoredVerificationTicketsNum int
-	}
-
-	// NotarisingNonExistentBlock represents config for cases.NotarisingNonExistentBlock.
-	NotarisingNonExistentBlock struct {
-		Hash       string `json:"hash" yaml:"hash" mapstructure:"hash"`
-		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
-	}
-
-	// ResendProposedBlock represents config for cases.ResendProposedBlock.
-	ResendProposedBlock struct {
-		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
-
-		Resent bool
-
-		mutex sync.Mutex
-	}
-
-	// ResendNotarisation represents config for cases.ResendNotarisation.
-	ResendNotarisation struct {
-		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
-
-		Notarisation []byte
-		Resent       bool
-
-		mutex sync.Mutex
-	}
-
-	TestReport struct {
-		ByGenerator        bool  `json:"by_generator" yaml:"by_generator" mapstructure:"by_generator"`
-		ByNodeWithTypeRank int   `json:"by_node_with_type_rank" yaml:"by_node_with_type_rank" mapstructure:"by_node_with_type_rank"`
-		OnRound            int64 `json:"round" yaml:"round" mapstructure:"round"`
-	}
-
 	// TestCaseCheck represents generic configuration for making tests checks.
 	TestCaseCheck struct {
 		WaitTimeStr string `mapstructure:"wait_time"`
 		WaitTime    time.Duration
 	}
 )
-
-var (
-	// Ensure DefaultTestCase implements TestCaseConfigurator interface.
-	_ TestCaseConfigurator = (*DefaultTestCase)(nil)
-
-	// Ensure VerifyingNonExistentBlock implements TestCaseConfigurator interface.
-	_ TestCaseConfigurator = (*VerifyingNonExistentBlock)(nil)
-
-	// Ensure NotarisingNonExistentBlock implements TestCaseConfigurator interface.
-	_ TestCaseConfigurator = (*NotarisingNonExistentBlock)(nil)
-
-	// Ensure ResendProposedBlock implements TestCaseConfigurator interface.
-	_ TestCaseConfigurator = (*ResendProposedBlock)(nil)
-)
-
-// IsTesting implements TestCaseConfigurator interface.
-func (b *TestReport) IsTesting(round int64, generator bool, nodeTypeRank int) bool {
-	return b.OnRound == round && b.ByGenerator == generator && nodeTypeRank == b.ByNodeWithTypeRank
-}
-
-// Decode decodes provided interface by executing mapstructure.Decode.
-func (c *DefaultTestCase) Decode(val interface{}) error {
-	return mapstructure.Decode(val, c)
-}
-
-// Decode decodes provided interface by executing mapstructure.Decode.
-func (c *VerifyingNonExistentBlock) Decode(val interface{}) error {
-	return mapstructure.Decode(val, c)
-}
-
-// Decode decodes provided interface by executing mapstructure.Decode.
-func (c *NotarisingNonExistentBlock) Decode(val interface{}) error {
-	return mapstructure.Decode(val, c)
-}
-
-func (c *ResendProposedBlock) Lock() {
-	if c == nil {
-		return
-	}
-	c.mutex.Lock()
-}
-
-func (c *ResendProposedBlock) Unlock() {
-	if c == nil {
-		return
-	}
-	c.mutex.Unlock()
-}
-
-// Decode decodes provided interface by executing mapstructure.Decode.
-func (c *ResendProposedBlock) Decode(val interface{}) error {
-	return mapstructure.Decode(val, c)
-}
-
-func (c *ResendNotarisation) Lock() {
-	if c == nil {
-		return
-	}
-	c.mutex.Lock()
-}
-
-func (c *ResendNotarisation) Unlock() {
-	if c == nil {
-		return
-	}
-	c.mutex.Unlock()
-}
-
-// Decode decodes provided interface by executing mapstructure.Decode.
-func (c *ResendNotarisation) Decode(val interface{}) error {
-	return mapstructure.Decode(val, c)
-}
 
 // Decode decodes provided interface by executing mapstructure.Decode.
 func (c *TestCaseCheck) Decode(val interface{}) (err error) {

--- a/code/go/0chain.net/conductor/config/byzantine.go
+++ b/code/go/0chain.net/conductor/config/byzantine.go
@@ -127,6 +127,16 @@ type (
 		mutex sync.Mutex
 	}
 
+	// ResendNotarisation represents config for cases.ResendNotarisation.
+	ResendNotarisation struct {
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+
+		Notarisation []byte
+		Resent       bool
+
+		mutex sync.Mutex
+	}
+
 	TestReport struct {
 		ByGenerator        bool  `json:"by_generator" yaml:"by_generator" mapstructure:"by_generator"`
 		ByNodeWithTypeRank int   `json:"by_node_with_type_rank" yaml:"by_node_with_type_rank" mapstructure:"by_node_with_type_rank"`
@@ -161,26 +171,17 @@ func (b *TestReport) IsTesting(round int64, generator bool, nodeTypeRank int) bo
 
 // Decode decodes provided interface by executing mapstructure.Decode.
 func (c *DefaultTestCase) Decode(val interface{}) error {
-	if err := mapstructure.Decode(val, c); err != nil {
-		return err
-	}
-	return nil
+	return mapstructure.Decode(val, c)
 }
 
 // Decode decodes provided interface by executing mapstructure.Decode.
 func (c *VerifyingNonExistentBlock) Decode(val interface{}) error {
-	if err := mapstructure.Decode(val, c); err != nil {
-		return err
-	}
-	return nil
+	return mapstructure.Decode(val, c)
 }
 
 // Decode decodes provided interface by executing mapstructure.Decode.
 func (c *NotarisingNonExistentBlock) Decode(val interface{}) error {
-	if err := mapstructure.Decode(val, c); err != nil {
-		return err
-	}
-	return nil
+	return mapstructure.Decode(val, c)
 }
 
 func (c *ResendProposedBlock) Lock() {
@@ -199,10 +200,26 @@ func (c *ResendProposedBlock) Unlock() {
 
 // Decode decodes provided interface by executing mapstructure.Decode.
 func (c *ResendProposedBlock) Decode(val interface{}) error {
-	if err := mapstructure.Decode(val, c); err != nil {
-		return err
+	return mapstructure.Decode(val, c)
+}
+
+func (c *ResendNotarisation) Lock() {
+	if c == nil {
+		return
 	}
-	return nil
+	c.mutex.Lock()
+}
+
+func (c *ResendNotarisation) Unlock() {
+	if c == nil {
+		return
+	}
+	c.mutex.Unlock()
+}
+
+// Decode decodes provided interface by executing mapstructure.Decode.
+func (c *ResendNotarisation) Decode(val interface{}) error {
+	return mapstructure.Decode(val, c)
 }
 
 // Decode decodes provided interface by executing mapstructure.Decode.

--- a/code/go/0chain.net/conductor/config/cases/breaking_single_block.go
+++ b/code/go/0chain.net/conductor/config/cases/breaking_single_block.go
@@ -1,0 +1,42 @@
+package cases
+
+import (
+	"0chain.net/conductor/cases"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// BreakingSingleBlock represents TestCaseConfigurator implementation.
+	BreakingSingleBlock struct {
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+	}
+)
+
+const (
+	BreakingSingleBlockName = "breaking single block"
+)
+
+var (
+	// Ensure BreakingSingleBlock implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*BreakingSingleBlock)(nil)
+)
+
+// NewBreakingSingleBlock creates initialised BreakingSingleBlock.
+func NewBreakingSingleBlock() *BreakingSingleBlock {
+	return new(BreakingSingleBlock)
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *BreakingSingleBlock) TestCase() cases.TestCase {
+	return cases.NewBreakingSingleBlock()
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *BreakingSingleBlock) Name() string {
+	return BreakingSingleBlockName
+}
+
+// Decode implements MapDecoder interface.
+func (n *BreakingSingleBlock) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}

--- a/code/go/0chain.net/conductor/config/cases/interface.go
+++ b/code/go/0chain.net/conductor/config/cases/interface.go
@@ -1,0 +1,19 @@
+package cases
+
+import (
+	"0chain.net/conductor/cases"
+)
+
+type (
+	// TestCaseConfigurator represents interface for configuring test cases.
+	TestCaseConfigurator interface {
+		TestCase() cases.TestCase
+		Name() string
+
+		MapDecoder
+	}
+
+	MapDecoder interface {
+		Decode(val interface{}) error
+	}
+)

--- a/code/go/0chain.net/conductor/config/cases/not_notarised_block_extension.go
+++ b/code/go/0chain.net/conductor/config/cases/not_notarised_block_extension.go
@@ -1,0 +1,42 @@
+package cases
+
+import (
+	"0chain.net/conductor/cases"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// NotNotarisedBlockExtension represents TestCaseConfigurator implementation.
+	NotNotarisedBlockExtension struct {
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+	}
+)
+
+const (
+	NotNotarisedBlockExtensionName = "not notarised block extension"
+)
+
+var (
+	// Ensure NotNotarisedBlockExtension implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*NotNotarisedBlockExtension)(nil)
+)
+
+// NewNotNotarisedBlockExtension creates initialised NotNotarisedBlockExtension.
+func NewNotNotarisedBlockExtension() *NotNotarisedBlockExtension {
+	return new(NotNotarisedBlockExtension)
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *NotNotarisedBlockExtension) TestCase() cases.TestCase {
+	return cases.NewNotNotarisedBlockExtension()
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *NotNotarisedBlockExtension) Name() string {
+	return NotNotarisedBlockExtensionName
+}
+
+// Decode implements MapDecoder interface.
+func (n *NotNotarisedBlockExtension) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}

--- a/code/go/0chain.net/conductor/config/cases/notarising_non_existent_block.go
+++ b/code/go/0chain.net/conductor/config/cases/notarising_non_existent_block.go
@@ -1,0 +1,49 @@
+package cases
+
+import (
+	"0chain.net/conductor/cases"
+	"0chain.net/conductor/conductrpc/stats"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// NotarisingNonExistentBlock represents TestCaseConfigurator implementation.
+	NotarisingNonExistentBlock struct {
+		Hash string `json:"hash" yaml:"hash" mapstructure:"hash"`
+
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+
+		statsCollector *stats.NodesServerStats
+	}
+)
+
+const (
+	NotarisingNonExistentBlockName = "notarising non existent block"
+)
+
+var (
+	// Ensure NotarisingNonExistentBlock implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*NotarisingNonExistentBlock)(nil)
+)
+
+// NewNotarisingNonExistentBlock creates initialised NotarisingNonExistentBlock.
+func NewNotarisingNonExistentBlock(statsCollector *stats.NodesServerStats) *NotarisingNonExistentBlock {
+	return &NotarisingNonExistentBlock{
+		statsCollector: statsCollector,
+	}
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *NotarisingNonExistentBlock) TestCase() cases.TestCase {
+	return cases.NewNotarisingNonExistentBlock(n.statsCollector)
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *NotarisingNonExistentBlock) Name() string {
+	return NotarisingNonExistentBlockName
+}
+
+// Decode implements MapDecoder interface.
+func (n *NotarisingNonExistentBlock) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}

--- a/code/go/0chain.net/conductor/config/cases/report.go
+++ b/code/go/0chain.net/conductor/config/cases/report.go
@@ -1,0 +1,14 @@
+package cases
+
+type (
+	TestReport struct {
+		ByGenerator        bool  `json:"by_generator" yaml:"by_generator" mapstructure:"by_generator"`
+		ByNodeWithTypeRank int   `json:"by_node_with_type_rank" yaml:"by_node_with_type_rank" mapstructure:"by_node_with_type_rank"`
+		OnRound            int64 `json:"round" yaml:"round" mapstructure:"round"`
+	}
+)
+
+// IsTesting implements TestCaseConfigurator interface.
+func (b *TestReport) IsTesting(round int64, generator bool, nodeTypeRank int) bool {
+	return b.OnRound == round && b.ByGenerator == generator && nodeTypeRank == b.ByNodeWithTypeRank
+}

--- a/code/go/0chain.net/conductor/config/cases/resend_notarisation.go
+++ b/code/go/0chain.net/conductor/config/cases/resend_notarisation.go
@@ -1,0 +1,63 @@
+package cases
+
+import (
+	"sync"
+
+	"0chain.net/conductor/cases"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// ResendNotarisation represents TestCaseConfigurator implementation.
+	ResendNotarisation struct {
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+
+		Notarisation []byte
+		Resent       bool
+
+		mutex sync.Mutex
+	}
+)
+
+const (
+	ResendNotarisationName = "resend notarisation"
+)
+
+var (
+	// Ensure ResendNotarisation implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*ResendNotarisation)(nil)
+)
+
+// NewResendNotarisation creates initialised ResendNotarisation.
+func NewResendNotarisation() *ResendNotarisation {
+	return new(ResendNotarisation)
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *ResendNotarisation) TestCase() cases.TestCase {
+	return cases.NewResendNotarisation()
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *ResendNotarisation) Name() string {
+	return ResendNotarisationName
+}
+
+// Decode implements MapDecoder interface.
+func (n *ResendNotarisation) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}
+
+func (n *ResendNotarisation) Lock() {
+	if n == nil {
+		return
+	}
+	n.mutex.Lock()
+}
+
+func (n *ResendNotarisation) Unlock() {
+	if n == nil {
+		return
+	}
+	n.mutex.Unlock()
+}

--- a/code/go/0chain.net/conductor/config/cases/resend_proposed_block.go
+++ b/code/go/0chain.net/conductor/config/cases/resend_proposed_block.go
@@ -1,0 +1,62 @@
+package cases
+
+import (
+	"sync"
+
+	"0chain.net/conductor/cases"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// ResendProposedBlock represents TestCaseConfigurator implementation.
+	ResendProposedBlock struct {
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+
+		Resent bool
+
+		mutex sync.Mutex
+	}
+)
+
+const (
+	ResendProposedBlockName = "resend proposed block"
+)
+
+var (
+	// Ensure ResendProposedBlock implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*ResendProposedBlock)(nil)
+)
+
+// NewResendProposedBlock creates initialised ResendProposedBlock.
+func NewResendProposedBlock() *ResendProposedBlock {
+	return new(ResendProposedBlock)
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *ResendProposedBlock) TestCase() cases.TestCase {
+	return cases.NewResendProposedBlock()
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *ResendProposedBlock) Name() string {
+	return ResendProposedBlockName
+}
+
+// Decode implements MapDecoder interface.
+func (n *ResendProposedBlock) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}
+
+func (n *ResendProposedBlock) Lock() {
+	if n == nil {
+		return
+	}
+	n.mutex.Lock()
+}
+
+func (n *ResendProposedBlock) Unlock() {
+	if n == nil {
+		return
+	}
+	n.mutex.Unlock()
+}

--- a/code/go/0chain.net/conductor/config/cases/send_diff_blocks_from_all_gen.go
+++ b/code/go/0chain.net/conductor/config/cases/send_diff_blocks_from_all_gen.go
@@ -1,0 +1,46 @@
+package cases
+
+import (
+	"0chain.net/conductor/cases"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// SendDifferentBlocksFromAllGenerators represents TestCaseConfigurator implementation.
+	SendDifferentBlocksFromAllGenerators struct {
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+
+		minersNum int
+	}
+)
+
+const (
+	SendDifferentBlocksFromAllGeneratorsName = "send different blocks from all generators"
+)
+
+var (
+	// Ensure SendDifferentBlocksFromAllGenerators implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*SendDifferentBlocksFromAllGenerators)(nil)
+)
+
+// NewSendDifferentBlocksFromAllGenerators creates initialised SendDifferentBlocksFromAllGenerators.
+func NewSendDifferentBlocksFromAllGenerators(minersNum int) *SendDifferentBlocksFromAllGenerators {
+	return &SendDifferentBlocksFromAllGenerators{
+		minersNum: minersNum,
+	}
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *SendDifferentBlocksFromAllGenerators) TestCase() cases.TestCase {
+	return cases.NewSendDifferentBlocksFromAllGenerators(n.minersNum)
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *SendDifferentBlocksFromAllGenerators) Name() string {
+	return SendDifferentBlocksFromAllGeneratorsName
+}
+
+// Decode implements MapDecoder interface.
+func (n *SendDifferentBlocksFromAllGenerators) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}

--- a/code/go/0chain.net/conductor/config/cases/send_diff_blocks_from_first_gen.go
+++ b/code/go/0chain.net/conductor/config/cases/send_diff_blocks_from_first_gen.go
@@ -1,0 +1,46 @@
+package cases
+
+import (
+	"0chain.net/conductor/cases"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// SendDifferentBlocksFromFirstGenerator represents TestCaseConfigurator implementation.
+	SendDifferentBlocksFromFirstGenerator struct {
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+
+		minersNum int
+	}
+)
+
+const (
+	SendDifferentBlocksFromFirstGeneratorName = "send different blocks from first generator"
+)
+
+var (
+	// Ensure SendDifferentBlocksFromFirstGenerator implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*SendDifferentBlocksFromFirstGenerator)(nil)
+)
+
+// NewSendDifferentBlocksFromFirstGenerator creates initialised SendDifferentBlocksFromFirstGenerator.
+func NewSendDifferentBlocksFromFirstGenerator(minersNum int) *SendDifferentBlocksFromFirstGenerator {
+	return &SendDifferentBlocksFromFirstGenerator{
+		minersNum: minersNum,
+	}
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *SendDifferentBlocksFromFirstGenerator) TestCase() cases.TestCase {
+	return cases.NewSendDifferentBlocksFromFirstGenerator(n.minersNum)
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *SendDifferentBlocksFromFirstGenerator) Name() string {
+	return SendDifferentBlocksFromFirstGeneratorName
+}
+
+// Decode implements MapDecoder interface.
+func (n *SendDifferentBlocksFromFirstGenerator) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}

--- a/code/go/0chain.net/conductor/config/cases/send_insufficient_blocks.go
+++ b/code/go/0chain.net/conductor/config/cases/send_insufficient_blocks.go
@@ -1,0 +1,42 @@
+package cases
+
+import (
+	"0chain.net/conductor/cases"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// SendInsufficientProposals represents TestCaseConfigurator implementation.
+	SendInsufficientProposals struct {
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+	}
+)
+
+const (
+	SendInsufficientProposalsName = "send insufficient proposals"
+)
+
+var (
+	// Ensure SendInsufficientProposals implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*SendInsufficientProposals)(nil)
+)
+
+// NewSendInsufficientProposals creates initialised SendInsufficientProposals.
+func NewSendInsufficientProposals() *SendInsufficientProposals {
+	return new(SendInsufficientProposals)
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *SendInsufficientProposals) TestCase() cases.TestCase {
+	return cases.NewSendInsufficientProposals()
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *SendInsufficientProposals) Name() string {
+	return SendInsufficientProposalsName
+}
+
+// Decode implements MapDecoder interface.
+func (n *SendInsufficientProposals) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}

--- a/code/go/0chain.net/conductor/config/cases/verifying_non_existent_block.go
+++ b/code/go/0chain.net/conductor/config/cases/verifying_non_existent_block.go
@@ -1,0 +1,50 @@
+package cases
+
+import (
+	"0chain.net/conductor/cases"
+	"0chain.net/conductor/conductrpc/stats"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// VerifyingNonExistentBlock represents TestCaseConfigurator implementation.
+	VerifyingNonExistentBlock struct {
+		Hash       string `json:"hash" yaml:"hash" mapstructure:"hash"`
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+
+		IgnoredVerificationTicketsNum int
+
+		statsCollector *stats.NodesServerStats
+	}
+)
+
+const (
+	VerifyingNonExistentBlockName = "verifying non existent block"
+)
+
+var (
+	// Ensure VerifyingNonExistentBlock implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*VerifyingNonExistentBlock)(nil)
+)
+
+// NewVerifyingNonExistentBlock creates initialised VerifyingNonExistentBlock.
+func NewVerifyingNonExistentBlock(statsCollector *stats.NodesServerStats) *VerifyingNonExistentBlock {
+	return &VerifyingNonExistentBlock{
+		statsCollector: statsCollector,
+	}
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *VerifyingNonExistentBlock) TestCase() cases.TestCase {
+	return cases.NewVerifyingNonExistentBlock(n.Hash, int(n.TestReport.OnRound), n.statsCollector)
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *VerifyingNonExistentBlock) Name() string {
+	return VerifyingNonExistentBlockName
+}
+
+// Decode implements MapDecoder interface.
+func (n *VerifyingNonExistentBlock) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}

--- a/code/go/0chain.net/conductor/config/execute.go
+++ b/code/go/0chain.net/conductor/config/execute.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"0chain.net/conductor/conductrpc/stats"
+	"0chain.net/conductor/config/cases"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -79,36 +81,19 @@ type Executor interface {
 	ValidatorProof(vp *Bad) (err error)
 	Challenges(cs *Bad) (err error)
 
-	// ConfigureNotNotarisedBlockExtensionCheck prepares state for cases.NotNotarisedBlockExtension test case.
-	ConfigureNotNotarisedBlockExtensionCheck(*DefaultTestCase) (err error)
+	// MinersNum returns number of miner nodes.
+	MinersNum() int
 
-	// ConfigureSendDifferentBlocksFromFirstGenerator prepares state for cases.SendDifferentBlocksFromFirstGenerator test case.
-	ConfigureSendDifferentBlocksFromFirstGenerator(*DefaultTestCase) (err error)
+	// EnableServerStatsCollector enables server stats collecting.
+	EnableServerStatsCollector() error
 
-	// ConfigureSendDifferentBlocksFromAllGenerators prepares state for
-	// cases.SendDifferentBlocksFromAllGenerators test case.
-	ConfigureSendDifferentBlocksFromAllGenerators(*DefaultTestCase) (err error)
+	// GetServerStatsCollector returns current server stats collector.
+	GetServerStatsCollector() *stats.NodesServerStats
 
-	// ConfigureBreakingSingleBlock prepares state for cases.BreakingSingleBlock test case.
-	ConfigureBreakingSingleBlock(cfg *DefaultTestCase) (err error)
+	// ConfigureTestCase runs cases.TestCase's configuring with cases.TestCaseConfigurator configuration.
+	ConfigureTestCase(cases.TestCaseConfigurator) error
 
-	// ConfigureSendInsufficientProposals prepares state for
-	// cases.SendInsufficientProposals test case.
-	ConfigureSendInsufficientProposals(*DefaultTestCase) (err error)
-
-	// ConfigureVerifyingNonExistentBlockTestCase prepares state for cases.VerifyingNonExistentBlock test case.
-	ConfigureVerifyingNonExistentBlockTestCase(*VerifyingNonExistentBlock) (err error)
-
-	// ConfigureNotarisingNonExistentBlockTestCase prepares state for cases.NotarisingNonExistentBlock test case.
-	ConfigureNotarisingNonExistentBlockTestCase(*NotarisingNonExistentBlock) (err error)
-
-	// ConfigureResendProposedBlock prepares state for cases.ResendProposedBlock test case.
-	ConfigureResendProposedBlock(*ResendProposedBlock) (err error)
-
-	// ConfigureResendNotarisation prepares state for cases.ResendNotarisation test case.
-	ConfigureResendNotarisation(*ResendNotarisation) (err error)
-
-	// MakeTestCaseCheck runs config.TestCase final check with TestCaseCheck configuration.
+	// MakeTestCaseCheck runs cases.TestCase's final check with TestCaseCheck configuration.
 	MakeTestCaseCheck(*TestCaseCheck) error
 }
 

--- a/code/go/0chain.net/conductor/config/execute.go
+++ b/code/go/0chain.net/conductor/config/execute.go
@@ -105,6 +105,9 @@ type Executor interface {
 	// ConfigureResendProposedBlock prepares state for cases.ResendProposedBlock test case.
 	ConfigureResendProposedBlock(*ResendProposedBlock) (err error)
 
+	// ConfigureResendNotarisation prepares state for cases.ResendNotarisation test case.
+	ConfigureResendNotarisation(*ResendNotarisation) (err error)
+
 	// MakeTestCaseCheck runs config.TestCase final check with TestCaseCheck configuration.
 	MakeTestCaseCheck(*TestCaseCheck) error
 }

--- a/code/go/0chain.net/conductor/config/registry.go
+++ b/code/go/0chain.net/conductor/config/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"0chain.net/conductor/config/cases"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -362,83 +363,101 @@ func init() {
 
 	register("configure_not_notarised_block_extension_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &DefaultTestCase{}
+
+		cfg := cases.NewNotNotarisedBlockExtension()
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
-		return ex.ConfigureNotNotarisedBlockExtensionCheck(cfg)
+
+		return ex.ConfigureTestCase(cfg)
 	})
 
 	register("configure_send_different_blocks_from_first_generator_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &DefaultTestCase{}
+
+		cfg := cases.NewSendDifferentBlocksFromFirstGenerator(ex.MinersNum())
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
-		return ex.ConfigureSendDifferentBlocksFromFirstGenerator(cfg)
+		return ex.ConfigureTestCase(cfg)
 	})
 
 	register("configure_send_different_blocks_from_all_generators_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &DefaultTestCase{}
+
+		cfg := cases.NewSendDifferentBlocksFromAllGenerators(ex.MinersNum())
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
-		return ex.ConfigureSendDifferentBlocksFromAllGenerators(cfg)
+		return ex.ConfigureTestCase(cfg)
 	})
 
 	register("configure_breaking_single_block", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &DefaultTestCase{}
+
+		cfg := cases.NewBreakingSingleBlock()
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
-		return ex.ConfigureBreakingSingleBlock(cfg)
+		return ex.ConfigureTestCase(cfg)
 	})
 
 	register("configure_send_insufficient_proposals_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &DefaultTestCase{}
+
+		cfg := cases.NewSendInsufficientProposals()
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
-		return ex.ConfigureSendInsufficientProposals(cfg)
+		return ex.ConfigureTestCase(cfg)
 	})
 
 	register("configure_verifying_non_existent_block_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &VerifyingNonExistentBlock{}
+
+		if err := ex.EnableServerStatsCollector(); err != nil {
+			return fmt.Errorf("error while enabling server stats collector: %v", err)
+		}
+
+		cfg := cases.NewVerifyingNonExistentBlock(ex.GetServerStatsCollector())
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
-		return ex.ConfigureVerifyingNonExistentBlockTestCase(cfg)
+		return ex.ConfigureTestCase(cfg)
 	})
 
 	register("configure_notarising_non_existent_block_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &NotarisingNonExistentBlock{}
+
+		if err := ex.EnableServerStatsCollector(); err != nil {
+			return fmt.Errorf("error while enabling server stats collector: %v", err)
+		}
+
+		cfg := cases.NewNotarisingNonExistentBlock(ex.GetServerStatsCollector())
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
-		return ex.ConfigureNotarisingNonExistentBlockTestCase(cfg)
+		return ex.ConfigureTestCase(cfg)
 	})
 
 	register("configure_resend_proposed_block_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &ResendProposedBlock{}
+
+		cfg := cases.NewResendProposedBlock()
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
-		return ex.ConfigureResendProposedBlock(cfg)
+		return ex.ConfigureTestCase(cfg)
 	})
 
 	register("configure_resend_notarisation_test_case", func(name string,
 		ex Executor, val interface{}, tm time.Duration) (err error) {
-		cfg := &ResendNotarisation{}
+
+		cfg := cases.NewResendNotarisation()
 		if err := cfg.Decode(val); err != nil {
 			return err
 		}
-		return ex.ConfigureResendNotarisation(cfg)
+		return ex.ConfigureTestCase(cfg)
 	})
 
 	register("make_test_case_check", func(name string, ex Executor, val interface{}, tm time.Duration) (err error) {

--- a/code/go/0chain.net/conductor/config/registry.go
+++ b/code/go/0chain.net/conductor/config/registry.go
@@ -432,6 +432,15 @@ func init() {
 		return ex.ConfigureResendProposedBlock(cfg)
 	})
 
+	register("configure_resend_notarisation_test_case", func(name string,
+		ex Executor, val interface{}, tm time.Duration) (err error) {
+		cfg := &ResendNotarisation{}
+		if err := cfg.Decode(val); err != nil {
+			return err
+		}
+		return ex.ConfigureResendNotarisation(cfg)
+	})
+
 	register("make_test_case_check", func(name string, ex Executor, val interface{}, tm time.Duration) (err error) {
 		cfg := &TestCaseCheck{}
 		if err := cfg.Decode(val); err != nil {

--- a/code/go/0chain.net/miner/protocol_block_integration_tests.go
+++ b/code/go/0chain.net/miner/protocol_block_integration_tests.go
@@ -21,7 +21,6 @@ import (
 	"0chain.net/chaincore/transaction"
 	"0chain.net/conductor/cases"
 	crpc "0chain.net/conductor/conductrpc"
-	cfg "0chain.net/conductor/config"
 	crpcutils "0chain.net/conductor/utils"
 	"0chain.net/core/common"
 	"0chain.net/core/datastore"
@@ -340,32 +339,32 @@ func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
 
 func isTestingOnUpdateFinalizedBlock(round int64) bool {
 	s := crpc.Client().State()
-	var configurator cfg.TestCaseConfigurator
+	var isTestingFunc func(round int64, generator bool, typeRank int) bool
 	switch {
 	case s.ExtendNotNotarisedBlock != nil:
-		configurator = s.ExtendNotNotarisedBlock
+		isTestingFunc = s.ExtendNotNotarisedBlock.IsTesting
 
 	case s.BreakingSingleBlock != nil:
-		configurator = s.BreakingSingleBlock
+		isTestingFunc = s.BreakingSingleBlock.IsTesting
 
 	case s.SendInsufficientProposals != nil:
-		configurator = s.SendInsufficientProposals
+		isTestingFunc = s.SendInsufficientProposals.IsTesting
 
 	case s.NotarisingNonExistentBlock != nil:
-		configurator = s.NotarisingNonExistentBlock
+		isTestingFunc = s.NotarisingNonExistentBlock.IsTesting
 
 	case s.ResendProposedBlock != nil:
-		configurator = s.ResendProposedBlock
+		isTestingFunc = s.ResendProposedBlock.IsTesting
 
 	case s.ResendNotarisation != nil:
-		configurator = s.ResendNotarisation
+		isTestingFunc = s.ResendNotarisation.IsTesting
 
 	default:
 		return false
 	}
 
 	nodeType, typeRank := getNodeTypeAndTypeRank(round)
-	return configurator.IsTesting(round, nodeType == generator, typeRank)
+	return isTestingFunc(round, nodeType == generator, typeRank)
 }
 
 func addRoundInfoResult(finalisedBlockHash string, r round.RoundI) error {

--- a/docker.local/config/conductor.no-view-change.byzantine.yaml
+++ b/docker.local/config/conductor.no-view-change.byzantine.yaml
@@ -14,6 +14,7 @@ sets:
   - name: "resend past messages"
     tests:
       - "resend proposed block"
+      - "resend notarisation"
 
 tests:
   - name: "not notarised block extension"
@@ -119,5 +120,18 @@ tests:
             round: 30
             by_generator: true
             by_node_with_type_rank: 1
+      - make_test_case_check:
+          wait_time: 5m
+
+  - name: "resend notarisation"
+    flow:
+      - set_monitor: "sharder-1"
+      - cleanup_bc: { }
+      - start: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - configure_resend_notarisation_test_case:
+          test_report:
+            round: 30
+            by_generator: false
+            by_node_with_type_rank: 0
       - make_test_case_check:
           wait_time: 5m


### PR DESCRIPTION
// Miner sends previous notarization used in notarized/finalized round in new round
(T0) Replica_j: obtain Notarization0_0
(T1) Leader_1: send Proposal1_0
(T1 + δ + Δ) Replica_j: send VerificationTicket1_j  
(T1 + 2δ + Δ) Replica_j: send Notarization1_1 
(T1 + 3δ + Δ Replica_j: send Notarisation0_0
(T1 + 4δ + Δ) Replica_j+1: reject Notarization0_0