### PR TITLE
Order events example

### DIFF
--- a/code/go/0chain.net/chaincore/block/entity.go
+++ b/code/go/0chain.net/chaincore/block/entity.go
@@ -150,7 +150,7 @@ type Block struct {
 	ChainID   datastore.Key `json:"chain_id"`
 	RoundRank int           `json:"-" msgpack:"-"` // rank of the block in the round it belongs to
 	PrevBlock *Block        `json:"-" msgpack:"-"`
-	Events    []event.Event
+	Events    event.EventList
 
 	TxnsMap   map[string]bool `json:"-" msgpack:"-"`
 	mutexTxns sync.RWMutex    `json:"-" msgpack:"-"`
@@ -784,7 +784,7 @@ type Chainer interface {
 	GetBlockStateChange(b *Block) error
 	ComputeState(ctx context.Context, pb *Block) error
 	GetStateDB() util.NodeDB
-	UpdateState(ctx context.Context, b *Block, bState util.MerklePatriciaTrieI, txn *transaction.Transaction) ([]event.Event, error)
+	UpdateState(ctx context.Context, b *Block, bState util.MerklePatriciaTrieI, txn *transaction.Transaction) (event.EventList, error)
 	GetEventDb() *event.EventDb
 }
 
@@ -891,7 +891,7 @@ func (b *Block) ComputeState(ctx context.Context, c Chainer) error {
 	bState := CreateStateWithPreviousBlock(pb, c.GetStateDB(), b.Round)
 
 	beginStateRoot := bState.GetRoot()
-	b.Events = []event.Event{}
+	b.Events = event.EventList{}
 	for _, txn := range b.Txns {
 		if datastore.IsEmpty(txn.ClientID) {
 			if err := txn.ComputeClientID(); err != nil {
@@ -1004,7 +1004,7 @@ func (b *Block) ComputeStateLocal(ctx context.Context, c Chainer) error {
 	bState := CreateStateWithPreviousBlock(b.PrevBlock, c.GetStateDB(), b.Round)
 
 	beginState := b.ClientState.GetRoot()
-	b.Events = []event.Event{}
+	b.Events = event.EventList{}
 	for _, txn := range b.Txns {
 		if datastore.IsEmpty(txn.ClientID) {
 			if err := txn.ComputeClientID(); err != nil {

--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -143,7 +143,7 @@ func (c *Chain) ExecuteSmartContract(
 // processed into a block, the state gets updated. If a state can't be updated
 // (e.g low balance), then a false is returned so that the transaction will not
 // make it into the block.
-func (c *Chain) UpdateState(ctx context.Context, b *block.Block, bState util.MerklePatriciaTrieI, txn *transaction.Transaction) ([]event.Event, error) {
+func (c *Chain) UpdateState(ctx context.Context, b *block.Block, bState util.MerklePatriciaTrieI, txn *transaction.Transaction) (event.EventList, error) {
 	c.stateMutex.Lock()
 	defer c.stateMutex.Unlock()
 	return c.updateState(ctx, b, bState, txn)
@@ -195,7 +195,7 @@ func (c *Chain) NewStateContext(
 	)
 }
 
-func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.MerklePatriciaTrieI, txn *transaction.Transaction) (events []event.Event, err error) {
+func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.MerklePatriciaTrieI, txn *transaction.Transaction) (events event.EventList, err error) {
 	// check if the block's ClientState has root value
 	_, err = bState.GetNodeDB().GetNode(bState.GetRoot())
 	if err != nil {

--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -78,7 +78,7 @@ type StateContextI interface {
 	GetLatestFinalizedBlock() *block.Block
 	EmitEvent(event.EventType, event.EventTag, string, string)
 	EmitError(error)
-	GetEvents() []event.Event   // cannot use in smart contracts or REST endpoints
+	GetEvents() event.EventList // cannot use in smart contracts or REST endpoints
 	GetEventDB() *event.EventDb // do not use in smart contracts can use in REST endpoints
 }
 
@@ -90,7 +90,7 @@ type StateContext struct {
 	transfers                     []*state.Transfer
 	signedTransfers               []*state.SignedTransfer
 	mints                         []*state.Mint
-	events                        []event.Event
+	events                        event.EventList
 	getSharders                   func(*block.Block) []string
 	getLastestFinalizedMagicBlock func() *block.Block
 	getLatestFinalizedBlock       func() *block.Block
@@ -202,7 +202,7 @@ func (sc *StateContext) GetMints() []*state.Mint {
 func (sc *StateContext) EmitEvent(eventType event.EventType, tag event.EventTag, index string, data string) {
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()
-	sc.events = append(sc.events, event.Event{
+	sc.events.AddEvent(event.Event{
 		BlockNumber: sc.block.Round,
 		TxHash:      sc.txn.Hash,
 		Type:        int(eventType),
@@ -213,7 +213,7 @@ func (sc *StateContext) EmitEvent(eventType event.EventType, tag event.EventTag,
 }
 
 func (sc *StateContext) EmitError(err error) {
-	sc.events = []event.Event{
+	sc.events = event.EventList{
 		{
 			BlockNumber: sc.block.Round,
 			TxHash:      sc.txn.Hash,
@@ -223,7 +223,7 @@ func (sc *StateContext) EmitError(err error) {
 	}
 }
 
-func (sc *StateContext) GetEvents() []event.Event {
+func (sc *StateContext) GetEvents() event.EventList {
 	return sc.events
 }
 

--- a/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"0chain.net/core/common"
 	"time"
 
 	"0chain.net/smartcontract/dbs"
@@ -15,11 +16,12 @@ func NewEventDb(config dbs.DbAccess) (*EventDb, error) {
 		return nil, err
 	}
 	eventDb := &EventDb{
-		Store:         db,
-		eventsChannel: make(chan EventList, 1000000),
+		Store:          db,
+		eventsChannel:  make(chan EventList, 1000000),
+		processChannel: make(chan EventList, 5),
 	}
-	go eventDb.addEventsWorker()
-	go eventDb.processRoundWorker()
+	go eventDb.addEventsWorker(common.GetRootContext())
+	go eventDb.processRoundWorker(common.GetRootContext())
 
 	if err := eventDb.AutoMigrate(); err != nil {
 		return nil, err

--- a/code/go/0chain.net/smartcontract/dbs/event/eventlist.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/eventlist.go
@@ -19,10 +19,6 @@ func (el *EventList) AddEvent(event Event) {
 	*el = append(*el, event)
 }
 
-func compareHash(eventMap map[string]bool) {
-
-}
-
 func (el *EventList) GetHash() []byte {
 	var data []byte
 	sort.Slice(el, func(i, j int) bool {

--- a/code/go/0chain.net/smartcontract/dbs/event/eventlist.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/eventlist.go
@@ -20,12 +20,15 @@ func (el *EventList) AddEvent(event Event) {
 }
 
 func (el *EventList) GetHash() []byte {
-	var data []byte
-	sort.Slice(el, func(i, j int) bool {
-		return (*el)[i].Hash < (*el)[j].Hash
-	})
+	var hashes []string
 	for _, event := range *el {
-		data = append(data, []byte(event.Hash)...)
+		hashes = append(hashes, event.Hash)
+	}
+	sort.Strings(hashes)
+
+	var data []byte
+	for _, hash := range hashes {
+		data = append(data, []byte(hash)...)
 	}
 	return encryption.RawHash(data)
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/eventlist.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/eventlist.go
@@ -1,0 +1,35 @@
+package event
+
+import (
+	"0chain.net/core/encryption"
+	"sort"
+)
+
+type RoundEnd struct {
+	EventCount int    `json:"round"`
+	Hash       []byte `json:"hash"`
+}
+
+type EventList []Event
+
+func (el *EventList) AddEvent(event Event) {
+	if len(event.Hash) == 0 {
+		event.GetHashBytes()
+	}
+	*el = append(*el, event)
+}
+
+func compareHash(eventMap map[string]bool) {
+
+}
+
+func (el *EventList) GetHash() []byte {
+	var data []byte
+	sort.Slice(el, func(i, j int) bool {
+		return (*el)[i].Hash < (*el)[j].Hash
+	})
+	for _, event := range *el {
+		data = append(data, []byte(event.Hash)...)
+	}
+	return encryption.RawHash(data)
+}

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -70,7 +70,6 @@ func (edb *EventDb) addEventsWorker(ctx context.Context) {
 	)
 
 	for {
-
 		events := append(events, <-edb.eventsChannel...)
 		for _, event := range events {
 			if err := edb.addEvent(event); err != nil {
@@ -121,7 +120,6 @@ func (edb *EventDb) addEventsWorker(ctx context.Context) {
 				)
 				events = EventList{}
 			}
-
 		}
 	}
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -60,7 +60,7 @@ func (edb *EventDb) AddEvents(ctx context.Context, events []Event) {
 	edb.eventsChannel <- events
 }
 
-func (edb *EventDb) addEventsWorker() {
+func (edb *EventDb) addEventsWorker(ctx context.Context) {
 	var (
 		currentRound  int64 = 1
 		roundEventMap map[string]bool
@@ -114,7 +114,7 @@ func (edb *EventDb) addEventsWorker() {
 	}
 }
 
-func (edb *EventDb) processRoundWorker() {
+func (edb *EventDb) processRoundWorker(ctx context.Context) {
 	for {
 		events := <-edb.processChannel
 		for _, event := range events {

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -320,6 +320,8 @@ func (edb *EventDb) addStat(event Event) error {
 			return err
 		}
 		return edb.updateChallenge(updates)
+	case TagEndBlock:
+		return nil
 	default:
 		return fmt.Errorf("unrecognised event %v", event)
 	}

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -92,17 +92,17 @@ func (edb *EventDb) addEventsWorker(ctx context.Context) {
 				continue
 			}
 
-			var roundEnd RoundEnd
-			if err := json.Unmarshal([]byte(event.Data), &roundEnd); err != nil {
+			var roundEndEvent RoundEnd
+			if err := json.Unmarshal([]byte(event.Data), &roundEndEvent); err != nil {
 				logging.Logger.Error("unmarshal end round", zap.Error(err))
 				switchedOff = true
 				continue
 			}
-			if len(roundEventMap) != roundEnd.EventCount {
+			if len(roundEvents) != roundEndEvent.EventCount {
 				switchedOff = true
 				continue
 			}
-			if string(roundEnd.Hash) != string(roundEvents.GetHash()) {
+			if string(roundEndEvent.Hash) != string(roundEvents.GetHash()) {
 				switchedOff = true
 				continue
 			}

--- a/code/go/0chain.net/smartcontract/dbs/event/process_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process_test.go
@@ -9,6 +9,10 @@ import (
 	"0chain.net/smartcontract/dbs"
 )
 
+func TestAddEventsWorker(t *testing.T) {
+
+}
+
 func TestAddEvents(t *testing.T) {
 	access := dbs.DbAccess{
 		Enabled:         true,

--- a/code/go/0chain.net/smartcontract/interestpoolsc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/balances_test.go
@@ -70,7 +70,7 @@ func (tb *testBalances) GetLastestFinalizedMagicBlock() *block.Block {
 }
 func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, string) {}
 func (tb *testBalances) EmitError(error)                                           {}
-func (tb *testBalances) GetEvents() []event.Event                                  { return nil }
+func (tb *testBalances) GetEvents() event.EventList                                { return nil }
 func (tb *testBalances) GetSignatureScheme() encryption.SignatureScheme {
 	return encryption.NewBLS0ChainScheme()
 }

--- a/code/go/0chain.net/smartcontract/interestpoolsc/sc2_test.go
+++ b/code/go/0chain.net/smartcontract/interestpoolsc/sc2_test.go
@@ -374,7 +374,7 @@ func (sc *mockStateContext) DeleteTrieNode(_ datastore.Key) (datastore.Key, erro
 func (sc *mockStateContext) GetChainCurrentMagicBlock() *block.MagicBlock              { return nil }
 func (sc *mockStateContext) EmitEvent(event.EventType, event.EventTag, string, string) {}
 func (sc *mockStateContext) EmitError(error)                                           {}
-func (sc *mockStateContext) GetEvents() []event.Event                                  { return nil }
+func (sc *mockStateContext) GetEvents() event.EventList                                { return nil }
 func (sc *mockStateContext) GetEventDB() *event.EventDb                                { return nil }
 func (sc *mockStateContext) GetClientBalance(_ datastore.Key) (state.Balance, error) {
 	if sc.clientStartBalance == 0 {

--- a/code/go/0chain.net/smartcontract/minersc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/minersc/balances_test.go
@@ -77,7 +77,7 @@ func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer)             
 func (tb *testBalances) GetEventDB() *event.EventDb                                { return nil }
 func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, string) {}
 func (tb *testBalances) EmitError(error)                                           {}
-func (tb *testBalances) GetEvents() []event.Event                                  { return nil }
+func (tb *testBalances) GetEvents() event.EventList                                { return nil }
 func (tb *testBalances) GetLatestFinalizedBlock() *block.Block                     { return nil }
 func (tb *testBalances) GetSignedTransfers() []*state.SignedTransfer {
 	return nil

--- a/code/go/0chain.net/smartcontract/minersc/handler.go
+++ b/code/go/0chain.net/smartcontract/minersc/handler.go
@@ -443,7 +443,7 @@ func (msc *MinerSmartContract) GetEventsHandler(
 	}
 
 	return struct {
-		Events []event.Event `json:"events"`
+		Events event.EventList `json:"events"`
 	}{
 		Events: events,
 	}, nil

--- a/code/go/0chain.net/smartcontract/minersc/helper2_test.go
+++ b/code/go/0chain.net/smartcontract/minersc/helper2_test.go
@@ -23,7 +23,7 @@ type mockStateContext struct {
 	block                      *block.Block
 	store                      map[datastore.Key]util.MPTSerializable
 	sharders                   []string
-	events                     []event.Event
+	events                     event.EventList
 	LastestFinalizedMagicBlock *block.Block
 }
 
@@ -46,10 +46,10 @@ func (sc *mockStateContext) EmitEvent(eventType event.EventType, tag event.Event
 		Data:        data,
 	})
 }
-func (sc *mockStateContext) EmitError(error)            {}
-func (sc *mockStateContext) GetEvents() []event.Event   { return nil }
-func (sc *mockStateContext) GetEventDB() *event.EventDb { return nil }
-func (sc *mockStateContext) GetLatestFinalizedBlock() *block.Block                     { return nil }
+func (sc *mockStateContext) EmitError(error)                       {}
+func (sc *mockStateContext) GetEvents() event.EventList            { return nil }
+func (sc *mockStateContext) GetEventDB() *event.EventDb            { return nil }
+func (sc *mockStateContext) GetLatestFinalizedBlock() *block.Block { return nil }
 func (sc *mockStateContext) GetTransfers() []*state.Transfer {
 	return sc.ctx.GetTransfers()
 }

--- a/code/go/0chain.net/smartcontract/storagesc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/balances_test.go
@@ -77,7 +77,7 @@ func (tb *testBalances) GetSignedTransfers() []*state.SignedTransfer            
 func (tb *testBalances) GetEventDB() *event.EventDb                                { return nil }
 func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, string) {}
 func (tb *testBalances) EmitError(error)                                           {}
-func (tb *testBalances) GetEvents() []event.Event                                  { return nil }
+func (tb *testBalances) GetEvents() event.EventList                                { return nil }
 func (tb *testBalances) GetChainCurrentMagicBlock() *block.MagicBlock              { return nil }
 func (tb *testBalances) GetLatestFinalizedBlock() *block.Block                     { return nil }
 func (tb *testBalances) DeleteTrieNode(key datastore.Key) (

--- a/code/go/0chain.net/smartcontract/storagesc/helper2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/helper2_test.go
@@ -52,7 +52,7 @@ func (sc *mockStateContext) GetSignatureScheme() encryption.SignatureScheme {
 
 func (tb *mockStateContext) EmitEvent(event.EventType, event.EventTag, string, string) {}
 func (sc *mockStateContext) EmitError(error)                                           {}
-func (sc *mockStateContext) GetEvents() []event.Event                                  { return nil }
+func (sc *mockStateContext) GetEvents() event.EventList                                { return nil }
 func (tb *mockStateContext) GetEventDB() *event.EventDb                                { return nil }
 func (sc *mockStateContext) AddSignedTransfer(_ *state.SignedTransfer)                 {}
 func (sc *mockStateContext) DeleteTrieNode(_ datastore.Key) (datastore.Key, error)     { return "", nil }

--- a/code/go/0chain.net/smartcontract/vestingsc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/balances_test.go
@@ -48,7 +48,7 @@ func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer)             
 func (tb *testBalances) GetEventDB() *event.EventDb                                { return nil }
 func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, string) {}
 func (tb *testBalances) EmitError(error)                                           {}
-func (tb *testBalances) GetEvents() []event.Event                                  { return nil }
+func (tb *testBalances) GetEvents() event.EventList                                { return nil }
 func (tb *testBalances) GetLatestFinalizedBlock() *block.Block                     { return nil }
 func (tb *testBalances) SetMagicBlock(block *block.MagicBlock)                     {}
 func (tb *testBalances) GetLastestFinalizedMagicBlock() *block.Block {


### PR DESCRIPTION
## Fixes
Change so events are processed in order. 
A block end event is added, and events for the current round are not processed until the round end event has been received.
The events for a round are not processed until they are all gathered together after receiving a round end event, and the hash value checked.
## Changes
## Todos
This is a bit roungh at the moment. For example we should order events inside a block properly. For this we should probably move the index from [generateBlock](https://github.com/0chain/0chain/blob/staging/code/go/0chain.net/miner/protocol_block.go#L927) into the transaction object so it can be used to index events.
```go
	for i := 0; i < len(iterInfo.currentTxns) && iterInfo.cost < mc.Config.MaxBlockCost() &&
		blockSize < mc.BlockSize() && iterInfo.byteSize < mc.MaxByteSize() && err != context.DeadlineExceeded; i++ {

```

When something goes wrong I just stopped the event database. However the events should be in the event table so we s should be able to recover with a bit more coding.

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
