### PR TITLE
Conductor: implement BlockStateChangeRequest (only one node replies correctly) test case

### DIFF
--- a/code/go/0chain.net/chaincore/chain/n2n_handler_integration_tests.go
+++ b/code/go/0chain.net/chaincore/chain/n2n_handler_integration_tests.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"0chain.net/chaincore/node"
 	"0chain.net/chaincore/round"
 	crpc "0chain.net/conductor/conductrpc"
 	"0chain.net/conductor/conductrpc/stats/middleware"
+	"0chain.net/conductor/config/cases"
 	"0chain.net/core/common"
 )
 
@@ -24,14 +26,18 @@ func SetupX2MRequestors() {
 }
 
 func (c *Chain) BlockStateChangeHandler(ctx context.Context, r *http.Request) (interface{}, error) {
-	if c.isIgnoringBlockStateChangeRequest(r) {
+	switch {
+	case isIgnoringBlockStateChangeRequest(r):
 		return nil, fmt.Errorf("%w: conductor expected error", common.ErrInternal)
-	}
 
-	return c.blockStateChangeHandler(ctx, r)
+	case isRespondingCorrectlyOnBlockStateChangeRequest(r):
+		fallthrough
+	default:
+		return c.blockStateChangeHandler(ctx, r)
+	}
 }
 
-func (c *Chain) isIgnoringBlockStateChangeRequest(r *http.Request) bool {
+func isIgnoringBlockStateChangeRequest(r *http.Request) bool {
 	cfg := crpc.Client().State().BlockStateChangeRequestor
 
 	cfg.Lock()
@@ -41,24 +47,78 @@ func (c *Chain) isIgnoringBlockStateChangeRequest(r *http.Request) bool {
 		return false
 	}
 
-	fromNode := r.Header.Get(node.HeaderNodeID)
-	bl, err := c.getNotarizedBlock(context.Background(), r)
-	if err != nil {
-		return false
-	}
-
-	rank := getMinerRank(bl.Round, bl.RoundRandomSeed, c.GetMiners(bl.Round), fromNode)
-	isReplica0 := (rank - c.GetGeneratorsNum()) == 0
-	ignoring := isReplica0 && bl.Round == cfg.OnRound
+	ignoring := isActingOnBlockStateChangeRequest(
+		r,
+		cfg.IgnoringRequestsBy.Sharders,
+		cfg.IgnoringRequestsBy.Miners,
+		cfg.OnRound,
+	)
 	if ignoring {
 		cfg.Ignored++
 	}
 	return ignoring
 }
 
-func getMinerRank(roundNum, seed int64, miners *node.Pool, minerID string) int {
+func isRespondingCorrectlyOnBlockStateChangeRequest(r *http.Request) bool {
+	cfg := crpc.Client().State().BlockStateChangeRequestor
+
+	cfg.Lock()
+	defer cfg.Unlock()
+
+	if cfg == nil {
+		return false
+	}
+
+	return isActingOnBlockStateChangeRequest(
+		r,
+		cfg.CorrectResponseBy.Sharders,
+		cfg.CorrectResponseBy.Miners,
+		cfg.OnRound,
+	)
+}
+
+func isActingOnBlockStateChangeRequest(r *http.Request, sharders cases.Sharders, miners cases.Miners, onRound int64) bool {
+	sChain := GetServerChain()
+	bl, err := sChain.getNotarizedBlock(context.Background(), r)
+	if err != nil || bl.Round != onRound {
+		return false
+	}
+
+	if node.Self.Type == node.NodeTypeSharder {
+		selfName := "sharder-" + strconv.Itoa(node.Self.SetIndex)
+		return sharders.Contains(selfName)
+	}
+
+	// node type miner
+
+	var (
+		roundMiners                             = sChain.GetMiners(bl.Round)
+		isRequestorGenerator, requestorTypeRank = getMinerTypeAndTypeRank(bl.Round, bl.RoundRandomSeed, roundMiners, r.Header.Get(node.HeaderNodeID))
+		isSelfGenerator, selfTypeRank           = getMinerTypeAndTypeRank(bl.Round, bl.RoundRandomSeed, roundMiners, node.Self.ID)
+	)
+	return !isRequestorGenerator && requestorTypeRank == 0 && // replica0
+		miners.Get(isSelfGenerator, selfTypeRank) != nil
+}
+
+// getMinerTypeAndTypeRank return true if the provided miner is generator and type rank of the provided miner.
+//
+// 	Explaining type rank example:
+//		Generators num = 2
+// 		len(miners) = 4
+// 		Generator0:	rank = 0; typeRank = 0; isGenerator = true.
+// 		Generator1:	rank = 1; typeRank = 1; isGenerator = true.
+// 		Replica0:	rank = 2; typeRank = 0; isGenerator = false.
+// 		Replica0:	rank = 3; typeRank = 1; isGenerator = false.
+func getMinerTypeAndTypeRank(roundNum, seed int64, miners *node.Pool, minerID string) (isGenerator bool, typeRank int) {
 	roundI := round.NewRound(roundNum)
 	roundI.SetRandomSeed(seed, len(miners.Nodes))
+	genNum := GetServerChain().GetGeneratorsNum()
 	miner := miners.GetNode(minerID)
-	return roundI.GetMinerRank(miner)
+	minerRank := roundI.GetMinerRank(miner)
+	isGenerator = minerRank < genNum
+	typeRank = minerRank
+	if !isGenerator {
+		typeRank = typeRank - genNum
+	}
+	return isGenerator, typeRank
 }

--- a/code/go/0chain.net/conductor/config/cases/block_state_change_requestor.go
+++ b/code/go/0chain.net/conductor/config/cases/block_state_change_requestor.go
@@ -13,6 +13,12 @@ type (
 	BlockStateChangeRequestor struct {
 		TestReport `json:"test_report" yaml:"test_report" mapstructure:"test_report"`
 
+		// IgnoringRequestsBy contains nodes which must ignore Replica0.
+		IgnoringRequestsBy Nodes `json:"ignoring_requests_by" yaml:"ignoring_requests_by" mapstructure:"ignoring_requests_by"`
+
+		// CorrectResponseBy contains nodes which must response correctly to Replica0.
+		CorrectResponseBy Nodes `json:"correct_response_by" yaml:"correct_response_by" mapstructure:"correct_response_by"`
+
 		Configured bool
 
 		Ignored int
@@ -24,7 +30,7 @@ type (
 )
 
 const (
-	BlockStateChangeRequestorName = "attack BlockStateChangeRequestor: neither node reply"
+	BlockStateChangeRequestorName = "attack BlockStateChangeRequestor"
 )
 
 var (
@@ -41,17 +47,41 @@ func NewBlockStateChangeRequestor(statsCollector *stats.NodesClientStats) *Block
 
 // TestCase implements TestCaseConfigurator interface.
 func (n *BlockStateChangeRequestor) TestCase() cases.TestCase {
-	return cases.NewBlockStateChangeRequestor(n.statsCollector)
+	return cases.NewBlockStateChangeRequestor(n.statsCollector, n.getType())
 }
 
 // Name implements TestCaseConfigurator interface.
 func (n *BlockStateChangeRequestor) Name() string {
-	return BlockStateChangeRequestorName
+	postfix := ""
+	switch n.getType() {
+	case cases.BSCRNoReplies:
+		postfix = "neither node reply"
+
+	case cases.BSCROnlyOneRepliesCorrectly:
+		postfix = "only one node replies correctly"
+
+	default:
+		postfix = "unknown"
+	}
+	return BlockStateChangeRequestorName + ": " + postfix
 }
 
 // Decode implements MapDecoder interface.
 func (n *BlockStateChangeRequestor) Decode(val interface{}) error {
 	return mapstructure.Decode(val, n)
+}
+
+func (n *BlockStateChangeRequestor) getType() cases.BlockStateChangeRequestorCaseType {
+	switch {
+	case n.IgnoringRequestsBy.Num() > 1 && n.CorrectResponseBy.Num() == 0:
+		return cases.BSCRNoReplies
+
+	case n.IgnoringRequestsBy.Num() > 0 && n.CorrectResponseBy.Num() == 1:
+		return cases.BSCROnlyOneRepliesCorrectly
+
+	default:
+		return -1
+	}
 }
 
 func (n *BlockStateChangeRequestor) Lock() {

--- a/code/go/0chain.net/conductor/config/cases/nodes.go
+++ b/code/go/0chain.net/conductor/config/cases/nodes.go
@@ -1,0 +1,61 @@
+package cases
+
+type (
+	// Nodes represents struct for containing miners and sharders info.
+	Nodes struct {
+		Miners   Miners   `json:"miners" yaml:"miners" mapstructure:"miners"`
+		Sharders Sharders `json:"sharders" yaml:"sharders" mapstructure:"sharders"`
+	}
+
+	// Miners represents list of Miner.
+	Miners []*Miner
+
+	// Miner represents struct for containing miner's info.
+	//
+	// 	Explaining definitions example:
+	//		Generators num = 2
+	// 		len(miners) = 4
+	//
+	// 		Generator0:	rank = 0; TypeRank = 0; Generator = true.
+	// 		Generator1:	rank = 1; TypeRank = 1; Generator = true.
+	// 		Replica0:	rank = 2; TypeRank = 0; Generator = false.
+	// 		Replica0:	rank = 3; TypeRank = 1; Generator = false.
+	Miner struct {
+		Generator bool `json:"generator" yaml:"generator" mapstructure:"generator"`
+
+		TypeRank int `json:"type_rank" yaml:"type_rank" mapstructure:"type_rank"`
+	}
+
+	// Sharders represents list of Sharder.
+	Sharders []Sharder
+
+	// Sharder represents string that explains sharder type.
+	//
+	// Example: "sharder-1".
+	Sharder string
+)
+
+// Num returns number of all nodes contained by Nodes.
+func (n *Nodes) Num() int {
+	return len(n.Miners) + len(n.Sharders)
+}
+
+// Get looks for Miner with provided Miner.Generator and Miner.TypeRank and returns it if founds.
+func (m Miners) Get(generator bool, typeRank int) *Miner {
+	for _, miner := range m {
+		if miner.Generator == generator && miner.TypeRank == typeRank {
+			return miner
+		}
+	}
+	return nil
+}
+
+// Contains looks for Sharder with provided name.
+func (s Sharders) Contains(name string) bool {
+	for _, sharder := range s {
+		if string(sharder) == name {
+			return true
+		}
+	}
+	return false
+}

--- a/docker.local/config/conductor.no-view-change.byzantine.yaml
+++ b/docker.local/config/conductor.no-view-change.byzantine.yaml
@@ -24,6 +24,7 @@ sets:
   - name: "attack fetching"
     tests:
       - "attack BlockStateChangeRequestor: neither node reply"
+      - "attack BlockStateChangeRequestor: only one node replies"
 
 tests:
   - name: "not notarised block extension"
@@ -178,6 +179,63 @@ tests:
             round: 30
             by_generator: true
             by_node_with_type_rank: 0
+
+          ignoring_requests_by:
+            miners:
+              # Generator0
+              - generator: true
+                type_rank: 0
+
+              # Generator1
+              - generator: true
+                type_rank: 1
+
+              # Replica1
+              - generator: false
+                type_rank: 1
+
+            sharders:
+              - "sharder-1"
+              - "sharder-2"
+
+      - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
+      - wait_round:
+          round: 50
+      - make_test_case_check:
+          wait_time: 5m
+
+
+  - name: "attack BlockStateChangeRequestor: only one node replies"
+    flow:
+      - set_monitor: "miner-1"
+      - cleanup_bc: {}
+      - start_lock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
+      - configure_block_state_change_requestor_test_case:
+          test_report:
+            round: 30
+            by_generator: false
+            by_node_with_type_rank: 0
+
+          ignoring_requests_by:
+            miners:
+              # Generator1
+              - generator: true
+                type_rank: 1
+
+              # Replica0
+              - generator: false
+                type_rank: 1
+
+            sharders:
+              - "sharder-1"
+              - "sharder-2"
+
+          correct_response_by:
+            miners:
+              # Generator0
+              - generator: true
+                type_rank: 0
+
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
       - wait_round:
           round: 50


### PR DESCRIPTION
Closing #931

```
// Attack BlockStateChangeRequestor: only one node replies correctly
Replica0: Ignore all VerifyBlock messages on round_n
Requested nodes: ignores all block state change requests from Replica0, but only one replies correctly
Check: Replica0 must retry requesting.
```