### PR TITLE
Conductor: implement HalfNodesDown test case

### DIFF
--- a/code/go/0chain.net/conductor/cases/half_nodes_down.go
+++ b/code/go/0chain.net/conductor/cases/half_nodes_down.go
@@ -1,0 +1,108 @@
+package cases
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+type (
+	// HalfNodesDown represents implementation of the TestCase interface.
+	//
+	//	Flow of this test case:
+	//		Half of nodes are down, generator proposes but can't get enough verification tickets, restarts.
+	//		Soon half of nodes get up and restarts round.
+	//
+	//		(T0) Replica_i: down, 0<=i<1/2f
+	//		(T0) Leader0_0: send Proposal0_0
+	//		(T0 + δ + Δ) Replica_0: send VerificationTicket0_0
+	//		(T0 + timeout) Replica_j: send VRFShare(timeout), 1/2f<j<=f
+	//		(T0 + 4*timeout) Replica_i: get up, send VRFShare(timeout), 0<=i<1/2f
+	//		(T0 + 4*timeout + δ): Leader0_1: send Proposal0_1
+	HalfNodesDown struct {
+		resultsMu sync.Mutex
+		results   []*RoundInfo
+
+		roundRandomSeedFromStartMu sync.Mutex
+		roundRandomSeedFromStart   int
+
+		minersNum int
+
+		wg *sync.WaitGroup
+	}
+)
+
+var (
+	// Ensure HalfNodesDown implements TestCase interface.
+	_ TestCase = (*HalfNodesDown)(nil)
+)
+
+// NewHalfNodesDown creates initialised HalfNodesDown.
+func NewHalfNodesDown(minersNum int) *HalfNodesDown {
+	wg := new(sync.WaitGroup)
+	wg.Add(minersNum)
+	return &HalfNodesDown{
+		minersNum: minersNum,
+		wg:        wg,
+	}
+}
+
+// Check implements TestCase interface.
+func (n *HalfNodesDown) Check(ctx context.Context) (success bool, err error) {
+	prepared := make(chan struct{})
+	go func() {
+		n.wg.Wait()
+		prepared <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// miners should send only first round restart reports, so if there is insufficient reports number
+		// it means that round has not restarted.
+		if expectedReportsNum := n.minersNum - n.minersNum/2; len(n.results) != expectedReportsNum {
+			return false, fmt.Errorf("unexpected number of result reports: %d, expected %d", len(n.results), expectedReportsNum)
+		}
+
+		return false, errors.New("cases state is not prepared, context is done")
+
+	case <-prepared:
+		return n.check()
+	}
+}
+
+func (n *HalfNodesDown) check() (bool, error) {
+	for _, res := range n.results {
+		switch {
+		case res.TimeoutCount != 1:
+			return false, fmt.Errorf("unexpected round timeout count: %d", res.TimeoutCount)
+
+		case res.RoundRandomSeed == int64(n.roundRandomSeedFromStart):
+			return false, errors.New("round random seed after timeout is unchanged")
+		}
+	}
+	return true, nil
+}
+
+// Configure implements TestCase interface.
+func (n *HalfNodesDown) Configure(blob []byte) (err error) {
+	defer n.wg.Done()
+	n.roundRandomSeedFromStartMu.Lock()
+	n.roundRandomSeedFromStart, err = strconv.Atoi(string(blob))
+	n.roundRandomSeedFromStartMu.Unlock()
+	return err
+}
+
+// AddResult implements TestCase interface.
+func (n *HalfNodesDown) AddResult(blob []byte) error {
+	defer n.wg.Done()
+	res := new(RoundInfo)
+	if err := res.Decode(blob); err != nil {
+		return err
+	}
+	n.resultsMu.Lock()
+	n.results = append(n.results, res)
+	n.resultsMu.Unlock()
+	return nil
+}

--- a/code/go/0chain.net/conductor/cases/misc.go
+++ b/code/go/0chain.net/conductor/cases/misc.go
@@ -15,6 +15,7 @@ type (
 		ProposedBlocks     []*BlockInfo `json:"proposed_blocks"`
 		NotarisedBlocks    []*BlockInfo `json:"notarised_blocks"`
 		TimeoutCount       int          `json:"timeout_count"`
+		RoundRandomSeed    int64        `json:"round_random_seed"`
 		IsFinalised        bool         `json:"is_finalised"`
 	}
 

--- a/code/go/0chain.net/conductor/conductor/executor.go
+++ b/code/go/0chain.net/conductor/conductor/executor.go
@@ -788,6 +788,9 @@ func (r *Runner) ConfigureTestCase(configurator cases.TestCaseConfigurator) erro
 				state.BadTimeoutVRFS = cfg
 			}
 
+		case *cases.HalfNodesDown:
+			state.HalfNodesDown = cfg
+
 		default:
 			log.Panicf("unknown test case name: %s", configurator.Name())
 		}

--- a/code/go/0chain.net/conductor/conductrpc/state.go
+++ b/code/go/0chain.net/conductor/conductrpc/state.go
@@ -58,6 +58,7 @@ type State struct {
 	ResendProposedBlock                   *cases.ResendProposedBlock
 	ResendNotarisation                    *cases.ResendNotarisation
 	BadTimeoutVRFS                        *cases.BadTimeoutVRFS
+	HalfNodesDown                         *cases.HalfNodesDown
 
 	// Blobbers related states
 	StorageTree    *config.Bad // blobber sends bad files/tree responses

--- a/code/go/0chain.net/conductor/config/cases/half_nodes_down.go
+++ b/code/go/0chain.net/conductor/config/cases/half_nodes_down.go
@@ -1,0 +1,46 @@
+package cases
+
+import (
+	"0chain.net/conductor/cases"
+	"github.com/mitchellh/mapstructure"
+)
+
+type (
+	// HalfNodesDown represents TestCaseConfigurator implementation.
+	HalfNodesDown struct {
+		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
+
+		minersNum int
+	}
+)
+
+const (
+	HalfNodesDownName = "half nodes down"
+)
+
+var (
+	// Ensure HalfNodesDown implements TestCaseConfigurator.
+	_ TestCaseConfigurator = (*HalfNodesDown)(nil)
+)
+
+// NewHalfNodesDown creates initialised HalfNodesDown.
+func NewHalfNodesDown(minersNum int) *HalfNodesDown {
+	return &HalfNodesDown{
+		minersNum: minersNum,
+	}
+}
+
+// TestCase implements TestCaseConfigurator interface.
+func (n *HalfNodesDown) TestCase() cases.TestCase {
+	return cases.NewHalfNodesDown(n.minersNum)
+}
+
+// Name implements TestCaseConfigurator interface.
+func (n *HalfNodesDown) Name() string {
+	return HalfNodesDownName
+}
+
+// Decode implements MapDecoder interface.
+func (n *HalfNodesDown) Decode(val interface{}) error {
+	return mapstructure.Decode(val, n)
+}

--- a/code/go/0chain.net/conductor/config/registry.go
+++ b/code/go/0chain.net/conductor/config/registry.go
@@ -474,6 +474,16 @@ func init() {
 		return ex.ConfigureTestCase(cfg)
 	})
 
+	register("configure_half_nodes_down_test_case", func(name string,
+		ex Executor, val interface{}, tm time.Duration) (err error) {
+
+		cfg := cases.NewHalfNodesDown(ex.MinersNum())
+		if err := cfg.Decode(val); err != nil {
+			return err
+		}
+		return ex.ConfigureTestCase(cfg)
+	})
+
 	register("make_test_case_check", func(name string, ex Executor, val interface{}, tm time.Duration) (err error) {
 		cfg := &TestCaseCheck{}
 		if err := cfg.Decode(val); err != nil {

--- a/code/go/0chain.net/miner/protocol_block_integration_tests.go
+++ b/code/go/0chain.net/miner/protocol_block_integration_tests.go
@@ -408,6 +408,7 @@ func roundInfo(round int64, finalisedBlockHash string) *cases.RoundInfo {
 		ProposedBlocks:     propBlocksInfo,
 		NotarisedBlocks:    notBlocksInfo,
 		TimeoutCount:       roundI.GetTimeoutCount(),
+		RoundRandomSeed:    roundI.GetRandomSeed(),
 		IsFinalised:        roundI.IsFinalized(),
 	}
 }

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -1374,8 +1374,8 @@ func (mc *Chain) GetNextRoundTimeoutTime(ctx context.Context) int {
 	return tick
 }
 
-// HandleRoundTimeout handle timeouts appropriately.
-func (mc *Chain) HandleRoundTimeout(ctx context.Context, round int64) {
+// handleRoundTimeout handle timeouts appropriately.
+func (mc *Chain) handleRoundTimeout(ctx context.Context, round int64) {
 	// 	mmb = mc.GetMagicBlock(rn + chain.ViewChangeOffset + 1)
 	// 	cmb = mc.GetMagicBlock(rn)
 

--- a/code/go/0chain.net/miner/protocol_round_main.go
+++ b/code/go/0chain.net/miner/protocol_round_main.go
@@ -17,3 +17,8 @@ func (mc *Chain) GetBlockToExtend(ctx context.Context, r round.RoundI) *block.Bl
 func (mc *Chain) StartRound(ctx context.Context, r *Round, seed int64) {
 	mc.startRound(ctx, r, seed)
 }
+
+// HandleRoundTimeout handle timeouts appropriately.
+func (mc *Chain) HandleRoundTimeout(ctx context.Context, round int64) {
+	mc.handleRoundTimeout(ctx, round)
+}

--- a/docker.local/config/conductor.no-view-change.byzantine.yaml
+++ b/docker.local/config/conductor.no-view-change.byzantine.yaml
@@ -19,6 +19,7 @@ sets:
   - name: "restart"
     tests:
       - "bad timeout VRF share"
+      - "half nodes down"
 
 tests:
   - name: "not notarised block extension"
@@ -153,5 +154,16 @@ tests:
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
           round: 50
+      - make_test_case_check:
+          wait_time: 5m
+
+  - name: "half nodes down"
+    flow:
+      - set_monitor: "sharder-1"
+      - cleanup_bc: { }
+      - start: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - configure_half_nodes_down_test_case:
+          test_report:
+            round: 30
       - make_test_case_check:
           wait_time: 5m


### PR DESCRIPTION
```
// Half of nodes are down, generator proposes but can't get enough verification tickets, restarts. Soon half of nodes get up and restarts round.
(T0) Replica_i: down, 0<=i<1/2f
(T0) Leader0_0: send Proposal0_0
(T0 + δ + Δ) Replica_0: send VerificationTicket0_0
(T0 + timeout) Replica_j: send VRFShare(timeout), 1/2f<j<=f
(T0 + 4*timeout) Replica_i: get up, send VRFShare(timeout), 0<=i<1/2f
(T0 + 4*timeout + δ): Leader0_1: send Proposal0_1
```