### PR TITLE
- StorageAllocation optimisation - don't need Blobbers

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -365,7 +365,6 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 		return allocatedBlobbers[i].ID < allocatedBlobbers[j].ID
 	})
 
-	sa.Blobbers = allocatedBlobbers
 	sa.ID = t.Hash
 	sa.StartTime = t.CreationDate
 	sa.Tx = t.Hash

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"sort"
 	"strconv"
 	"time"
 
@@ -325,11 +324,9 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 	}
 
 	sa.ID = t.Hash
-	allocatedBlobbers := make([]*StorageNode, 0)
 	for _, b := range blobberNodes {
 		balloc := newBlobberAllocation(bSize, sa, b, t.CreationDate)
 		sa.BlobberDetails = append(sa.BlobberDetails, balloc)
-		allocatedBlobbers = append(allocatedBlobbers, b)
 
 		if b.Terms.ChallengeCompletionTime > sa.ChallengeCompletionTime {
 			sa.ChallengeCompletionTime = b.Terms.ChallengeCompletionTime
@@ -352,11 +349,6 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 		}
 	}
 
-	sort.SliceStable(allocatedBlobbers, func(i, j int) bool {
-		return allocatedBlobbers[i].ID < allocatedBlobbers[j].ID
-	})
-
-	sa.Blobbers = allocatedBlobbers
 	sa.StartTime = t.CreationDate
 	sa.Tx = t.Hash
 

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"sort"
 	"strconv"
 	"time"
 
@@ -323,7 +324,6 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 		return "", common.NewErrorf("allocation_creation_failed", "%v", err)
 	}
 
-
 	sa.ID = t.Hash
 	allocatedBlobbers := make([]*StorageNode, 0)
 	for _, b := range blobberNodes {
@@ -351,7 +351,6 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 			return "", fmt.Errorf("can't save blobber's stake pool: %v", err)
 		}
 	}
-
 
 	sort.SliceStable(allocatedBlobbers, func(i, j int) bool {
 		return allocatedBlobbers[i].ID < allocatedBlobbers[j].ID

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"sort"
 	"strconv"
 	"time"
 
@@ -325,7 +324,6 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 	}
 
 	var gbSize = sizeInGB(bSize) // size in gigabytes
-	allocatedBlobbers := make([]*StorageNode, 0)
 	for _, b := range blobberNodes {
 		var balloc BlobberAllocation
 		balloc.Stats = &StorageAllocationStats{}
@@ -335,7 +333,6 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 		balloc.BlobberID = b.ID
 
 		sa.BlobberDetails = append(sa.BlobberDetails, &balloc)
-		allocatedBlobbers = append(allocatedBlobbers, b)
 
 		// the Expiration and TimeUnit are already set for the 'sa' and we c
 		// an use the restDurationInTimeUnits method here
@@ -360,10 +357,6 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 			return "", fmt.Errorf("can't save blobber's stake pool: %v", err)
 		}
 	}
-
-	sort.SliceStable(allocatedBlobbers, func(i, j int) bool {
-		return allocatedBlobbers[i].ID < allocatedBlobbers[j].ID
-	})
 
 	sa.ID = t.Hash
 	sa.StartTime = t.CreationDate

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -1097,8 +1097,6 @@ func TestStorageSmartContract_newAllocationRequest(t *testing.T) {
 	sb.Nodes[0].Used += 10 * GB
 	sb.Nodes[1].Used += 10 * GB
 
-	// blobbers of the allocation
-	assert.EqualValues(t, sb.Nodes, aresp.BlobberDetails)
 	// blobbers saved in all blobbers list
 	allBlobbers, err = ssc.getBlobbersList(balances)
 	require.NoError(t, err)

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -1098,7 +1098,7 @@ func TestStorageSmartContract_newAllocationRequest(t *testing.T) {
 	sb.Nodes[1].Used += 10 * GB
 
 	// blobbers of the allocation
-	assert.EqualValues(t, sb.Nodes, aresp.Blobbers)
+	assert.EqualValues(t, sb.Nodes, aresp.BlobberDetails)
 	// blobbers saved in all blobbers list
 	allBlobbers, err = ssc.getBlobbersList(balances)
 	require.NoError(t, err)

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
@@ -95,17 +95,6 @@ func addMockAllocation(
 			MinLockDemand:  mockMinLockDemand,
 			AllocationRoot: encryption.Hash("allocation root"),
 		})
-		sa.Blobbers = append(sa.Blobbers, &StorageNode{
-			ID:      bId,
-			BaseURL: bId + ".com",
-			Terms:   getMockBlobberTerms(),
-
-			Capacity:          viper.GetInt64(sc.StorageMinBlobberCapacity) * 100000,
-			Used:              0,
-			LastHealthCheck:   now,
-			PublicKey:         "",
-			StakePoolSettings: getMockStakePoolSettings(bId),
-		})
 	}
 
 	if _, err := balances.InsertTrieNode(sa.GetKey(ADDRESS), sa); err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -670,10 +670,11 @@ func (sc *StorageSmartContract) commitBlobberConnection(
 
 	// Update saved_data on storage node
 	var storageNode *StorageNode
-	for _, b := range alloc.Blobbers {
-		if b.ID == commitConnection.WriteMarker.BlobberID {
-			storageNode = b
-			break
+	if _, ok := alloc.BlobberMap[commitConnection.WriteMarker.BlobberID]; ok {
+		storageNode, err = sc.getBlobber(commitConnection.WriteMarker.BlobberID, balances)
+		if err != nil {
+			return "", common.NewError("commit_connection_failed",
+				"can't get blobber")
 		}
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -812,16 +812,7 @@ func (sc *StorageSmartContract) populateGenerateChallenge(
 			"empty blobber id")
 	}
 
-	blobber := &StorageNode{}
-
-	for _, b := range alloc.Blobbers {
-		if b.ID == blobberID {
-			blobber = b
-			break
-		}
-	}
-
-	blobberAllocation, ok := alloc.BlobberMap[blobber.ID]
+	blobberAllocation, ok := alloc.BlobberMap[blobberID]
 	if !ok {
 		return nil, common.NewError("add_challenges",
 			"blobber allocation doesn't exists in allocation")
@@ -840,7 +831,7 @@ func (sc *StorageSmartContract) populateGenerateChallenge(
 
 	perm := challRand.Perm(len(randSlice))
 	for i := 0; i < minInt(len(randSlice), alloc.DataShards+1); i++ {
-		if randSlice[perm[i]].Name() != blobber.ID {
+		if randSlice[perm[i]].Name() != blobberID {
 			selectedValidators = append(selectedValidators,
 				&ValidationNode{
 					ID:      randSlice[perm[i]].Name(),

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -813,17 +813,7 @@ func (sc *StorageSmartContract) populateGenerateChallenge(
 		return nil, errors.New("empty allocation")
 	}
 
-
-	blobber := &StorageNode{}
-
-	for _, b := range alloc.Blobbers {
-		if b.ID == blobberID {
-			blobber = b
-			break
-		}
-	}
-
-	blobberAllocation, ok := alloc.BlobberMap[blobber.ID]
+	blobberAllocation, ok := alloc.BlobberMap[blobberID]
 	if !ok {
 		return nil, common.NewError("add_challenges",
 			"blobber allocation doesn't exists in allocation")
@@ -840,11 +830,10 @@ func (sc *StorageSmartContract) populateGenerateChallenge(
 			"error getting validators random slice: "+err.Error())
 	}
 
-
 	perm := challRand.Perm(len(randValidators))
 	for i := 0; i < minInt(len(randValidators), alloc.DataShards+1); i++ {
 		randValidator := randValidators[perm[i]]
-		if randValidator.Name() != blobber.ID {
+		if randValidator.Name() != blobberID {
 			selectedValidators = append(selectedValidators,
 				&ValidationNode{
 					ID:      randValidator.Name(),

--- a/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
@@ -173,6 +173,7 @@ func TestAddChallenge(t *testing.T) {
 			require.EqualValues(t, want.errorMsg, err.Error())
 			return
 		}
+
 		challenge := &StorageChallenge{}
 		require.NoError(t, json.Unmarshal([]byte(resp), challenge))
 

--- a/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
@@ -150,7 +150,6 @@ func TestAddChallenge(t *testing.T) {
 
 		return args{
 			alloc: &StorageAllocation{
-				Blobbers:   blobbers,
 				BlobberMap: blobberMap,
 				Stats:      &StorageAllocationStats{},
 			},

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -333,6 +333,12 @@ func (ssc *StorageSmartContract) GetAllocationsHandler(ctx context.Context,
 		err := balances.GetTrieNode(allocationObj.GetKey(ssc.ID), allocationObj)
 		switch err {
 		case nil:
+			if balances.GetEventDB() != nil {
+				err = allocationObj.getBlobbers(balances)
+				if err != nil {
+					return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, cantGetBlobber)
+				}
+			}
 			result = append(result, allocationObj)
 		case util.ErrValueNotPresent:
 			continue
@@ -388,7 +394,10 @@ func (ssc *StorageSmartContract) GetAllocationMinLockHandler(ctx context.Context
 	return response, nil
 }
 
-const cantGetAllocation = "can't get allocation"
+const (
+	cantGetAllocation = "can't get allocation"
+	cantGetBlobber    = "can't get blobber"
+)
 
 func (ssc *StorageSmartContract) AllocationStatsHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
 	allocationID := params.Get("allocation")
@@ -398,6 +407,13 @@ func (ssc *StorageSmartContract) AllocationStatsHandler(ctx context.Context, par
 	err := balances.GetTrieNode(allocationObj.GetKey(ssc.ID), allocationObj)
 	if err != nil {
 		return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, cantGetAllocation)
+	}
+
+	if balances.GetEventDB() != nil {
+		err = allocationObj.getBlobbers(balances)
+		if err != nil {
+			return nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, cantGetBlobber)
+		}
 	}
 
 	return allocationObj, nil

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"time"
 
+	"go.uber.org/zap"
+
 	"0chain.net/smartcontract/stakepool/spenum"
 
 	"0chain.net/core/datastore"
@@ -320,6 +322,9 @@ func (msc *StorageSmartContract) GetErrors(
 func (ssc *StorageSmartContract) GetAllocationsHandler(ctx context.Context,
 	params url.Values, balances cstate.StateContextI) (interface{}, error) {
 
+	logging.Logger.Info("GetAllocationsHandler",
+		zap.Bool("is event db present", balances.GetEventDB() != nil))
+
 	clientID := params.Get("client")
 	allocations, err := ssc.getAllocationsList(clientID, balances)
 	if err != nil {
@@ -400,6 +405,8 @@ const (
 )
 
 func (ssc *StorageSmartContract) AllocationStatsHandler(ctx context.Context, params url.Values, balances cstate.StateContextI) (interface{}, error) {
+	logging.Logger.Info("AllocationStatsHandler",
+		zap.Bool("is event db present", balances.GetEventDB() != nil))
 	allocationID := params.Get("allocation")
 	allocationObj := &StorageAllocation{}
 	allocationObj.ID = allocationID

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -707,7 +707,6 @@ type StorageAllocation struct {
 	ParityShards      int                           `json:"parity_shards"`
 	Size              int64                         `json:"size"`
 	Expiration        common.Timestamp              `json:"expiration_date"`
-	Blobbers          []*StorageNode                `json:"blobbers"`
 	Owner             string                        `json:"owner_id"`
 	OwnerPublicKey    string                        `json:"owner_public_key"`
 	Stats             *StorageAllocationStats       `json:"stats"`

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -703,19 +703,20 @@ type StorageAllocation struct {
 	// Tx keeps hash with which the allocation has created or updated.
 	Tx string `json:"tx"`
 
-	DataShards        int                           `json:"data_shards"`
-	ParityShards      int                           `json:"parity_shards"`
-	Size              int64                         `json:"size"`
-	Expiration        common.Timestamp              `json:"expiration_date"`
-	Owner             string                        `json:"owner_id"`
-	OwnerPublicKey    string                        `json:"owner_public_key"`
-	Stats             *StorageAllocationStats       `json:"stats"`
-	DiverseBlobbers   bool                          `json:"diverse_blobbers"`
-	PreferredBlobbers []string                      `json:"preferred_blobbers"`
-	Blobbers          []*StorageNode                `json:"blobbers"`
-	BlobberDetails    []*BlobberAllocation          `json:"blobber_details"`
-	BlobberMap        map[string]*BlobberAllocation `json:"-" msg:"-"`
-	IsImmutable       bool                          `json:"is_immutable"`
+	DataShards        int                     `json:"data_shards"`
+	ParityShards      int                     `json:"parity_shards"`
+	Size              int64                   `json:"size"`
+	Expiration        common.Timestamp        `json:"expiration_date"`
+	Owner             string                  `json:"owner_id"`
+	OwnerPublicKey    string                  `json:"owner_public_key"`
+	Stats             *StorageAllocationStats `json:"stats"`
+	DiverseBlobbers   bool                    `json:"diverse_blobbers"`
+	PreferredBlobbers []string                `json:"preferred_blobbers"`
+	// Blobbers not to be used anywhere except /allocation and /allocations table
+	Blobbers       []*StorageNode                `json:"blobbers"`
+	BlobberDetails []*BlobberAllocation          `json:"blobber_details"`
+	BlobberMap     map[string]*BlobberAllocation `json:"-" msg:"-"`
+	IsImmutable    bool                          `json:"is_immutable"`
 
 	// Requested ranges.
 	ReadPriceRange             PriceRange    `json:"read_price_range"`

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -838,24 +838,12 @@ func (sa *StorageAllocation) removeBlobber(
 	}
 	delete(sa.BlobberMap, removeId)
 
-	found = false
-	for i, d := range sa.Blobbers {
-		if d.ID == removeId {
-			sa.Blobbers[i] = sa.Blobbers[len(sa.Blobbers)-1]
-			sa.Blobbers = sa.Blobbers[:len(sa.Blobbers)-1]
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil, fmt.Errorf("cannot find blobber %s in allocation", remove.BlobberID)
-	}
 	var removedBlobber *StorageNode
 	found = false
 	for i, d := range blobbers {
 		if d.ID == removeId {
 			removedBlobber = blobbers[i]
-			blobbers[i] = blobbers[len(sa.Blobbers)-1]
+			blobbers[i] = blobbers[len(sa.BlobberDetails)-1]
 			blobbers = blobbers[:len(blobbers)-1]
 			found = true
 			break
@@ -868,7 +856,7 @@ func (sa *StorageAllocation) removeBlobber(
 	found = false
 	for i, d := range sa.BlobberDetails {
 		if d.BlobberID == removeId {
-			sa.BlobberDetails[i] = sa.BlobberDetails[len(sa.Blobbers)-1]
+			sa.BlobberDetails[i] = sa.BlobberDetails[len(sa.BlobberDetails)-1]
 			sa.BlobberDetails = sa.BlobberDetails[:len(sa.BlobberDetails)-1]
 			removedBlobber.Used -= d.Size
 			found = true
@@ -928,7 +916,6 @@ func (sa *StorageAllocation) changeBlobbers(
 	addedBlobber.Used += sa.bSize()
 	afterSize := sa.bSize()
 
-	sa.Blobbers = append(sa.Blobbers, addedBlobber)
 	blobbers = append(blobbers, addedBlobber)
 	ba := newBlobberAllocation(afterSize, sa, addedBlobber, now)
 	sa.BlobberMap[addId] = ba

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -713,6 +713,7 @@ type StorageAllocation struct {
 	DiverseBlobbers   bool                    `json:"diverse_blobbers"`
 	PreferredBlobbers []string                `json:"preferred_blobbers"`
 	// Blobbers not to be used anywhere except /allocation and /allocations table
+	// if Blobbers are getting used in any smart-contract, we should avoid.
 	Blobbers       []*StorageNode                `json:"blobbers"`
 	BlobberDetails []*BlobberAllocation          `json:"blobber_details"`
 	BlobberMap     map[string]*BlobberAllocation `json:"-" msg:"-"`

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -712,6 +712,7 @@ type StorageAllocation struct {
 	Stats             *StorageAllocationStats       `json:"stats"`
 	DiverseBlobbers   bool                          `json:"diverse_blobbers"`
 	PreferredBlobbers []string                      `json:"preferred_blobbers"`
+	Blobbers          []*StorageNode                `json:"blobbers"`
 	BlobberDetails    []*BlobberAllocation          `json:"blobber_details"`
 	BlobberMap        map[string]*BlobberAllocation `json:"-" msg:"-"`
 	IsImmutable       bool                          `json:"is_immutable"`
@@ -770,6 +771,22 @@ func (sa *StorageAllocation) restMinLockDemand() (rest state.Balance) {
 		}
 	}
 	return
+}
+
+func (sa *StorageAllocation) getBlobbers(balances chainstate.StateContextI) error {
+
+	for _, ba := range sa.BlobberDetails {
+		blobber, err := balances.GetEventDB().GetBlobber(ba.BlobberID)
+		if err != nil {
+			return err
+		}
+		sn, err := blobberTableToStorageNode(*blobber)
+		if err != nil {
+			return err
+		}
+		sa.Blobbers = append(sa.Blobbers, &sn)
+	}
+	return nil
 }
 
 func (sa *StorageAllocation) addWritePoolOwner(userId string) {

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -961,7 +961,7 @@ func (sa *StorageAllocation) getBlobbers(balances chainstate.StateContextI) erro
 		if err != nil {
 			return err
 		}
-		sa.Blobbers = append(sa.Blobbers, &sn)
+		sa.Blobbers = append(sa.Blobbers, &sn.StorageNode)
 	}
 	return nil
 }

--- a/code/go/0chain.net/smartcontract/storagesc/models_gen.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models_gen.go
@@ -1709,9 +1709,9 @@ func (z *RewardPartitionLocation) Msgsize() (s int) {
 // MarshalMsg implements msgp.Marshaler
 func (z *StorageAllocationDecode) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 26
+	// map header, size 27
 	// string "ID"
-	o = append(o, 0xde, 0x0, 0x1a, 0xa2, 0x49, 0x44)
+	o = append(o, 0xde, 0x0, 0x1b, 0xa2, 0x49, 0x44)
 	o = msgp.AppendString(o, z.ID)
 	// string "Tx"
 	o = append(o, 0xa2, 0x54, 0x78)
@@ -1758,16 +1758,30 @@ func (z *StorageAllocationDecode) MarshalMsg(b []byte) (o []byte, err error) {
 	for za0001 := range z.PreferredBlobbers {
 		o = msgp.AppendString(o, z.PreferredBlobbers[za0001])
 	}
+	// string "Blobbers"
+	o = append(o, 0xa8, 0x42, 0x6c, 0x6f, 0x62, 0x62, 0x65, 0x72, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Blobbers)))
+	for za0002 := range z.Blobbers {
+		if z.Blobbers[za0002] == nil {
+			o = msgp.AppendNil(o)
+		} else {
+			o, err = z.Blobbers[za0002].MarshalMsg(o)
+			if err != nil {
+				err = msgp.WrapError(err, "Blobbers", za0002)
+				return
+			}
+		}
+	}
 	// string "BlobberDetails"
 	o = append(o, 0xae, 0x42, 0x6c, 0x6f, 0x62, 0x62, 0x65, 0x72, 0x44, 0x65, 0x74, 0x61, 0x69, 0x6c, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.BlobberDetails)))
-	for za0002 := range z.BlobberDetails {
-		if z.BlobberDetails[za0002] == nil {
+	for za0003 := range z.BlobberDetails {
+		if z.BlobberDetails[za0003] == nil {
 			o = msgp.AppendNil(o)
 		} else {
-			o, err = z.BlobberDetails[za0002].MarshalMsg(o)
+			o, err = z.BlobberDetails[za0003].MarshalMsg(o)
 			if err != nil {
-				err = msgp.WrapError(err, "BlobberDetails", za0002)
+				err = msgp.WrapError(err, "BlobberDetails", za0003)
 				return
 			}
 		}
@@ -1815,8 +1829,8 @@ func (z *StorageAllocationDecode) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "WritePoolOwners"
 	o = append(o, 0xaf, 0x57, 0x72, 0x69, 0x74, 0x65, 0x50, 0x6f, 0x6f, 0x6c, 0x4f, 0x77, 0x6e, 0x65, 0x72, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.WritePoolOwners)))
-	for za0003 := range z.WritePoolOwners {
-		o = msgp.AppendString(o, z.WritePoolOwners[za0003])
+	for za0004 := range z.WritePoolOwners {
+		o = msgp.AppendString(o, z.WritePoolOwners[za0004])
 	}
 	// string "ChallengeCompletionTime"
 	o = append(o, 0xb7, 0x43, 0x68, 0x61, 0x6c, 0x6c, 0x65, 0x6e, 0x67, 0x65, 0x43, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x69, 0x6d, 0x65)
@@ -1861,8 +1875,8 @@ func (z *StorageAllocationDecode) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Curators"
 	o = append(o, 0xa8, 0x43, 0x75, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Curators)))
-	for za0004 := range z.Curators {
-		o = msgp.AppendString(o, z.Curators[za0004])
+	for za0005 := range z.Curators {
+		o = msgp.AppendString(o, z.Curators[za0005])
 	}
 	return
 }
@@ -1975,32 +1989,62 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 					return
 				}
 			}
-		case "BlobberDetails":
+		case "Blobbers":
 			var zb0003 uint32
 			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "BlobberDetails")
+				err = msgp.WrapError(err, "Blobbers")
 				return
 			}
-			if cap(z.BlobberDetails) >= int(zb0003) {
-				z.BlobberDetails = (z.BlobberDetails)[:zb0003]
+			if cap(z.Blobbers) >= int(zb0003) {
+				z.Blobbers = (z.Blobbers)[:zb0003]
 			} else {
-				z.BlobberDetails = make([]*BlobberAllocation, zb0003)
+				z.Blobbers = make([]*StorageNode, zb0003)
 			}
-			for za0002 := range z.BlobberDetails {
+			for za0002 := range z.Blobbers {
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
 						return
 					}
-					z.BlobberDetails[za0002] = nil
+					z.Blobbers[za0002] = nil
 				} else {
-					if z.BlobberDetails[za0002] == nil {
-						z.BlobberDetails[za0002] = new(BlobberAllocation)
+					if z.Blobbers[za0002] == nil {
+						z.Blobbers[za0002] = new(StorageNode)
 					}
-					bts, err = z.BlobberDetails[za0002].UnmarshalMsg(bts)
+					bts, err = z.Blobbers[za0002].UnmarshalMsg(bts)
 					if err != nil {
-						err = msgp.WrapError(err, "BlobberDetails", za0002)
+						err = msgp.WrapError(err, "Blobbers", za0002)
+						return
+					}
+				}
+			}
+		case "BlobberDetails":
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "BlobberDetails")
+				return
+			}
+			if cap(z.BlobberDetails) >= int(zb0004) {
+				z.BlobberDetails = (z.BlobberDetails)[:zb0004]
+			} else {
+				z.BlobberDetails = make([]*BlobberAllocation, zb0004)
+			}
+			for za0003 := range z.BlobberDetails {
+				if msgp.IsNil(bts) {
+					bts, err = msgp.ReadNilBytes(bts)
+					if err != nil {
+						return
+					}
+					z.BlobberDetails[za0003] = nil
+				} else {
+					if z.BlobberDetails[za0003] == nil {
+						z.BlobberDetails[za0003] = new(BlobberAllocation)
+					}
+					bts, err = z.BlobberDetails[za0003].UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "BlobberDetails", za0003)
 						return
 					}
 				}
@@ -2012,14 +2056,14 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				return
 			}
 		case "ReadPriceRange":
-			var zb0004 uint32
-			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0005 uint32
+			zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ReadPriceRange")
 				return
 			}
-			for zb0004 > 0 {
-				zb0004--
+			for zb0005 > 0 {
+				zb0005--
 				field, bts, err = msgp.ReadMapKeyZC(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ReadPriceRange")
@@ -2047,14 +2091,14 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				}
 			}
 		case "WritePriceRange":
-			var zb0005 uint32
-			zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "WritePriceRange")
 				return
 			}
-			for zb0005 > 0 {
-				zb0005--
+			for zb0006 > 0 {
+				zb0006--
 				field, bts, err = msgp.ReadMapKeyZC(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "WritePriceRange")
@@ -2088,21 +2132,21 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				return
 			}
 		case "WritePoolOwners":
-			var zb0006 uint32
-			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 uint32
+			zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "WritePoolOwners")
 				return
 			}
-			if cap(z.WritePoolOwners) >= int(zb0006) {
-				z.WritePoolOwners = (z.WritePoolOwners)[:zb0006]
+			if cap(z.WritePoolOwners) >= int(zb0007) {
+				z.WritePoolOwners = (z.WritePoolOwners)[:zb0007]
 			} else {
-				z.WritePoolOwners = make([]string, zb0006)
+				z.WritePoolOwners = make([]string, zb0007)
 			}
-			for za0003 := range z.WritePoolOwners {
-				z.WritePoolOwners[za0003], bts, err = msgp.ReadStringBytes(bts)
+			for za0004 := range z.WritePoolOwners {
+				z.WritePoolOwners[za0004], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "WritePoolOwners", za0003)
+					err = msgp.WrapError(err, "WritePoolOwners", za0004)
 					return
 				}
 			}
@@ -2155,21 +2199,21 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				return
 			}
 		case "Curators":
-			var zb0007 uint32
-			zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0008 uint32
+			zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Curators")
 				return
 			}
-			if cap(z.Curators) >= int(zb0007) {
-				z.Curators = (z.Curators)[:zb0007]
+			if cap(z.Curators) >= int(zb0008) {
+				z.Curators = (z.Curators)[:zb0008]
 			} else {
-				z.Curators = make([]string, zb0007)
+				z.Curators = make([]string, zb0008)
 			}
-			for za0004 := range z.Curators {
-				z.Curators[za0004], bts, err = msgp.ReadStringBytes(bts)
+			for za0005 := range z.Curators {
+				z.Curators[za0005], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "Curators", za0004)
+					err = msgp.WrapError(err, "Curators", za0005)
 					return
 				}
 			}
@@ -2197,21 +2241,29 @@ func (z *StorageAllocationDecode) Msgsize() (s int) {
 	for za0001 := range z.PreferredBlobbers {
 		s += msgp.StringPrefixSize + len(z.PreferredBlobbers[za0001])
 	}
-	s += 15 + msgp.ArrayHeaderSize
-	for za0002 := range z.BlobberDetails {
-		if z.BlobberDetails[za0002] == nil {
+	s += 9 + msgp.ArrayHeaderSize
+	for za0002 := range z.Blobbers {
+		if z.Blobbers[za0002] == nil {
 			s += msgp.NilSize
 		} else {
-			s += z.BlobberDetails[za0002].Msgsize()
+			s += z.Blobbers[za0002].Msgsize()
+		}
+	}
+	s += 15 + msgp.ArrayHeaderSize
+	for za0003 := range z.BlobberDetails {
+		if z.BlobberDetails[za0003] == nil {
+			s += msgp.NilSize
+		} else {
+			s += z.BlobberDetails[za0003].Msgsize()
 		}
 	}
 	s += 12 + msgp.BoolSize + 15 + 1 + 4 + z.ReadPriceRange.Min.Msgsize() + 4 + z.ReadPriceRange.Max.Msgsize() + 16 + 1 + 4 + z.WritePriceRange.Min.Msgsize() + 4 + z.WritePriceRange.Max.Msgsize() + 27 + msgp.DurationSize + 16 + msgp.ArrayHeaderSize
-	for za0003 := range z.WritePoolOwners {
-		s += msgp.StringPrefixSize + len(z.WritePoolOwners[za0003])
+	for za0004 := range z.WritePoolOwners {
+		s += msgp.StringPrefixSize + len(z.WritePoolOwners[za0004])
 	}
 	s += 24 + msgp.DurationSize + 10 + z.StartTime.Msgsize() + 10 + msgp.BoolSize + 9 + msgp.BoolSize + 17 + z.MovedToChallenge.Msgsize() + 10 + z.MovedBack.Msgsize() + 18 + z.MovedToValidators.Msgsize() + 9 + msgp.DurationSize + 9 + msgp.ArrayHeaderSize
-	for za0004 := range z.Curators {
-		s += msgp.StringPrefixSize + len(z.Curators[za0004])
+	for za0005 := range z.Curators {
+		s += msgp.StringPrefixSize + len(z.Curators[za0005])
 	}
 	return
 }

--- a/code/go/0chain.net/smartcontract/storagesc/models_gen.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models_gen.go
@@ -1759,9 +1759,9 @@ func (z *RewardPartitionLocation) Msgsize() (s int) {
 // MarshalMsg implements msgp.Marshaler
 func (z *StorageAllocationDecode) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 27
+	// map header, size 26
 	// string "ID"
-	o = append(o, 0xde, 0x0, 0x1b, 0xa2, 0x49, 0x44)
+	o = append(o, 0xde, 0x0, 0x1a, 0xa2, 0x49, 0x44)
 	o = msgp.AppendString(o, z.ID)
 	// string "Tx"
 	o = append(o, 0xa2, 0x54, 0x78)
@@ -1781,20 +1781,6 @@ func (z *StorageAllocationDecode) MarshalMsg(b []byte) (o []byte, err error) {
 	if err != nil {
 		err = msgp.WrapError(err, "Expiration")
 		return
-	}
-	// string "Blobbers"
-	o = append(o, 0xa8, 0x42, 0x6c, 0x6f, 0x62, 0x62, 0x65, 0x72, 0x73)
-	o = msgp.AppendArrayHeader(o, uint32(len(z.Blobbers)))
-	for za0001 := range z.Blobbers {
-		if z.Blobbers[za0001] == nil {
-			o = msgp.AppendNil(o)
-		} else {
-			o, err = z.Blobbers[za0001].MarshalMsg(o)
-			if err != nil {
-				err = msgp.WrapError(err, "Blobbers", za0001)
-				return
-			}
-		}
 	}
 	// string "Owner"
 	o = append(o, 0xa5, 0x4f, 0x77, 0x6e, 0x65, 0x72)
@@ -1819,19 +1805,19 @@ func (z *StorageAllocationDecode) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "PreferredBlobbers"
 	o = append(o, 0xb1, 0x50, 0x72, 0x65, 0x66, 0x65, 0x72, 0x72, 0x65, 0x64, 0x42, 0x6c, 0x6f, 0x62, 0x62, 0x65, 0x72, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.PreferredBlobbers)))
-	for za0002 := range z.PreferredBlobbers {
-		o = msgp.AppendString(o, z.PreferredBlobbers[za0002])
+	for za0001 := range z.PreferredBlobbers {
+		o = msgp.AppendString(o, z.PreferredBlobbers[za0001])
 	}
 	// string "BlobberDetails"
 	o = append(o, 0xae, 0x42, 0x6c, 0x6f, 0x62, 0x62, 0x65, 0x72, 0x44, 0x65, 0x74, 0x61, 0x69, 0x6c, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.BlobberDetails)))
-	for za0003 := range z.BlobberDetails {
-		if z.BlobberDetails[za0003] == nil {
+	for za0002 := range z.BlobberDetails {
+		if z.BlobberDetails[za0002] == nil {
 			o = msgp.AppendNil(o)
 		} else {
-			o, err = z.BlobberDetails[za0003].MarshalMsg(o)
+			o, err = z.BlobberDetails[za0002].MarshalMsg(o)
 			if err != nil {
-				err = msgp.WrapError(err, "BlobberDetails", za0003)
+				err = msgp.WrapError(err, "BlobberDetails", za0002)
 				return
 			}
 		}
@@ -1879,8 +1865,8 @@ func (z *StorageAllocationDecode) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "WritePoolOwners"
 	o = append(o, 0xaf, 0x57, 0x72, 0x69, 0x74, 0x65, 0x50, 0x6f, 0x6f, 0x6c, 0x4f, 0x77, 0x6e, 0x65, 0x72, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.WritePoolOwners)))
-	for za0004 := range z.WritePoolOwners {
-		o = msgp.AppendString(o, z.WritePoolOwners[za0004])
+	for za0003 := range z.WritePoolOwners {
+		o = msgp.AppendString(o, z.WritePoolOwners[za0003])
 	}
 	// string "ChallengeCompletionTime"
 	o = append(o, 0xb7, 0x43, 0x68, 0x61, 0x6c, 0x6c, 0x65, 0x6e, 0x67, 0x65, 0x43, 0x6f, 0x6d, 0x70, 0x6c, 0x65, 0x74, 0x69, 0x6f, 0x6e, 0x54, 0x69, 0x6d, 0x65)
@@ -1925,8 +1911,8 @@ func (z *StorageAllocationDecode) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "Curators"
 	o = append(o, 0xa8, 0x43, 0x75, 0x72, 0x61, 0x74, 0x6f, 0x72, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Curators)))
-	for za0005 := range z.Curators {
-		o = msgp.AppendString(o, z.Curators[za0005])
+	for za0004 := range z.Curators {
+		o = msgp.AppendString(o, z.Curators[za0004])
 	}
 	return
 }
@@ -1985,36 +1971,6 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				err = msgp.WrapError(err, "Expiration")
 				return
 			}
-		case "Blobbers":
-			var zb0002 uint32
-			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Blobbers")
-				return
-			}
-			if cap(z.Blobbers) >= int(zb0002) {
-				z.Blobbers = (z.Blobbers)[:zb0002]
-			} else {
-				z.Blobbers = make([]*StorageNode, zb0002)
-			}
-			for za0001 := range z.Blobbers {
-				if msgp.IsNil(bts) {
-					bts, err = msgp.ReadNilBytes(bts)
-					if err != nil {
-						return
-					}
-					z.Blobbers[za0001] = nil
-				} else {
-					if z.Blobbers[za0001] == nil {
-						z.Blobbers[za0001] = new(StorageNode)
-					}
-					bts, err = z.Blobbers[za0001].UnmarshalMsg(bts)
-					if err != nil {
-						err = msgp.WrapError(err, "Blobbers", za0001)
-						return
-					}
-				}
-			}
 		case "Owner":
 			z.Owner, bts, err = msgp.ReadStringBytes(bts)
 			if err != nil {
@@ -2051,50 +2007,50 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				return
 			}
 		case "PreferredBlobbers":
-			var zb0003 uint32
-			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "PreferredBlobbers")
 				return
 			}
-			if cap(z.PreferredBlobbers) >= int(zb0003) {
-				z.PreferredBlobbers = (z.PreferredBlobbers)[:zb0003]
+			if cap(z.PreferredBlobbers) >= int(zb0002) {
+				z.PreferredBlobbers = (z.PreferredBlobbers)[:zb0002]
 			} else {
-				z.PreferredBlobbers = make([]string, zb0003)
+				z.PreferredBlobbers = make([]string, zb0002)
 			}
-			for za0002 := range z.PreferredBlobbers {
-				z.PreferredBlobbers[za0002], bts, err = msgp.ReadStringBytes(bts)
+			for za0001 := range z.PreferredBlobbers {
+				z.PreferredBlobbers[za0001], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "PreferredBlobbers", za0002)
+					err = msgp.WrapError(err, "PreferredBlobbers", za0001)
 					return
 				}
 			}
 		case "BlobberDetails":
-			var zb0004 uint32
-			zb0004, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "BlobberDetails")
 				return
 			}
-			if cap(z.BlobberDetails) >= int(zb0004) {
-				z.BlobberDetails = (z.BlobberDetails)[:zb0004]
+			if cap(z.BlobberDetails) >= int(zb0003) {
+				z.BlobberDetails = (z.BlobberDetails)[:zb0003]
 			} else {
-				z.BlobberDetails = make([]*BlobberAllocation, zb0004)
+				z.BlobberDetails = make([]*BlobberAllocation, zb0003)
 			}
-			for za0003 := range z.BlobberDetails {
+			for za0002 := range z.BlobberDetails {
 				if msgp.IsNil(bts) {
 					bts, err = msgp.ReadNilBytes(bts)
 					if err != nil {
 						return
 					}
-					z.BlobberDetails[za0003] = nil
+					z.BlobberDetails[za0002] = nil
 				} else {
-					if z.BlobberDetails[za0003] == nil {
-						z.BlobberDetails[za0003] = new(BlobberAllocation)
+					if z.BlobberDetails[za0002] == nil {
+						z.BlobberDetails[za0002] = new(BlobberAllocation)
 					}
-					bts, err = z.BlobberDetails[za0003].UnmarshalMsg(bts)
+					bts, err = z.BlobberDetails[za0002].UnmarshalMsg(bts)
 					if err != nil {
-						err = msgp.WrapError(err, "BlobberDetails", za0003)
+						err = msgp.WrapError(err, "BlobberDetails", za0002)
 						return
 					}
 				}
@@ -2106,14 +2062,14 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				return
 			}
 		case "ReadPriceRange":
-			var zb0005 uint32
-			zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0004 uint32
+			zb0004, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "ReadPriceRange")
 				return
 			}
-			for zb0005 > 0 {
-				zb0005--
+			for zb0004 > 0 {
+				zb0004--
 				field, bts, err = msgp.ReadMapKeyZC(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "ReadPriceRange")
@@ -2141,14 +2097,14 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				}
 			}
 		case "WritePriceRange":
-			var zb0006 uint32
-			zb0006, bts, err = msgp.ReadMapHeaderBytes(bts)
+			var zb0005 uint32
+			zb0005, bts, err = msgp.ReadMapHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "WritePriceRange")
 				return
 			}
-			for zb0006 > 0 {
-				zb0006--
+			for zb0005 > 0 {
+				zb0005--
 				field, bts, err = msgp.ReadMapKeyZC(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "WritePriceRange")
@@ -2182,21 +2138,21 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				return
 			}
 		case "WritePoolOwners":
-			var zb0007 uint32
-			zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "WritePoolOwners")
 				return
 			}
-			if cap(z.WritePoolOwners) >= int(zb0007) {
-				z.WritePoolOwners = (z.WritePoolOwners)[:zb0007]
+			if cap(z.WritePoolOwners) >= int(zb0006) {
+				z.WritePoolOwners = (z.WritePoolOwners)[:zb0006]
 			} else {
-				z.WritePoolOwners = make([]string, zb0007)
+				z.WritePoolOwners = make([]string, zb0006)
 			}
-			for za0004 := range z.WritePoolOwners {
-				z.WritePoolOwners[za0004], bts, err = msgp.ReadStringBytes(bts)
+			for za0003 := range z.WritePoolOwners {
+				z.WritePoolOwners[za0003], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "WritePoolOwners", za0004)
+					err = msgp.WrapError(err, "WritePoolOwners", za0003)
 					return
 				}
 			}
@@ -2249,21 +2205,21 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 				return
 			}
 		case "Curators":
-			var zb0008 uint32
-			zb0008, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			var zb0007 uint32
+			zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Curators")
 				return
 			}
-			if cap(z.Curators) >= int(zb0008) {
-				z.Curators = (z.Curators)[:zb0008]
+			if cap(z.Curators) >= int(zb0007) {
+				z.Curators = (z.Curators)[:zb0007]
 			} else {
-				z.Curators = make([]string, zb0008)
+				z.Curators = make([]string, zb0007)
 			}
-			for za0005 := range z.Curators {
-				z.Curators[za0005], bts, err = msgp.ReadStringBytes(bts)
+			for za0004 := range z.Curators {
+				z.Curators[za0004], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "Curators", za0005)
+					err = msgp.WrapError(err, "Curators", za0004)
 					return
 				}
 			}
@@ -2281,39 +2237,31 @@ func (z *StorageAllocationDecode) UnmarshalMsg(bts []byte) (o []byte, err error)
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *StorageAllocationDecode) Msgsize() (s int) {
-	s = 3 + 3 + msgp.StringPrefixSize + len(z.ID) + 3 + msgp.StringPrefixSize + len(z.Tx) + 11 + msgp.IntSize + 13 + msgp.IntSize + 5 + msgp.Int64Size + 11 + z.Expiration.Msgsize() + 9 + msgp.ArrayHeaderSize
-	for za0001 := range z.Blobbers {
-		if z.Blobbers[za0001] == nil {
-			s += msgp.NilSize
-		} else {
-			s += z.Blobbers[za0001].Msgsize()
-		}
-	}
-	s += 6 + msgp.StringPrefixSize + len(z.Owner) + 15 + msgp.StringPrefixSize + len(z.OwnerPublicKey) + 6
+	s = 3 + 3 + msgp.StringPrefixSize + len(z.ID) + 3 + msgp.StringPrefixSize + len(z.Tx) + 11 + msgp.IntSize + 13 + msgp.IntSize + 5 + msgp.Int64Size + 11 + z.Expiration.Msgsize() + 6 + msgp.StringPrefixSize + len(z.Owner) + 15 + msgp.StringPrefixSize + len(z.OwnerPublicKey) + 6
 	if z.Stats == nil {
 		s += msgp.NilSize
 	} else {
 		s += z.Stats.Msgsize()
 	}
 	s += 16 + msgp.BoolSize + 18 + msgp.ArrayHeaderSize
-	for za0002 := range z.PreferredBlobbers {
-		s += msgp.StringPrefixSize + len(z.PreferredBlobbers[za0002])
+	for za0001 := range z.PreferredBlobbers {
+		s += msgp.StringPrefixSize + len(z.PreferredBlobbers[za0001])
 	}
 	s += 15 + msgp.ArrayHeaderSize
-	for za0003 := range z.BlobberDetails {
-		if z.BlobberDetails[za0003] == nil {
+	for za0002 := range z.BlobberDetails {
+		if z.BlobberDetails[za0002] == nil {
 			s += msgp.NilSize
 		} else {
-			s += z.BlobberDetails[za0003].Msgsize()
+			s += z.BlobberDetails[za0002].Msgsize()
 		}
 	}
 	s += 12 + msgp.BoolSize + 15 + 1 + 4 + z.ReadPriceRange.Min.Msgsize() + 4 + z.ReadPriceRange.Max.Msgsize() + 16 + 1 + 4 + z.WritePriceRange.Min.Msgsize() + 4 + z.WritePriceRange.Max.Msgsize() + 27 + msgp.DurationSize + 16 + msgp.ArrayHeaderSize
-	for za0004 := range z.WritePoolOwners {
-		s += msgp.StringPrefixSize + len(z.WritePoolOwners[za0004])
+	for za0003 := range z.WritePoolOwners {
+		s += msgp.StringPrefixSize + len(z.WritePoolOwners[za0003])
 	}
 	s += 24 + msgp.DurationSize + 10 + z.StartTime.Msgsize() + 10 + msgp.BoolSize + 9 + msgp.BoolSize + 17 + z.MovedToChallenge.Msgsize() + 10 + z.MovedBack.Msgsize() + 18 + z.MovedToValidators.Msgsize() + 9 + msgp.DurationSize + 9 + msgp.ArrayHeaderSize
-	for za0005 := range z.Curators {
-		s += msgp.StringPrefixSize + len(z.Curators[za0005])
+	for za0004 := range z.Curators {
+		s += msgp.StringPrefixSize + len(z.Curators[za0004])
 	}
 	return
 }

--- a/code/go/0chain.net/smartcontract/storagesc/transactions_bench_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/transactions_bench_test.go
@@ -424,7 +424,7 @@ func Benchmark_verifyChallenge(b *testing.B) {
 				require.NoError(b, err)
 
 				// 6.3 keep for the benchmark
-				blobberID = alloc.Blobbers[rand.Intn(len(alloc.Blobbers))].ID
+				blobberID = alloc.BlobberDetails[rand.Intn(len(alloc.BlobberDetails))].BlobberID
 
 				var (
 					challID    = encryption.Hash(fmt.Sprintf("chall-%d", tp))


### PR DESCRIPTION
## Changes

## Fixes
- Removed use of Blobbers in 0chain sc
- Blobbers would only be required for /allocation and /allocations client API
- also lot of gosdk depends on /allocation API - which will lead to huge changes if we remove Blobbers from there.
- Area of impact - MPT data size (which will help in sc execution)


## Tests 
Tasks to complete before merging PR:
- [x]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [x]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [x]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber: https://github.com/0chain/blobber/pull/623
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
