### PR TITLE
Conductor: attack BlockStateChangeRequestor: implement test cases.

### DIFF
--- a/code/go/0chain.net/chaincore/chain/n2n_handler_integration_tests.go
+++ b/code/go/0chain.net/chaincore/chain/n2n_handler_integration_tests.go
@@ -13,10 +13,13 @@ import (
 	"0chain.net/chaincore/block"
 	"0chain.net/chaincore/node"
 	"0chain.net/chaincore/round"
+	"0chain.net/chaincore/state"
 	crpc "0chain.net/conductor/conductrpc"
 	"0chain.net/conductor/conductrpc/stats/middleware"
 	"0chain.net/conductor/config/cases"
 	"0chain.net/core/common"
+	"0chain.net/core/encryption"
+	"0chain.net/core/util"
 )
 
 func SetupX2MRequestors() {
@@ -33,13 +36,13 @@ func (c *Chain) BlockStateChangeHandler(ctx context.Context, r *http.Request) (i
 		return nil, fmt.Errorf("%w: conductor expected error", common.ErrInternal)
 
 	case isChangingMPTNode(r):
-		return changeMPTNode(ctx, r)
+		return changeMPTNode(r)
 
 	case isDeletingMPTNode(r):
 		return deleteMPTNode(ctx, r)
 
 	case isAddingMPTNode(r):
-		return addMPTNode(ctx, r)
+		return addMPTNode(r)
 
 	case isChangingPartialState(r):
 		return changePartialState(ctx, r)
@@ -187,18 +190,31 @@ func isActingOnBlockStateChangeRequest(r *http.Request, sharders cases.Sharders,
 		miners.Get(isSelfGenerator, selfTypeRank) != nil
 }
 
-func changeMPTNode(ctx context.Context, r *http.Request) (*block.StateChange, error) {
-	stChange, err := GetServerChain().blockStateChangeHandler(ctx, r)
+func changeMPTNode(r *http.Request) (*block.StateChange, error) {
+	sChain := GetServerChain()
+	bl, err := sChain.getNotarizedBlock(context.Background(), r.FormValue("round"), r.FormValue("block"))
 	if err != nil {
-		return nil, err
+		log.Panicf("Conductor: error while fetching notarized block: %v")
 	}
 
-	if len(stChange.Nodes) == 0 {
-		log.Panicf("Conductor: mpt is empty")
+	bsc := block.NewBlockStateChange(bl)
+	st := state.State{
+		TxnHashBytes: encryption.RawHash("txn hash"),
+		Round:        bl.Round,
+		Balance:      1000000000,
 	}
 
-	stChange.Nodes[len(stChange.Nodes)-1] = stChange.Nodes[0].Clone()
-	return stChange, nil
+	for _, n := range bsc.Nodes {
+		if n.GetNodeType() == util.NodeTypeLeafNode {
+			ln, ok := n.(*util.LeafNode)
+			if !ok {
+				log.Panic("Conductor: unexpected node type")
+			}
+			ln.SetValue(&st)
+		}
+	}
+
+	return bsc, nil
 }
 
 func deleteMPTNode(ctx context.Context, r *http.Request) (*block.StateChange, error) {
@@ -215,18 +231,23 @@ func deleteMPTNode(ctx context.Context, r *http.Request) (*block.StateChange, er
 	return stChange, nil
 }
 
-func addMPTNode(ctx context.Context, r *http.Request) (*block.StateChange, error) {
-	stChange, err := GetServerChain().blockStateChangeHandler(ctx, r)
+func addMPTNode(r *http.Request) (*block.StateChange, error) {
+	sChain := GetServerChain()
+	bl, err := sChain.getNotarizedBlock(context.Background(), r.FormValue("round"), r.FormValue("block"))
 	if err != nil {
-		return nil, err
+		log.Panicf("Conductor: error while fetching notarized block: %v")
 	}
 
-	if len(stChange.Nodes) == 0 {
-		log.Panicf("Conductor: mpt is empty")
+	bsc := block.NewBlockStateChange(bl)
+	lastNode := bsc.Nodes[len(bsc.Nodes)-1]
+	st := state.State{
+		TxnHashBytes: encryption.RawHash("txn hash"),
+		Round:        bl.Round,
+		Balance:      1000000000,
 	}
+	bsc.AddNode(util.NewLeafNode(util.Path(""), util.Path(lastNode.GetHash()), lastNode.GetOrigin(), &st))
 
-	stChange.AddNode(stChange.Nodes[0])
-	return stChange, nil
+	return bsc, nil
 }
 
 func changePartialState(ctx context.Context, r *http.Request) (*block.StateChange, error) {

--- a/code/go/0chain.net/chaincore/chain/protocol_view_change_integration_tests.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change_integration_tests.go
@@ -1,3 +1,4 @@
+//go:build integration_tests
 // +build integration_tests
 
 package chain

--- a/code/go/0chain.net/conductor/config/cases/block_state_change_requestor.go
+++ b/code/go/0chain.net/conductor/config/cases/block_state_change_requestor.go
@@ -19,6 +19,14 @@ type (
 		// CorrectResponseBy contains nodes which must response correctly to Replica0.
 		CorrectResponseBy Nodes `json:"correct_response_by" yaml:"correct_response_by" mapstructure:"correct_response_by"`
 
+		ChangedMPTNodeBy Nodes `json:"changed_mpt_node_by" yaml:"changed_mpt_node_by" mapstructure:"changed_mpt_node_by"`
+
+		DeletedMPTNodeBy Nodes `json:"deleted_mpt_node_by" yaml:"deleted_mpt_node_by" mapstructure:"deleted_mpt_node_by"`
+
+		AddedMPTNodeBy Nodes `json:"added_mpt_node_by" yaml:"added_mpt_node_by" mapstructure:"added_mpt_node_by"`
+
+		PartialStateFromAnotherBlockBy Nodes `json:"partial_state_from_another_block_by" yaml:"partial_state_from_another_block_by" mapstructure:"partial_state_from_another_block_by"`
+
 		Configured bool
 
 		Ignored int
@@ -60,6 +68,18 @@ func (n *BlockStateChangeRequestor) Name() string {
 	case cases.BSCROnlyOneRepliesCorrectly:
 		postfix = "only one node replies correctly"
 
+	case cases.BSCRChangeNode:
+		postfix = "one node sends state change with changed mpt node"
+
+	case cases.BSCRDeleteNode:
+		postfix = "one node sends state change with deleted mpt node"
+
+	case cases.BSCRAddNode:
+		postfix = "one node sends state change with added mpt node"
+
+	case cases.BSCRAnotherPartialState:
+		postfix = "one node sends partial state from another block"
+
 	default:
 		postfix = "unknown"
 	}
@@ -73,11 +93,36 @@ func (n *BlockStateChangeRequestor) Decode(val interface{}) error {
 
 func (n *BlockStateChangeRequestor) getType() cases.BlockStateChangeRequestorCaseType {
 	switch {
-	case n.IgnoringRequestsBy.Num() > 1 && n.CorrectResponseBy.Num() == 0:
+	case !n.IgnoringRequestsBy.IsEmpty() &&
+		n.CorrectResponseBy.IsEmpty() && n.ChangedMPTNodeBy.IsEmpty() && n.DeletedMPTNodeBy.IsEmpty() &&
+		n.PartialStateFromAnotherBlockBy.IsEmpty() && n.AddedMPTNodeBy.IsEmpty():
+
 		return cases.BSCRNoReplies
 
-	case n.IgnoringRequestsBy.Num() > 0 && n.CorrectResponseBy.Num() == 1:
+	case !n.IgnoringRequestsBy.IsEmpty() && n.CorrectResponseBy.Num() == 1 &&
+		n.ChangedMPTNodeBy.IsEmpty() && n.DeletedMPTNodeBy.IsEmpty() && n.AddedMPTNodeBy.IsEmpty() && n.PartialStateFromAnotherBlockBy.IsEmpty():
+
 		return cases.BSCROnlyOneRepliesCorrectly
+
+	case n.ChangedMPTNodeBy.Num() == 1 && !n.IgnoringRequestsBy.IsEmpty() &&
+		n.CorrectResponseBy.IsEmpty() && n.DeletedMPTNodeBy.IsEmpty() && n.AddedMPTNodeBy.IsEmpty() && n.PartialStateFromAnotherBlockBy.IsEmpty():
+
+		return cases.BSCRChangeNode
+
+	case n.DeletedMPTNodeBy.Num() == 1 && !n.IgnoringRequestsBy.IsEmpty() &&
+		n.CorrectResponseBy.IsEmpty() && n.ChangedMPTNodeBy.IsEmpty() && n.AddedMPTNodeBy.IsEmpty() && n.PartialStateFromAnotherBlockBy.IsEmpty():
+
+		return cases.BSCRDeleteNode
+
+	case n.AddedMPTNodeBy.Num() == 1 && !n.IgnoringRequestsBy.IsEmpty() &&
+		n.CorrectResponseBy.IsEmpty() && n.ChangedMPTNodeBy.IsEmpty() && n.DeletedMPTNodeBy.IsEmpty() && n.PartialStateFromAnotherBlockBy.IsEmpty():
+
+		return cases.BSCRAddNode
+
+	case n.PartialStateFromAnotherBlockBy.Num() == 1 && !n.IgnoringRequestsBy.IsEmpty() &&
+		n.CorrectResponseBy.IsEmpty() && n.ChangedMPTNodeBy.IsEmpty() && n.DeletedMPTNodeBy.IsEmpty() && n.AddedMPTNodeBy.IsEmpty():
+
+		return cases.BSCRAnotherPartialState
 
 	default:
 		return -1

--- a/code/go/0chain.net/conductor/config/cases/nodes.go
+++ b/code/go/0chain.net/conductor/config/cases/nodes.go
@@ -40,6 +40,10 @@ func (n *Nodes) Num() int {
 	return len(n.Miners) + len(n.Sharders)
 }
 
+func (n *Nodes) IsEmpty() bool {
+	return (len(n.Miners) + len(n.Sharders)) == 0
+}
+
 // Get looks for Miner with provided Miner.Generator and Miner.TypeRank and returns it if founds.
 func (m Miners) Get(generator bool, typeRank int) *Miner {
 	for _, miner := range m {

--- a/docker.local/config/conductor.no-view-change.byzantine.yaml
+++ b/docker.local/config/conductor.no-view-change.byzantine.yaml
@@ -25,6 +25,10 @@ sets:
     tests:
       - "attack BlockStateChangeRequestor: neither node reply"
       - "attack BlockStateChangeRequestor: only one node replies"
+      - "attack BlockStateChangeRequestor: one node sends state change with changed mpt node"
+      - "attack BlockStateChangeRequestor: one node sends state change with deleted mpt node"
+      - "attack BlockStateChangeRequestor: one node sends state change with added mpt node"
+      - "attack BlockStateChangeRequestor: one node sends partial state from another block"
 
 tests:
   - name: "not notarised block extension"
@@ -204,7 +208,6 @@ tests:
       - make_test_case_check:
           wait_time: 5m
 
-
   - name: "attack BlockStateChangeRequestor: only one node replies"
     flow:
       - set_monitor: "miner-1"
@@ -222,7 +225,7 @@ tests:
               - generator: true
                 type_rank: 1
 
-              # Replica0
+              # Replica1
               - generator: false
                 type_rank: 1
 
@@ -237,6 +240,154 @@ tests:
                 type_rank: 0
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
+      - wait_round:
+          round: 50
+      - make_test_case_check:
+          wait_time: 5m
+
+  - name: "attack BlockStateChangeRequestor: one node sends state change with changed mpt node"
+    flow:
+        - set_monitor: "miner-1"
+        - cleanup_bc: { }
+        - start_lock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+        - configure_block_state_change_requestor_test_case:
+            test_report:
+              round: 30
+              by_generator: false
+              by_node_with_type_rank: 0
+
+            ignoring_requests_by:
+              miners:
+                # Generator1
+                - generator: true
+                  type_rank: 1
+
+                # Replica1
+                - generator: false
+                  type_rank: 1
+
+              sharders:
+                - "sharder-1"
+                - "sharder-2"
+
+            changed_mpt_node_by:
+              miners:
+                # Generator0
+                - generator: true
+                  type_rank: 0
+
+        - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+        - wait_round:
+            round: 50
+        - make_test_case_check:
+            wait_time: 5m
+
+  - name: "attack BlockStateChangeRequestor: one node sends state change with deleted mpt node"
+    flow:
+      - set_monitor: "miner-1"
+      - cleanup_bc: { }
+      - start_lock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - configure_block_state_change_requestor_test_case:
+          test_report:
+            round: 30
+            by_generator: false
+            by_node_with_type_rank: 0
+
+          ignoring_requests_by:
+            miners:
+              # Generator1
+              - generator: true
+                type_rank: 1
+
+              # Replica1
+              - generator: false
+                type_rank: 1
+
+            sharders:
+              - "sharder-1"
+              - "sharder-2"
+
+          deleted_mpt_node_by:
+            miners:
+              # Generator0
+              - generator: true
+                type_rank: 0
+
+      - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - wait_round:
+          round: 50
+      - make_test_case_check:
+          wait_time: 5m
+
+  - name: "attack BlockStateChangeRequestor: one node sends state change with added mpt node"
+    flow:
+      - set_monitor: "miner-1"
+      - cleanup_bc: { }
+      - start_lock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - configure_block_state_change_requestor_test_case:
+          test_report:
+            round: 30
+            by_generator: false
+            by_node_with_type_rank: 0
+
+          ignoring_requests_by:
+            miners:
+              # Generator1
+              - generator: true
+                type_rank: 1
+
+              # Replica1
+              - generator: false
+                type_rank: 1
+
+            sharders:
+              - "sharder-1"
+              - "sharder-2"
+
+          added_mpt_node_by:
+            miners:
+              # Generator0
+              - generator: true
+                type_rank: 0
+
+      - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - wait_round:
+          round: 50
+      - make_test_case_check:
+          wait_time: 5m
+
+  - name: "attack BlockStateChangeRequestor: one node sends partial state from another block"
+    flow:
+      - set_monitor: "miner-1"
+      - cleanup_bc: { }
+      - start_lock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
+      - configure_block_state_change_requestor_test_case:
+          test_report:
+            round: 30
+            by_generator: false
+            by_node_with_type_rank: 0
+
+          ignoring_requests_by:
+            miners:
+              # Generator1
+              - generator: true
+                type_rank: 1
+
+              # Replica1
+              - generator: false
+                type_rank: 1
+
+            sharders:
+              - "sharder-1"
+              - "sharder-2"
+
+          partial_state_from_another_block_by:
+            miners:
+              # Generator0
+              - generator: true
+                type_rank: 0
+
+      - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
           round: 50
       - make_test_case_check:


### PR DESCRIPTION
1. Attack BlockStateChangeRequestor: one node sends state change with changed MPT node.
```
Replica0: Ignore all VerifyBlock messages on round_n
Requested nodes: ignore all block state change requests from Replica0, but only one
node sends incorrect state change with changed MPT node.
Check: Replica0 must retry requesting.
```

2. Attack BlockStateChangeRequestor: one node sends state change with deleted MPT node
```
Replica0: Ignore all VerifyBlock messages on round_n
Requested nodes: ignore all block state change requests from Replica0, but only one
node sends incorrect state change with deleted MPT node.
Check: Replica0 must retry requesting.
```

3. Attack BlockStateChangeRequestor: one node sends state change with added MPT node
```
Replica0: Ignore all VerifyBlock messages on round_n
Requested nodes: ignore all block state change requests from Replica0, but only one
node sends incorrect state change with added MPT node.
Check: Replica0 must retry requesting.

```
4. Attack BlockStateChangeRequestor: one node sends partial state from another block
```
Replica0: Ignore all VerifyBlock messages on round_n
Requested nodes: ignore all block state change requests from Replica0, but only one
node sends incorrect state change from another block.
Check: Replica0 must retry requesting.
```

Closing #950 