### PR TITLE
Add events on block finalizing process

### DIFF
--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"0chain.net/core/datastore"
+	"0chain.net/smartcontract/dbs/event"
 
 	"0chain.net/chaincore/config"
 	"0chain.net/chaincore/node"
@@ -344,6 +345,13 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 
 	c.SetLatestOwnFinalizedBlockRound(fb.Round)
 	c.SetLatestFinalizedBlock(fb)
+
+	if len(fb.Events) > 0 && c.GetEventDb() != nil {
+		go func(events []event.Event) {
+			c.GetEventDb().AddEvents(ctx, events)
+		}(fb.Events)
+		fb.Events = nil
+	}
 
 	if fb.MagicBlock != nil {
 		if err := c.UpdateMagicBlock(fb.MagicBlock); err != nil {

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -59,9 +59,8 @@ func (edb *EventDb) AddEvents(ctx context.Context, events []Event) {
 func (edb *EventDb) addEventsWorker(ctx context.Context) {
 	for {
 		events := <-edb.eventsChannel
-		newEvents := edb.removeDuplicate(ctx, events)
-		edb.addEvents(ctx, newEvents)
-		for _, event := range newEvents {
+		edb.addEvents(ctx, events)
+		for _, event := range events {
 			var err error = nil
 			switch EventType(event.Type) {
 			case TypeStats:


### PR DESCRIPTION
## Fixes
-  https://github.com/0chain/0chain/issues/993 
    Fix duplicate db events insert error, db events should be insert to db when the block is finalized, otherwise, sharders would continually reporting the duplicate transaction hash get insert error. 

## Tests 
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR
