### PR TITLE
Fix sharder/miner/validator rewards bug in eventsDB

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/stakepool.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/stakepool.go
@@ -9,7 +9,7 @@ import (
 )
 
 type providerAggregateStats struct {
-	Reward      int64 `json:"reward"`
+	Rewards     int64 `json:"rewards"`
 	TotalReward int64 `json:"total_reward"`
 }
 
@@ -59,24 +59,24 @@ func (edb *EventDb) rewardProvider(spu dbs.StakePoolReward) error {
 		if err != nil {
 			return err
 		}
-		update.Updates["reward"] = validator.Reward + spu.Reward
-		update.Updates["total_service_charge"] = validator.TotalReward + spu.Reward
+		update.Updates["rewards"] = validator.Rewards + spu.Reward
+		update.Updates["total_reward"] = validator.TotalReward + spu.Reward
 		return edb.updateValidator(*update)
 	case spenum.Miner:
 		miner, err := edb.minerAggregateStats(spu.ProviderId)
 		if err != nil {
 			return err
 		}
-		update.Updates["reward"] = miner.Reward + spu.Reward
-		update.Updates["total_service_charge"] = miner.TotalReward + spu.Reward
+		update.Updates["rewards"] = miner.Rewards + spu.Reward
+		update.Updates["total_reward"] = miner.TotalReward + spu.Reward
 		return edb.updateMiner(*update)
 	case spenum.Sharder:
 		sharder, err := edb.sharderAggregateStats(spu.ProviderId)
 		if err != nil {
 			return err
 		}
-		update.Updates["reward"] = sharder.Reward + spu.Reward
-		update.Updates["total_service_charge"] = sharder.TotalReward + spu.Reward
+		update.Updates["rewards"] = sharder.Rewards + spu.Reward
+		update.Updates["total_reward"] = sharder.TotalReward + spu.Reward
 		return edb.updateSharder(*update)
 	default:
 		return fmt.Errorf("not implented provider type %v", spu.ProviderType)

--- a/code/go/0chain.net/smartcontract/dbs/event/validator.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/validator.go
@@ -24,7 +24,7 @@ type Validator struct {
 	NumDelegates   int           `json:"num_delegates"`
 	ServiceCharge  float64       `json:"service_charge"`
 
-	Reward      int64 `json:"reward"`
+	Rewards     int64 `json:"rewards"`
 	TotalReward int64 `json:"total_reward"`
 }
 

--- a/docker.local/config/0chain.yaml
+++ b/docker.local/config/0chain.yaml
@@ -2,7 +2,7 @@ version: 1.0
 
 logging:
   level: "debug"
-  console: true # printing log to console is only supported in development mode
+  console: false # printing log to console is only supported in development mode
   goroutines: false
   memlog: false
 


### PR DESCRIPTION
## Fixes
In eventsDB for sharder/miner/validator:
- Mismatching name `rewards` and `reward` for the same field
- Reference to non-existing field `total_service_charge`

Ref:
https://0chain.slack.com/archives/C03788G8N2D/p1652975157823899