### PR TITLE
Stop generating challenges is there are no validators

### DIFF
--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -45,7 +45,7 @@ on:
         required: true
 jobs:
   system-tests:
-    uses: 0chain/actions/.github/workflows/manual_system_tests.yml@check-without-validators
+    uses: 0chain/actions/.github/workflows/manual_system_tests.yml@master
     with:
       system_tests_branch: ${{ github.event.inputs.system_tests_branch }}
       miner_branch: ${{ github.ref_name }}

--- a/.github/workflows/system_tests.yml
+++ b/.github/workflows/system_tests.yml
@@ -45,7 +45,7 @@ on:
         required: true
 jobs:
   system-tests:
-    uses: 0chain/actions/.github/workflows/manual_system_tests.yml@master
+    uses: 0chain/actions/.github/workflows/manual_system_tests.yml@check-without-validators
     with:
       system_tests_branch: ${{ github.event.inputs.system_tests_branch }}
       miner_branch: ${{ github.ref_name }}

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -567,6 +567,12 @@ func (sc *StorageSmartContract) generateChallenges(t *transaction.Transaction,
 			"error getting the validators list: %v", err)
 	}
 
+	listLen, err := validators.Size(balances)
+	if listLen == 0 {
+		return common.NewErrorf("adding_challenge_error",
+			"no available validators")
+	}
+
 	var all *Allocations
 	if all, err = sc.getAllAllocationsList(balances); err != nil {
 		return common.NewErrorf("adding_challenge_error",


### PR DESCRIPTION
## Changes
Added check on size of validators list to stop generating challenges if there are no validators.

## Fixes
Resolves #1060 

## Tests 
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
