### PR TITLE
Fix API to return 404 on unknown paths

### DIFF
--- a/code/go/0chain.net/chaincore/chain/handler.go
+++ b/code/go/0chain.net/chaincore/chain/handler.go
@@ -82,7 +82,7 @@ func handlersMap(c Chainer) map[string]func(http.ResponseWriter, *http.Request) 
 			),
 		),
 		"/": common.UserRateLimit(
-			HomePageAndNotFoundHandlerFunc("/"),
+			HomePageAndNotFoundHandler,
 		),
 		"/_diagnostics": common.UserRateLimit(
 			DiagnosticsHomepageHandler,
@@ -215,16 +215,14 @@ func RecentFinalizedBlockHandler(ctx context.Context, r *http.Request) (interfac
 // StartTime - time when the server has started.
 var StartTime time.Time
 
-/*HomePageAndNotFoundHandlerFunc - returns handler which returns home page or 404 if not matching home path */
-func HomePageAndNotFoundHandlerFunc(homePage string) common.ReqRespHandlerf {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != homePage {
-			NotFoundPageHandler(w, r)
-			return
-		}
-
-		HomePageHandler(w, r)
+/*HomePageAndNotFoundHandler - catch all handler that returns home page for root path and 404 for other paths */
+func HomePageAndNotFoundHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		NotFoundPageHandler(w, r)
+		return
 	}
+
+	HomePageHandler(w, r)
 }
 
 /*HomePageHandler - provides basic info when accessing the home page of the server */

--- a/code/go/0chain.net/chaincore/chain/handler.go
+++ b/code/go/0chain.net/chaincore/chain/handler.go
@@ -82,7 +82,7 @@ func handlersMap(c Chainer) map[string]func(http.ResponseWriter, *http.Request) 
 			),
 		),
 		"/": common.UserRateLimit(
-			HomePageHandler,
+			HomePageAndNotFoundHandlerFunc("/"),
 		),
 		"/_diagnostics": common.UserRateLimit(
 			DiagnosticsHomepageHandler,
@@ -215,6 +215,18 @@ func RecentFinalizedBlockHandler(ctx context.Context, r *http.Request) (interfac
 // StartTime - time when the server has started.
 var StartTime time.Time
 
+/*HomePageAndNotFoundHandlerFunc - returns handler which returns home page or 404 if not matching home path */
+func HomePageAndNotFoundHandlerFunc(homePage string) common.ReqRespHandlerf {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != homePage {
+			NotFoundPageHandler(w, r)
+			return
+		}
+
+		HomePageHandler(w, r)
+	}
+}
+
 /*HomePageHandler - provides basic info when accessing the home page of the server */
 func HomePageHandler(w http.ResponseWriter, r *http.Request) {
 	sc := GetServerChain()
@@ -223,6 +235,11 @@ func HomePageHandler(w http.ResponseWriter, r *http.Request) {
 	selfNode := node.Self.Underlying()
 	fmt.Fprintf(w, "<div>I am %v working on the chain %v <ul><li>id:%v</li><li>public_key:%v</li><li>build_tag:%v</li></ul></div>\n",
 		selfNode.GetPseudoName(), sc.GetKey(), selfNode.GetKey(), selfNode.PublicKey, build.BuildTag)
+}
+
+/*NotFoundPageHandler - provides the 404 page */
+func NotFoundPageHandler(w http.ResponseWriter, r *http.Request) {
+	common.Respond(w, r, nil, common.ErrNoResource)
 }
 
 func (c *Chain) healthSummary(w http.ResponseWriter, r *http.Request) {

--- a/code/go/0chain.net/chaincore/chain/handler_test.go
+++ b/code/go/0chain.net/chaincore/chain/handler_test.go
@@ -122,3 +122,39 @@ func TestGetLatestFinalizedMagicBlock(t *testing.T) {
 	//require.Equal(t, lfmb.Hash, b.Hash)
 
 }
+
+func TestHomePageAndNotFoundHandler(t *testing.T) {
+	t.Run("request to root path must return home page", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://localhost:7071/", nil)
+		w := httptest.NewRecorder()
+
+		c := Provider().(*Chain)
+		SetServerChain(c)
+		defer SetServerChain(nil) // ensure to reset after test
+
+		HomePageAndNotFoundHandler(w, req)
+
+		body, err := ioutil.ReadAll(w.Result().Body)
+
+		wantSubstring := `I am Miner000 working on the chain`
+
+		require.NoError(t, err)
+		require.Contains(t, string(body), wantSubstring)
+		require.Equal(t, 200, w.Result().StatusCode)
+	})
+
+	t.Run("request to non-root path must return 404", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "http://localhost:7071/unknown", nil)
+		w := httptest.NewRecorder()
+
+		HomePageAndNotFoundHandler(w, req)
+
+		body, err := ioutil.ReadAll(w.Result().Body)
+
+		wantSubstring := `{"code":"resource_not_found","error":"resource_not_found: can't retrieve resource"}`
+
+		require.NoError(t, err)
+		require.Contains(t, string(body), wantSubstring)
+		require.Equal(t, 404, w.Result().StatusCode)
+	})
+}


### PR DESCRIPTION
## Changes

Update the catch all handler to show only home page for root path (`/`) requests and 404 to everything else.

## Fixes

Fixes https://github.com/0chain/0chain/issues/1022

## Tests 
Tasks to complete before merging PR:
- [x]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber: N/A
- gosdk: N/A
- system_test: N/A
- zboxcli: N/A
- zwalletcli: N/A
- Other: ...
