### PR TITLE
Change default CCT time from 30m to 3m

### DIFF
--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -160,7 +160,7 @@ jobs:
           echo "RUNNER_NUMBER=${RUNNER_NAME:(-1)}" >> $GITHUB_ENV
 
       - name: "Deploy 0Chain"
-        uses: 0chain/actions/deploy-0chain@master
+        uses: 0chain/actions/deploy-0chain@feat/reduce-mcct
         with:
           kube_config: ${{ secrets[format('DEV{0}KC', env.RUNNER_NUMBER)] }}
           teardown_condition: "TESTS_PASSED"
@@ -180,7 +180,7 @@ jobs:
           custom_go_sdk_version: staging
 
       - name: "Run System tests"
-        uses: 0chain/actions/run-system-tests@master
+        uses: 0chain/actions/run-system-tests@feat/reduce-mcct
         with:
           system_tests_branch: master
           network: ${{ env.NETWORK_URL }}

--- a/.github/workflows/build-&-publish-docker-image.yml
+++ b/.github/workflows/build-&-publish-docker-image.yml
@@ -160,7 +160,7 @@ jobs:
           echo "RUNNER_NUMBER=${RUNNER_NAME:(-1)}" >> $GITHUB_ENV
 
       - name: "Deploy 0Chain"
-        uses: 0chain/actions/deploy-0chain@feat/reduce-mcct
+        uses: 0chain/actions/deploy-0chain@master
         with:
           kube_config: ${{ secrets[format('DEV{0}KC', env.RUNNER_NUMBER)] }}
           teardown_condition: "TESTS_PASSED"
@@ -180,7 +180,7 @@ jobs:
           custom_go_sdk_version: staging
 
       - name: "Run System tests"
-        uses: 0chain/actions/run-system-tests@feat/reduce-mcct
+        uses: 0chain/actions/run-system-tests@master
         with:
           system_tests_branch: master
           network: ${{ env.NETWORK_URL }}

--- a/code/go/0chain.net/chaincore/config/config.go
+++ b/code/go/0chain.net/chaincore/config/config.go
@@ -105,7 +105,7 @@ func SetupDefaultSmartContractConfig() {
 
 	SmartContractConfig.SetDefault("smart_contracts.storagesc.challenge_enabled", true)
 	SmartContractConfig.SetDefault("smart_contracts.storagesc.challenge_rate_per_mb_min", 1)
-	SmartContractConfig.SetDefault("smart_contracts.storagesc.max_challenge_completion_time", "30m")
+	SmartContractConfig.SetDefault("smart_contracts.storagesc.max_challenge_completion_time", "3m")
 }
 
 // SetupSmartContractConfig setups the smart contracts configuration system.

--- a/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
+++ b/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
@@ -81,7 +81,7 @@ smart_contracts:
     min_alloc_duration: 1y
     max_read_price: 100.0
     max_write_price: 100.0
-    max_challenge_completion_time: 30m
+    max_challenge_completion_time: 3m
     min_offer_duration: 10h
     min_blobber_capacity: 1024
     max_charge: 0.2
@@ -116,7 +116,7 @@ smart_contracts:
       write_price_range:
         min: 0.0
         max: 0.1
-      max_challenge_completion_time: 30m
+      max_challenge_completion_time: 3m
       read_pool_fraction: 0.2
     max_mint: 1500000.0
     challenge_enabled: true

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
@@ -1,16 +1,17 @@
 package storagesc
 
 import (
-	"0chain.net/chaincore/state"
-	sc "0chain.net/smartcontract"
-	"0chain.net/smartcontract/stakepool"
-	"0chain.net/smartcontract/stakepool/spenum"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log"
 	"testing"
 	"time"
+
+	"0chain.net/chaincore/state"
+	sc "0chain.net/smartcontract"
+	"0chain.net/smartcontract/stakepool"
+	"0chain.net/smartcontract/stakepool/spenum"
 
 	"0chain.net/chaincore/smartcontract"
 
@@ -678,7 +679,7 @@ func BenchmarkTests(
 					"time_unit":                     "720h",
 					"min_alloc_size":                "1024",
 					"min_alloc_duration":            "5m",
-					"max_challenge_completion_time": "30m",
+					"max_challenge_completion_time": "3m",
 					"min_offer_duration":            "10h",
 					"min_blobber_capacity":          "1024",
 

--- a/code/go/0chain.net/smartcontract/storagesc/config_settings_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config_settings_test.go
@@ -126,7 +126,7 @@ func TestUpdateSettings(t *testing.T) {
 					"time_unit":                     "720h",
 					"min_alloc_size":                "1024",
 					"min_alloc_duration":            "5m",
-					"max_challenge_completion_time": "30m",
+					"max_challenge_completion_time": "3m",
 					"min_offer_duration":            "10h",
 					"min_blobber_capacity":          "1024",
 
@@ -330,7 +330,7 @@ func TestCommitSettingChanges(t *testing.T) {
 					"time_unit":                     "720h",
 					"min_alloc_size":                "1024",
 					"min_alloc_duration":            "5m",
-					"max_challenge_completion_time": "30m",
+					"max_challenge_completion_time": "3m",
 					"min_offer_duration":            "10h",
 					"min_blobber_capacity":          "1024",
 

--- a/docker.local/config/sc.yaml
+++ b/docker.local/config/sc.yaml
@@ -105,7 +105,7 @@ smart_contracts:
     # min possible allocation duration allowed by the SC
     min_alloc_duration: "5m"
     # max challenge completion time of a blobber allowed by the SC
-    max_challenge_completion_time: "30m"
+    max_challenge_completion_time: "3m"
     # min blobber's offer duration allowed by the SC
     min_offer_duration: "10h"
     # min blobber capacity allowed by the SC
@@ -162,7 +162,7 @@ smart_contracts:
     max_read_price: 100.0
     max_write_price: 100.0
     # min_write_price: 0.1
-    
+
     max_blobbers_per_allocation: 40
     # allocation cancellation
     #

--- a/quickstart/1s_2m_4b/config/1s_2m_4b/0Chain/docker.local/config/sc.yaml
+++ b/quickstart/1s_2m_4b/config/1s_2m_4b/0Chain/docker.local/config/sc.yaml
@@ -9,7 +9,7 @@ smart_contracts:
     global_reset: 48h # in hours
   interestpoolsc:
     owner_id: 1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802
-    min_lock: 10 
+    min_lock: 10
     apr: 0.1
     min_lock_period: 1m
     max_mint: 4000000.0
@@ -54,7 +54,7 @@ smart_contracts:
     interest_decline_rate: 0.1 # [0; 1), 0.1 = 10%
     # no mints after miner SC total mints reaches this boundary
     max_mint: 4000000.0 # tokens
-    # if view change is false then reward round frequency is used to send rewards and interests 
+    # if view change is false then reward round frequency is used to send rewards and interests
     reward_round_frequency: 250
 
   storagesc:
@@ -72,7 +72,7 @@ smart_contracts:
     # min possible allocation duration allowed by the SC
     min_alloc_duration: '5m'
     # max challenge completion time of a blobber allowed by the SC
-    max_challenge_completion_time: '30m'
+    max_challenge_completion_time: '3m'
     # min blobber's offer duration allowed by the SC
     min_offer_duration: '10h'
     # min blobber capacity allowed by the SC

--- a/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/config/sc.yaml
+++ b/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/config/sc.yaml
@@ -9,7 +9,7 @@ smart_contracts:
     global_reset: 48h # in hours
   interestpoolsc:
     owner_id: 1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802
-    min_lock: 10 
+    min_lock: 10
     apr: 0.1
     min_lock_period: 1m
     max_mint: 4000000.0
@@ -54,7 +54,7 @@ smart_contracts:
     interest_decline_rate: 0.1 # [0; 1), 0.1 = 10%
     # no mints after miner SC total mints reaches this boundary
     max_mint: 4000000.0 # tokens
-    # if view change is false then reward round frequency is used to send rewards and interests 
+    # if view change is false then reward round frequency is used to send rewards and interests
     reward_round_frequency: 250
 
   storagesc:
@@ -72,7 +72,7 @@ smart_contracts:
     # min possible allocation duration allowed by the SC
     min_alloc_duration: '5m'
     # max challenge completion time of a blobber allowed by the SC
-    max_challenge_completion_time: '30m'
+    max_challenge_completion_time: '3m'
     # min blobber's offer duration allowed by the SC
     min_offer_duration: '10h'
     # min blobber capacity allowed by the SC


### PR DESCRIPTION
## Fixes

- The default 30m for max challanege completion time was incorrect and will cause OOM before we fix the blobber/validator challenge completion issue.


## Need to be mentioned in CHANGELOG.md?
No

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
No
