### PR TITLE
Make allocID optional in getReadPoolAllocBlobberStat

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_pool.go
@@ -265,6 +265,14 @@ func (aps allocationPools) allocationCut(allocID string) (
 	return
 }
 
+func (aps allocationPools) expiredBlobberCut(blobberID string,
+	now common.Timestamp) (cut []*allocationPool) {
+
+	cut = removeBlobberExpired(cut, blobberID, now)
+	sortExpireAt(cut)
+	return
+}
+
 func (aps allocationPools) blobberCut(allocID, blobberID string,
 	now common.Timestamp) (cut []*allocationPool) {
 

--- a/code/go/0chain.net/smartcontract/storagesc/readpool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/readpool.go
@@ -37,6 +37,12 @@ type readPool struct {
 	Pools allocationPools `json:"pools"`
 }
 
+func (rp *readPool) expiredBlobberCut(blobberID string, now common.Timestamp,
+) []*allocationPool {
+
+	return rp.Pools.expiredBlobberCut(blobberID, now)
+}
+
 func (rp *readPool) blobberCut(allocID, blobberID string, now common.Timestamp,
 ) []*allocationPool {
 
@@ -426,9 +432,15 @@ func (ssc *StorageSmartContract) getReadPoolAllocBlobberStatHandler(
 	}
 
 	var (
-		cut  = rp.blobberCut(allocID, blobberID, common.Now())
+		cut  []*allocationPool
 		stat []untilStat
 	)
+
+	if len(allocID) > 0 {
+		cut = rp.blobberCut(allocID, blobberID, common.Now())
+	} else {
+		cut = rp.expiredBlobberCut(blobberID, common.Now()) // rx_pay case
+	}
 
 	for _, ap := range cut {
 		var bp, ok = ap.Blobbers.get(blobberID)


### PR DESCRIPTION
## Changes

The issue happens when clients use rx_pay. In that case, blobber requests read pool stats with allocation ID and another ownerID (not the owner of the allocation). Hence it returns errors and gives tons of errors while pre-redeeming the read marker.

## Fixes

I made allocID optional and added an extra function to cut blobbers without allocID

## Tests 
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
