### PR TITLE
New "filename" param in /getWriteMarkers

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
@@ -64,13 +64,22 @@ func (edb *EventDb) GetWriteMarkers(offset, limit int, isDescending bool) ([]Wri
 	}).Scan(&wm).Error
 }
 
-func (edb *EventDb) GetWriteMarkersForAllocationID(allocationID string) (*[]WriteMarker, error) {
+func (edb *EventDb) GetWriteMarkersForAllocationID(allocationID string) ([]WriteMarker, error) {
 	var wms []WriteMarker
 	result := edb.Store.Get().
 		Model(&WriteMarker{}).
 		Where(&WriteMarker{AllocationID: allocationID}).
 		Find(&wms)
-	return &wms, result.Error
+	return wms, result.Error
+}
+
+func (edb *EventDb) GetWriteMarkersForAllocationFile(allocationID string, filename string) ([]WriteMarker, error) {
+	var wms []WriteMarker
+	result := edb.Store.Get().
+		Model(&WriteMarker{}).
+		Where(&WriteMarker{AllocationID: allocationID, Name: filename}).
+		Find(&wms)
+	return wms, result.Error
 }
 
 func (edb *EventDb) overwriteWriteMarker(wm WriteMarker) error {

--- a/code/go/0chain.net/smartcontract/dbs/event/writemarker_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/writemarker_test.go
@@ -99,8 +99,8 @@ func TestWriteMarker(t *testing.T) {
 
 	wms, err := eventDb.GetWriteMarkersForAllocationID(eWriteMarker.AllocationID)
 	require.NoError(t, err)
-	require.EqualValues(t, 1, len(*wms))
-	require.EqualValues(t, eWriteMarker.BlockNumber, (*wms)[0].BlockNumber)
+	require.EqualValues(t, 1, len(wms))
+	require.EqualValues(t, eWriteMarker.BlockNumber, (wms)[0].BlockNumber)
 }
 
 func TestGetWriteMarkers(t *testing.T) {
@@ -169,6 +169,21 @@ func TestGetWriteMarkers(t *testing.T) {
 		assert.NoError(t, err)
 		compareWriteMarker(t, gotWM, "someHash", 5, 5, true)
 	})
+	t.Run("GetWriteMarkersForAllocationID", func(t *testing.T) {
+		gotWM, err := eventDb.GetWriteMarkersForAllocationID("allocation_id")
+		assert.NoError(t, err)
+		compareWriteMarker(t, gotWM, "someHash", 5, 5, true)
+	})
+	t.Run("GetWriteMarkersForAllocationFile", func(t *testing.T) {
+		gotWM, err := eventDb.GetWriteMarkersForAllocationFile("allocation_id", "name_txt")
+		assert.NoError(t, err)
+		compareWriteMarker(t, gotWM, "someHash", 5, 5, true)
+	})
+	t.Run("GetWriteMarkers 5 offset 5 limit descending", func(t *testing.T) {
+		gotWM, err := eventDb.GetWriteMarkers(5, 5, true)
+		assert.NoError(t, err)
+		compareWriteMarker(t, gotWM, "someHash", 5, 5, true)
+	})
 	t.Run("WriteMarkers size total", func(t *testing.T) {
 		gotWM, err := eventDb.GetAllocationWrittenSizeInLastNBlocks(5, "")
 		assert.NoError(t, err)
@@ -188,7 +203,7 @@ func addWriterMarkers(t *testing.T, eventDb *EventDb, blobberID string) {
 		if !assert.NoError(t, err, "Error while writing blobber marker") {
 			return
 		}
-		err = eventDb.addOrOverwriteWriteMarker(WriteMarker{TransactionID: transactionID, BlobberID: blobberID, BlockNumber: int64(i), Size: int64(i), AllocationID: "allocation_id"})
+		err = eventDb.addOrOverwriteWriteMarker(WriteMarker{TransactionID: transactionID, BlobberID: blobberID, BlockNumber: int64(i), Size: int64(i), AllocationID: "allocation_id", Name: "name.txt"})
 		if !assert.NoError(t, err, "Error while writing read marker") {
 			return
 		}

--- a/code/go/0chain.net/smartcontract/dbs/event/writemarker_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/writemarker_test.go
@@ -179,11 +179,6 @@ func TestGetWriteMarkers(t *testing.T) {
 		assert.NoError(t, err)
 		compareWriteMarker(t, gotWM, "someHash", 5, 5, true)
 	})
-	t.Run("GetWriteMarkers 5 offset 5 limit descending", func(t *testing.T) {
-		gotWM, err := eventDb.GetWriteMarkers(5, 5, true)
-		assert.NoError(t, err)
-		compareWriteMarker(t, gotWM, "someHash", 5, 5, true)
-	})
 	t.Run("WriteMarkers size total", func(t *testing.T) {
 		gotWM, err := eventDb.GetAllocationWrittenSizeInLastNBlocks(5, "")
 		assert.NoError(t, err)

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -650,13 +650,23 @@ func (ssc *StorageSmartContract) GetWriteMarkersHandler(ctx context.Context,
 		return nil, common.NewErrNoResource("db not initialized")
 	}
 
-	writeMarkers, err := balances.GetEventDB().GetWriteMarkersForAllocationID(allocationID)
-	if err != nil {
-		return nil, common.NewErrInternal("can't get write markers", err.Error())
+	filename := params.Get("filename")
+
+	if filename == "" {
+		writeMarkers, err := balances.GetEventDB().GetWriteMarkersForAllocationID(allocationID)
+		if err != nil {
+			return nil, common.NewErrInternal("can't get write markers", err.Error())
+		}
+
+		return writeMarkers, nil
+	} else {
+		writeMarkers, err := balances.GetEventDB().GetWriteMarkersForAllocationFile(allocationID, filename)
+		if err != nil {
+			return nil, common.NewErrInternal("can't get write markers for file", err.Error())
+		}
+
+		return writeMarkers, nil
 	}
-
-	return writeMarkers, nil
-
 }
 
 func (ssc *StorageSmartContract) GetWrittenAmountHandler(


### PR DESCRIPTION
## Changes

Update /getWriteMarkers endpoint to support filter by an optional `filename` param
- This will be on top of required `allocation_id` param

## Fixes
Fixes https://github.com/0chain/0chain/issues/900

## Tests 
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
