### PR TITLE
Full node sharders

### DIFF
--- a/code/go/0chain.net/chaincore/chain/block_fetcher.go
+++ b/code/go/0chain.net/chaincore/chain/block_fetcher.go
@@ -189,12 +189,6 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 				continue
 			}
 
-			//if bfr.hash != "" {
-			//	fetching[bfr.hash] = bfr // add, increasing map length
-			//} else {
-			//	fetching[strconv.FormatInt(bfr.round, 10)] = bfr
-			//}
-
 			// if force from sharders
 			if bfr.sharders {
 				if bf.acquire(ctx, shardersl) {

--- a/code/go/0chain.net/chaincore/chain/block_fetcher.go
+++ b/code/go/0chain.net/chaincore/chain/block_fetcher.go
@@ -230,7 +230,9 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 			if !ok {
 				bfr, ok = fetching[strconv.FormatInt(rpl.Round, 10)]
 				if !ok {
-					panic("BlockFetcher, invalid state: missing block fetch request")
+					// a fetch request with round number could be removed by the request with block hash
+					continue
+					//panic("BlockFetcher, invalid state: missing block fetch request")
 				}
 			}
 

--- a/code/go/0chain.net/chaincore/chain/block_fetcher.go
+++ b/code/go/0chain.net/chaincore/chain/block_fetcher.go
@@ -403,13 +403,14 @@ func (c *Chain) getFinalizedBlockFromSharders(ctx context.Context,
 			select {
 			case fb = <-blockC:
 				return validateBlock(fb)
-			default:
-				// or continue to request from all other sharders
+			case <-lctx.Done():
 			}
 		}
 	}
 
 	doneC := make(chan struct{})
+	lctx, cancel = context.WithTimeout(ctx, node.TimeoutLargeMessage)
+	defer cancel()
 	go func() {
 		sharders.RequestEntityFromAll(lctx, FBRequestor, &params, handler)
 		close(doneC)

--- a/code/go/0chain.net/chaincore/chain/block_fetcher.go
+++ b/code/go/0chain.net/chaincore/chain/block_fetcher.go
@@ -732,6 +732,7 @@ func (c *Chain) GetNotarizedBlockFromSharders(ctx context.Context, hash string, 
 
 	select {
 	case <-ctx.Done():
+		logging.Logger.Error("fetch block context err", zap.Error(ctx.Err()))
 		return nil, ctx.Err()
 	case rpl = <-reply:
 	}
@@ -739,6 +740,7 @@ func (c *Chain) GetNotarizedBlockFromSharders(ctx context.Context, hash string, 
 	switch rpl.Err {
 	case nil:
 	case context.Canceled:
+		logging.Logger.Error("fetch block context cancelled")
 		return nil, context.Canceled
 	default:
 		return nil, rpl.Err

--- a/code/go/0chain.net/chaincore/chain/block_fetcher.go
+++ b/code/go/0chain.net/chaincore/chain/block_fetcher.go
@@ -181,16 +181,21 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 				continue
 			}
 
-			if bfr.hash != "" {
-				fetching[bfr.hash] = bfr // add, increasing map length
-			} else {
-				fetching[strconv.FormatInt(bfr.round, 10)] = bfr
-			}
+			//if bfr.hash != "" {
+			//	fetching[bfr.hash] = bfr // add, increasing map length
+			//} else {
+			//	fetching[strconv.FormatInt(bfr.round, 10)] = bfr
+			//}
 
 			// if force from sharders
 			if bfr.sharders {
 				if bf.acquire(ctx, shardersl) {
 					//fetching[bfr.hash] = bfr
+					if bfr.hash != "" {
+						fetching[bfr.hash] = bfr // add, increasing map length
+					} else {
+						fetching[strconv.FormatInt(bfr.round, 10)] = bfr
+					}
 					go bf.fetchFromSharders(ctx, bfr, got, chainer, shardersl)
 				} else {
 					go bf.terminate(ctx, bfr, ErrBlockFetchShardersQueueFull)
@@ -201,6 +206,11 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 			// fetch from miners first
 			if bf.acquire(ctx, minersl) {
 				//fetching[bfr.hash] = bfr
+				if bfr.hash != "" {
+					fetching[bfr.hash] = bfr // add, increasing map length
+				} else {
+					fetching[strconv.FormatInt(bfr.round, 10)] = bfr
+				}
 				go bf.fetchFromMiners(ctx, bfr, got, chainer, minersl)
 			} else {
 				// don't try to fetch from sharder on miners full queue

--- a/code/go/0chain.net/chaincore/chain/block_fetcher.go
+++ b/code/go/0chain.net/chaincore/chain/block_fetcher.go
@@ -242,13 +242,12 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 
 			// got the correct response
 			if rpl.Block != nil {
+				rd := strconv.FormatInt(rpl.Round, 10)
+				delete(fetching, rd)
 				if rpl.Hash != "" {
 					delete(fetching, rpl.Hash)
-				} else {
-					rd := strconv.FormatInt(rpl.Round, 10)
-					logging.Logger.Debug("remove from fetching", zap.String("round", rd))
-					delete(fetching, rd)
 				}
+
 				go bf.respond(ctx, bfr, rpl.Block)
 				continue
 			}
@@ -257,14 +256,12 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 
 			// already requested from sharders, so, it's the end
 			if bfr.sharders {
+				rd := strconv.FormatInt(rpl.Round, 10)
+				delete(fetching, rd)
 				if rpl.Hash != "" {
 					delete(fetching, rpl.Hash)
-				} else {
-					rd := strconv.FormatInt(rpl.Round, 10)
-					logging.Logger.Debug("remove from fetching", zap.String("round", rd))
-					delete(fetching, rd)
-					//delete(fetching, strconv.FormatInt(rpl.Round, 10))
 				}
+
 				go bf.terminate(ctx, bfr, rpl.Err)
 				continue
 			}
@@ -272,14 +269,12 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 			// if block round > the latest ticket round, then we shouldn't
 			// request it from sharders (it can't be on sharders)
 			if bfr.round > 0 && bfr.round > latest {
+				rd := strconv.FormatInt(rpl.Round, 10)
+				delete(fetching, rd)
 				if rpl.Hash != "" {
 					delete(fetching, rpl.Hash)
-				} else {
-					rd := strconv.FormatInt(rpl.Round, 10)
-					logging.Logger.Debug("remove from fetching", zap.String("round", rd))
-					delete(fetching, rd)
-					//delete(fetching, strconv.FormatInt(rpl.Round, 10))
 				}
+
 				go bf.terminate(ctx, bfr, rpl.Err)
 				continue
 			}

--- a/code/go/0chain.net/chaincore/chain/block_fetcher.go
+++ b/code/go/0chain.net/chaincore/chain/block_fetcher.go
@@ -184,7 +184,6 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 			}
 
 			if len(fetching) >= total {
-				logging.Logger.Error("full block fetcher list:", zap.Any("fetching", fetching))
 				go bf.terminate(ctx, bfr, ErrBlockFetchQueueFull)
 				continue
 			}
@@ -206,7 +205,6 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 
 			// fetch from miners first
 			if bf.acquire(ctx, minersl) {
-				//fetching[bfr.hash] = bfr
 				if bfr.hash != "" {
 					fetching[bfr.hash] = bfr // add, increasing map length
 				} else {
@@ -227,7 +225,6 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 				if !ok {
 					// a fetch request with round number could be removed by the request with block hash
 					continue
-					//panic("BlockFetcher, invalid state: missing block fetch request")
 				}
 			}
 
@@ -742,8 +739,7 @@ func (c *Chain) GetNotarizedBlockFromSharders(ctx context.Context, hash string, 
 
 	var (
 		cround = c.GetCurrentRound()
-
-		rpl BlockFetchReply
+		rpl    BlockFetchReply
 	)
 
 	select {

--- a/code/go/0chain.net/chaincore/chain/block_fetcher.go
+++ b/code/go/0chain.net/chaincore/chain/block_fetcher.go
@@ -192,12 +192,9 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 			// if force from sharders
 			if bfr.sharders {
 				if bf.acquire(ctx, shardersl) {
-					//fetching[bfr.hash] = bfr
 					if bfr.hash != "" {
 						fetching[bfr.hash] = bfr // add, increasing map length
 					} else {
-						rd := strconv.FormatInt(bfr.round, 10)
-						logging.Logger.Debug("fetching block", zap.String("round", rd))
 						fetching[strconv.FormatInt(bfr.round, 10)] = bfr
 					}
 					go bf.fetchFromSharders(ctx, bfr, got, chainer, shardersl)
@@ -213,8 +210,6 @@ func (bf *BlockFetcher) StartBlockFetchWorker(ctx context.Context,
 				if bfr.hash != "" {
 					fetching[bfr.hash] = bfr // add, increasing map length
 				} else {
-					rd := strconv.FormatInt(bfr.round, 10)
-					logging.Logger.Debug("fetching block", zap.String("round", rd))
 					fetching[strconv.FormatInt(bfr.round, 10)] = bfr
 				}
 				go bf.fetchFromMiners(ctx, bfr, got, chainer, minersl)

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -613,7 +613,7 @@ func (c *Chain) AddGenesisBlock(b *block.Block) {
 }
 
 // AddLoadedFinalizedBlocks - adds the genesis block to the chain.
-func (c *Chain) AddLoadedFinalizedBlocks(lfb, lfmb *block.Block) {
+func (c *Chain) AddLoadedFinalizedBlocks(lfb, lfmb *block.Block, r *round.Round) {
 	err := c.UpdateMagicBlock(lfmb.MagicBlock)
 	if err != nil {
 		logging.Logger.Warn("update magic block failed", zap.Error(err))
@@ -621,6 +621,7 @@ func (c *Chain) AddLoadedFinalizedBlocks(lfb, lfmb *block.Block) {
 	c.SetLatestFinalizedMagicBlock(lfmb)
 	c.SetLatestFinalizedBlock(lfb)
 	c.blocks[lfb.Hash] = lfb
+	c.rounds[lfb.Round] = r
 }
 
 /*AddBlock - adds a block to the cache */

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -1293,7 +1293,9 @@ func (c *Chain) SetLatestFinalizedBlock(b *block.Block) {
 		bs := b.GetSummary()
 		c.lfbSummary = bs
 		c.BroadcastLFBTicket(context.Background(), b)
-		go c.notifyToSyncFinalizedRoundState(bs)
+		if !node.Self.IsSharder() {
+			go c.notifyToSyncFinalizedRoundState(bs)
+		}
 	}
 	c.lfbMutex.Unlock()
 

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -594,6 +594,7 @@ func (c *Chain) GenerateGenesisBlock(hash string, genesisMagicBlock *block.Magic
 	gb.SetRoundRandomSeed(genesisRandomSeed)
 	gr.Block = gb
 	gr.AddNotarizedBlock(gb)
+	gr.BlockHash = gb.Hash
 	return gr, gb
 }
 

--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -310,7 +310,7 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 	}
 	fr := c.GetRound(fb.Round)
 
-	logging.Logger.Info("finalize block -- round", zap.Any("round", fr))
+	logging.Logger.Info("finalize block -- round", zap.Any("round", fr), zap.String("block", fb.Hash))
 
 	if fr != nil {
 		generators := c.GetGenerators(fr)
@@ -371,6 +371,8 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 		}
 	}
 	go bsh.UpdateFinalizedBlock(ctx, fb)
+
+	fr.Finalize(fb)
 	c.BlockChain.Value = fb.GetSummary()
 	c.BlockChain = c.BlockChain.Next()
 

--- a/code/go/0chain.net/chaincore/chain/protocol_lfb_ticket.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_lfb_ticket.go
@@ -337,8 +337,10 @@ func (c *Chain) StartLFBTicketWorker(ctx context.Context, on *block.Block) {
 			// send for all subscribers, if any
 			c.sendLFBTicketEventToSubscribers(subs, ticket)
 
-			latest = ticket // update the latest
-			logging.Logger.Debug("update lfb ticket", zap.Int64("round", latest.Round))
+			if latest.Round < ticket.Round {
+				latest = ticket // update the latest
+				logging.Logger.Debug("update lfb ticket", zap.Int64("round", latest.Round))
+			}
 
 		// rebroadcast after some timeout
 		case <-rebroadcast.C:
@@ -362,6 +364,7 @@ func (c *Chain) StartLFBTicketWorker(ctx context.Context, on *block.Block) {
 func (c *Chain) AddReceivedLFBTicket(ctx context.Context, ticket *LFBTicket) {
 	select {
 	case c.updateLFBTicket <- ticket:
+		logging.Logger.Debug("AddReceivedLFBTicket", zap.Int64("round", ticket.Round))
 	case <-ctx.Done():
 	}
 }

--- a/code/go/0chain.net/chaincore/chain/protocol_lfb_ticket.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_lfb_ticket.go
@@ -290,13 +290,13 @@ func (c *Chain) StartLFBTicketWorker(ctx context.Context, on *block.Block) {
 			// only if updated, only for sharders
 			// (don't rebroadcast without a block verification)
 
-			if isSharder {
-				if _, err := c.GetBlock(ctx, ticket.LFBHash); err != nil {
-					c.AsyncFetchFinalizedBlockFromSharders(ctx, ticket,
-						c.afterFetcher)
-					continue // if haven't the block, then don't update the latest
-				}
-			}
+			//if isSharder {
+			//	if _, err := c.GetBlock(ctx, ticket.LFBHash); err != nil {
+			//		c.AsyncFetchFinalizedBlockFromSharders(ctx, ticket,
+			//			c.afterFetcher)
+			//		continue // if haven't the block, then don't update the latest
+			//	}
+			//}
 
 			// send for all subscribers
 			c.sendLFBTicketEventToSubscribers(subs, ticket)

--- a/code/go/0chain.net/chaincore/chain/protocol_lfb_ticket.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_lfb_ticket.go
@@ -204,8 +204,6 @@ func (c *Chain) GetLatestLFBTicket(ctx context.Context) (tk *LFBTicket) {
 func (c *Chain) sendLFBTicketEventToSubscribers(
 	subs map[chan *LFBTicket]struct{}, ticket *LFBTicket) {
 
-	//logging.Logger.Debug("[send LFB-ticket event to subscribers]",
-	//	zap.Int("subs", len(subs)), zap.Int64("round", ticket.Round))
 	for s := range subs {
 		select {
 		case s <- ticket: // the sending must be non-blocking
@@ -286,17 +284,6 @@ func (c *Chain) StartLFBTicketWorker(ctx context.Context, on *block.Block) {
 				c.sendLFBTicketEventToSubscribers(subs, ticket)
 				continue // don't need a block for the blank kick ticket
 			}
-
-			// only if updated, only for sharders
-			// (don't rebroadcast without a block verification)
-
-			//if isSharder {
-			//	if _, err := c.GetBlock(ctx, ticket.LFBHash); err != nil {
-			//		c.AsyncFetchFinalizedBlockFromSharders(ctx, ticket,
-			//			c.afterFetcher)
-			//		continue // if haven't the block, then don't update the latest
-			//	}
-			//}
 
 			// send for all subscribers
 			c.sendLFBTicketEventToSubscribers(subs, ticket)

--- a/code/go/0chain.net/chaincore/chain/protocol_lfb_ticket.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_lfb_ticket.go
@@ -204,8 +204,8 @@ func (c *Chain) GetLatestLFBTicket(ctx context.Context) (tk *LFBTicket) {
 func (c *Chain) sendLFBTicketEventToSubscribers(
 	subs map[chan *LFBTicket]struct{}, ticket *LFBTicket) {
 
-	logging.Logger.Debug("[send LFB-ticket event to subscribers]",
-		zap.Int("subs", len(subs)), zap.Int64("round", ticket.Round))
+	//logging.Logger.Debug("[send LFB-ticket event to subscribers]",
+	//	zap.Int("subs", len(subs)), zap.Int64("round", ticket.Round))
 	for s := range subs {
 		select {
 		case s <- ticket: // the sending must be non-blocking
@@ -303,7 +303,6 @@ func (c *Chain) StartLFBTicketWorker(ctx context.Context, on *block.Block) {
 
 			// update latest
 			latest = ticket //
-			logging.Logger.Debug("update lfb ticket", zap.Int64("round", latest.Round))
 
 			// don't broadcast a received LFB ticket, since its already
 			// broadcasted by its sender
@@ -364,7 +363,6 @@ func (c *Chain) StartLFBTicketWorker(ctx context.Context, on *block.Block) {
 func (c *Chain) AddReceivedLFBTicket(ctx context.Context, ticket *LFBTicket) {
 	select {
 	case c.updateLFBTicket <- ticket:
-		logging.Logger.Debug("AddReceivedLFBTicket", zap.Int64("round", ticket.Round))
 	case <-ctx.Done():
 	}
 }
@@ -390,8 +388,6 @@ func LFBTicketHandler(ctx context.Context, r *http.Request) (
 		return nil, common.NewError("lfb_ticket_handler", "can't verify")
 	}
 
-	logging.Logger.Debug("handle LFB ticket", zap.String("sharder", r.RemoteAddr),
-		zap.Int64("round", ticket.Round))
 	chain.AddReceivedLFBTicket(ctx, &ticket)
 	return // (nil, nil)
 }

--- a/code/go/0chain.net/chaincore/chain/protocol_round.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_round.go
@@ -242,14 +242,6 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 		return
 	}
 
-	//if roundNumber-lfb.Round <= 1 {
-	//	logging.Logger.Debug("finalize round - lfb round should have confirmed number > 1",
-	//		zap.Int64("round", roundNumber),
-	//		zap.Int64("lfb round", lfb.Round),
-	//		zap.String("lfb", lfb.Hash))
-	//	return
-	//}
-
 	if lfb.Round > plfb.Round {
 
 		if roundNumber-lfb.Round >= int64(2*config.GetLFBTicketAhead()) {

--- a/code/go/0chain.net/chaincore/chain/protocol_round.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_round.go
@@ -242,6 +242,14 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 		return
 	}
 
+	if roundNumber-lfb.Round <= 1 {
+		logging.Logger.Debug("finalize round - lfb round should have confirmed number > 1",
+			zap.Int64("round", roundNumber),
+			zap.Int64("lfb round", lfb.Round),
+			zap.String("lfb", lfb.Hash))
+		return
+	}
+
 	if lfb.Round > plfb.Round {
 
 		if roundNumber-lfb.Round >= int64(2*config.GetLFBTicketAhead()) {

--- a/code/go/0chain.net/chaincore/chain/protocol_round.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_round.go
@@ -327,13 +327,8 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 			zap.String("lfb block", lfb.Hash))
 		for idx := range frchain {
 			fb := frchain[len(frchain)-1-idx]
-			if roundNumber-fb.Round <= 2 {
-				logging.Logger.Debug("finalize round - round should have confirmed number > 2",
-					zap.Int64("latest round", roundNumber),
-					zap.Int64("round", fb.Round),
-					zap.String("block", fb.Hash),
-					zap.Int64("new lfb round", lfb.Round),
-					zap.String("new lfb", lfb.Hash))
+			if roundNumber-fb.Round < 3 {
+				// finalize the block only when it has at least 3 confirmation
 				continue
 			}
 

--- a/code/go/0chain.net/chaincore/chain/protocol_round.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_round.go
@@ -265,15 +265,6 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 		maxBackDepth := config.GetLFBTicketAhead()
 		frchain := make([]*block.Block, 0, maxBackDepth)
 		for b := lfb; b != nil && b.Hash != plfb.Hash && b.Round > plfb.Round; {
-			if roundNumber-b.Round <= 2 {
-				logging.Logger.Debug("finalize round - round should have confirmed number > 1",
-					zap.Int64("finalize round", roundNumber),
-					zap.Int64("round", b.Round),
-					zap.String("block", b.Hash),
-					zap.Int64("new lfb round", lfb.Round),
-					zap.String("new lfb", lfb.Hash))
-				continue
-			}
 			frchain = append(frchain, b)
 			if b.PrevBlock == nil {
 				if node.Self.IsSharder() {
@@ -344,6 +335,16 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 			zap.String("lfb block", lfb.Hash))
 		for idx := range frchain {
 			fb := frchain[len(frchain)-1-idx]
+			if roundNumber-fb.Round <= 2 {
+				logging.Logger.Debug("finalize round - round should have confirmed number > 2",
+					zap.Int64("latest round", roundNumber),
+					zap.Int64("round", fb.Round),
+					zap.String("block", fb.Hash),
+					zap.Int64("new lfb round", lfb.Round),
+					zap.String("new lfb", lfb.Hash))
+				continue
+			}
+
 			if pb := c.GetLocalPreviousBlock(ctx, fb); pb == nil {
 				logging.Logger.Error("finalize round - get previous block failed",
 					zap.Int64("round", fb.Round))

--- a/code/go/0chain.net/chaincore/chain/protocol_round.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_round.go
@@ -242,13 +242,13 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 		return
 	}
 
-	if roundNumber-lfb.Round <= 1 {
-		logging.Logger.Debug("finalize round - lfb round should have confirmed number > 1",
-			zap.Int64("round", roundNumber),
-			zap.Int64("lfb round", lfb.Round),
-			zap.String("lfb", lfb.Hash))
-		return
-	}
+	//if roundNumber-lfb.Round <= 1 {
+	//	logging.Logger.Debug("finalize round - lfb round should have confirmed number > 1",
+	//		zap.Int64("round", roundNumber),
+	//		zap.Int64("lfb round", lfb.Round),
+	//		zap.String("lfb", lfb.Hash))
+	//	return
+	//}
 
 	if lfb.Round > plfb.Round {
 
@@ -265,6 +265,15 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 		maxBackDepth := config.GetLFBTicketAhead()
 		frchain := make([]*block.Block, 0, maxBackDepth)
 		for b := lfb; b != nil && b.Hash != plfb.Hash && b.Round > plfb.Round; {
+			if roundNumber-b.Round <= 2 {
+				logging.Logger.Debug("finalize round - round should have confirmed number > 1",
+					zap.Int64("finalize round", roundNumber),
+					zap.Int64("round", b.Round),
+					zap.String("block", b.Hash),
+					zap.Int64("new lfb round", lfb.Round),
+					zap.String("new lfb", lfb.Hash))
+				continue
+			}
 			frchain = append(frchain, b)
 			if b.PrevBlock == nil {
 				if node.Self.IsSharder() {

--- a/code/go/0chain.net/chaincore/chain/protocol_round.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_round.go
@@ -287,6 +287,15 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 			}
 
 			b = b.PrevBlock
+			if b.Round == plfb.Round && b.Hash != plfb.Hash {
+				logging.Logger.Error("finalize round, computed lfb could not connect to prev lfb",
+					zap.Int64("round", b.Round),
+					zap.String("block", b.Hash),
+					zap.String("prev lfb block", plfb.Hash),
+					zap.Int64("computed lfb", lfb.Round),
+					zap.String("computed lfb block", lfb.Hash))
+				return
+			}
 
 			if len(frchain) >= maxBackDepth {
 				break

--- a/code/go/0chain.net/chaincore/chain/worker.go
+++ b/code/go/0chain.net/chaincore/chain/worker.go
@@ -361,30 +361,32 @@ func (c *Chain) finalizeBlockProcess(ctx context.Context, fb *block.Block, bsh B
 		}
 	}
 
-	// get previous finalized block
-	pr := c.GetRound(fb.Round - 1)
-	if pr == nil {
-		Logger.Error("finalize block - previous round not found",
-			zap.Int64("round", fb.Round))
-		return
-	}
+	if isSharder {
+		// get previous finalized block
+		pr := c.GetRound(fb.Round - 1)
+		if pr == nil {
+			Logger.Error("finalize block - previous round not found",
+				zap.Int64("round", fb.Round))
+			return
+		}
 
-	prevBlockHash := pr.GetBlockHash()
-	if prevBlockHash == "" {
-		Logger.Error("finalize block - previous round not finalized",
-			zap.Int64("round", fb.Round))
-		return
-	}
+		prevBlockHash := pr.GetBlockHash()
+		if prevBlockHash == "" {
+			Logger.Error("finalize block - previous round not finalized",
+				zap.Int64("round", fb.Round))
+			return
+		}
 
-	if fb.PrevHash != prevBlockHash {
-		Logger.Error("finalize block - previous block hash can not connect to last finalized block",
-			zap.Int64("round", fb.Round),
-			zap.String("block", fb.Hash),
-			zap.String("prev block", fb.PrevHash),
-			zap.String("finalized previous block", prevBlockHash))
-		return
-	}
+		if fb.PrevHash != prevBlockHash {
+			Logger.Error("finalize block - previous block hash can not connect to last finalized block",
+				zap.Int64("round", fb.Round),
+				zap.String("block", fb.Hash),
+				zap.String("prev block", fb.PrevHash),
+				zap.String("finalized previous block", prevBlockHash))
+			return
+		}
 
+	}
 	// finalize
 	c.finalizeBlock(ctx, fb, bsh)
 }

--- a/code/go/0chain.net/chaincore/chain/worker.go
+++ b/code/go/0chain.net/chaincore/chain/worker.go
@@ -361,6 +361,30 @@ func (c *Chain) finalizeBlockProcess(ctx context.Context, fb *block.Block, bsh B
 		}
 	}
 
+	// get previous finalized block
+	pr := c.GetRound(fb.Round - 1)
+	if pr == nil {
+		Logger.Error("finalize block - previous round not found",
+			zap.Int64("round", fb.Round))
+		return
+	}
+
+	prevBlockHash := pr.GetBlockHash()
+	if prevBlockHash == "" {
+		Logger.Error("finalize block - previous round not finalized",
+			zap.Int64("round", fb.Round))
+		return
+	}
+
+	if fb.PrevHash != prevBlockHash {
+		Logger.Error("finalize block - previous block hash can not connect to last finalized block",
+			zap.Int64("round", fb.Round),
+			zap.String("block", fb.Hash),
+			zap.String("prev block", fb.PrevHash),
+			zap.String("finalized previous block", prevBlockHash))
+		return
+	}
+
 	// finalize
 	c.finalizeBlock(ctx, fb, bsh)
 }

--- a/code/go/0chain.net/chaincore/chain/worker.go
+++ b/code/go/0chain.net/chaincore/chain/worker.go
@@ -28,7 +28,6 @@ func init() {
 func (c *Chain) SetupWorkers(ctx context.Context) {
 	go c.StatusMonitor(ctx)
 	go c.PruneClientStateWorker(ctx)
-	//go c.SyncLFBStateWorker(ctx)
 	go c.blockFetcher.StartBlockFetchWorker(ctx, c)
 	go c.StartLFBTicketWorker(ctx, c.GetLatestFinalizedBlock())
 	go node.Self.Underlying().MemoryUsage()
@@ -374,12 +373,12 @@ func (c *Chain) finalizeBlockProcess(ctx context.Context, fb *block.Block, bsh B
 		}
 
 		if fb.PrevHash != prevBlockHash {
-			Logger.Error("finalize block - previous block hash can not connect to last finalized block",
+			Logger.Error("finalize block - could not connect to lfb",
 				zap.Int64("round", fb.Round),
 				zap.String("block", fb.Hash),
 				zap.String("prev block", fb.PrevHash),
 				zap.String("finalized previous block", prevBlockHash))
-			return errors.New("could not connect to previous finalized round")
+			return errors.New("could not connect to lfb")
 		}
 
 	}

--- a/code/go/0chain.net/chaincore/chain/worker.go
+++ b/code/go/0chain.net/chaincore/chain/worker.go
@@ -28,7 +28,7 @@ func init() {
 func (c *Chain) SetupWorkers(ctx context.Context) {
 	go c.StatusMonitor(ctx)
 	go c.PruneClientStateWorker(ctx)
-	go c.SyncLFBStateWorker(ctx)
+	//go c.SyncLFBStateWorker(ctx)
 	go c.blockFetcher.StartBlockFetchWorker(ctx, c)
 	go c.StartLFBTicketWorker(ctx, c.GetLatestFinalizedBlock())
 	go node.Self.Underlying().MemoryUsage()

--- a/code/go/0chain.net/chaincore/node/n2n_send.go
+++ b/code/go/0chain.net/chaincore/node/n2n_send.go
@@ -75,7 +75,7 @@ func (np *Pool) SendAtleast(ctx context.Context, numNodes int, handler SendHandl
 	for _, n := range nodes {
 		infos = append(infos, n.GetPseudoName())
 	}
-	logging.Logger.Debug("send at least", zap.Int("number_to_send", numNodes),
+	logging.N2n.Debug("send at least", zap.Int("number_to_send", numNodes),
 		zap.Int("num_of_nodes", len(nodes)), zap.Strings("nodes", infos))
 	return np.sendTo(ctx, numNodes, nodes, handler)
 }

--- a/code/go/0chain.net/chaincore/node/self_node.go
+++ b/code/go/0chain.net/chaincore/node/self_node.go
@@ -138,3 +138,7 @@ func (sn *SelfNode) SetNodeIfPublicKeyIsEqual(node *Node) {
 	sn.Node.Info.BuildTag = build.BuildTag
 	sn.Node.Status = NodeStatusActive
 }
+
+func (sn *SelfNode) IsSharder() bool {
+	return sn.Type == NodeTypeSharder
+}

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -450,6 +450,13 @@ func (r *Round) Finalize(b *block.Block) {
 	r.BlockHash = b.Hash
 }
 
+func (r *Round) GetBlockHash() (hash string) {
+	r.mutex.Lock()
+	hash = r.BlockHash
+	r.mutex.Unlock()
+	return
+}
+
 /*SetFinalizing - the round is being finalized */
 func (r *Round) SetFinalizing() bool {
 	r.mutex.Lock()

--- a/code/go/0chain.net/chaincore/round/round.go
+++ b/code/go/0chain.net/chaincore/round/round.go
@@ -8,6 +8,7 @@ import (
 //RoundI - an interface that represents a blockchain round
 type RoundI interface {
 	GetRoundNumber() int64
+	GetBlockHash() string
 
 	GetRandomSeed() int64
 	SetRandomSeed(seed int64, minersNum int)

--- a/code/go/0chain.net/core/ememorystore/store.go
+++ b/code/go/0chain.net/core/ememorystore/store.go
@@ -3,7 +3,6 @@ package ememorystore
 import (
 	"context"
 	"encoding/binary"
-	"log"
 	"strconv"
 
 	"github.com/0chain/gorocksdb"
@@ -47,14 +46,7 @@ func (ems *Store) Read(ctx context.Context, key datastore.Key, entity datastore.
 		}
 	}
 	defer data.Free()
-	err = datastore.FromJSON(data.Data(), entity)
-	if err != nil {
-		if entity.GetKey() == "0" {
-			log.Println("data:", string(data.Data()))
-		}
-		return err
-	}
-	return nil
+	return datastore.FromJSON(data.Data(), entity)
 }
 
 func (ems *Store) Write(ctx context.Context, entity datastore.Entity) error {
@@ -68,9 +60,6 @@ func (ems *Store) Write(ctx context.Context, entity datastore.Entity) error {
 		}
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(rNumber))
-		if rNumber == 0 {
-			log.Println("write genesis round, data:", string(data))
-		}
 		if err := c.Conn.Put(key, data); err != nil {
 			return err
 		}

--- a/code/go/0chain.net/core/ememorystore/store.go
+++ b/code/go/0chain.net/core/ememorystore/store.go
@@ -68,6 +68,9 @@ func (ems *Store) Write(ctx context.Context, entity datastore.Entity) error {
 		}
 		key := make([]byte, 8)
 		binary.BigEndian.PutUint64(key, uint64(rNumber))
+		if rNumber == 0 {
+			log.Println("write genesis round, data:", string(data))
+		}
 		if err := c.Conn.Put(key, data); err != nil {
 			return err
 		}

--- a/code/go/0chain.net/core/ememorystore/store.go
+++ b/code/go/0chain.net/core/ememorystore/store.go
@@ -3,6 +3,7 @@ package ememorystore
 import (
 	"context"
 	"encoding/binary"
+	"log"
 	"strconv"
 
 	"github.com/0chain/gorocksdb"
@@ -48,6 +49,9 @@ func (ems *Store) Read(ctx context.Context, key datastore.Key, entity datastore.
 	defer data.Free()
 	err = datastore.FromJSON(data.Data(), entity)
 	if err != nil {
+		if entity.GetKey() == "0" {
+			log.Println("data:", string(data.Data()))
+		}
 		return err
 	}
 	return nil

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -893,7 +893,7 @@ func (mc *Chain) generateBlock(ctx context.Context, b *block.Block,
 		for _, txn := range iterInfo.pastTxns {
 			keys = append(keys, txn.GetKey())
 		}
-		logging.Logger.Info("generate block (found pastTxns transactions)", zap.Any("round", b.Round), zap.Strings("txn_hashes", keys))
+		logging.Logger.Info("generate block (found pastTxns transactions)", zap.Any("round", b.Round), zap.Int("txn num", len(keys)))
 	}
 	if iterInfo.roundMismatch {
 		logging.Logger.Debug("generate block (round mismatch)", zap.Any("round", b.Round), zap.Any("current_round", mc.GetCurrentRound()))

--- a/code/go/0chain.net/miner/protocol_receive.go
+++ b/code/go/0chain.net/miner/protocol_receive.go
@@ -297,6 +297,12 @@ func (mc *Chain) handleVerificationTicketMessage(ctx context.Context,
 		return
 	}
 
+	sender := mc.GetMiners(bvt.Round).GetNode(bvt.VerifierID)
+	logging.Logger.Debug("handle vt. msg - verify ticket successfully",
+		zap.Int64("round", bvt.Round),
+		zap.String("block", bvt.BlockID),
+		zap.Int("verifier", sender.SetIndex))
+
 	b, err := mc.GetBlock(ctx, bvt.BlockID)
 	if err != nil {
 		logging.Logger.Debug("handle vt. msg - block does not exist, collect tickets though",

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -888,7 +888,9 @@ func (mc *Chain) CollectBlocksForVerification(ctx context.Context, r *Round) {
 			}
 			minerStats.VerificationTicketsByRank[b.RoundRank]++
 		}
-		logging.Logger.Debug("verifyAndSend - finished successfully", zap.Any("block", b.Hash))
+		logging.Logger.Debug("verifyAndSend - finished successfully",
+			zap.Int64("round", b.Round),
+			zap.Any("block", b.Hash))
 		return true
 	}
 	var sendVerification = false

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -890,7 +890,7 @@ func (mc *Chain) CollectBlocksForVerification(ctx context.Context, r *Round) {
 		}
 		logging.Logger.Debug("verifyAndSend - finished successfully",
 			zap.Int64("round", b.Round),
-			zap.Any("block", b.Hash))
+			zap.String("block", b.Hash))
 		return true
 	}
 	var sendVerification = false

--- a/code/go/0chain.net/miner/worker.go
+++ b/code/go/0chain.net/miner/worker.go
@@ -25,6 +25,8 @@ func SetupWorkers(ctx context.Context) {
 	go mc.FinalizeRoundWorker(ctx)      // 2) sequentially finalize the rounds
 	go mc.FinalizedBlockWorker(ctx, mc) // 3) sequentially processes finalized blocks
 
+	go mc.SyncLFBStateWorker(ctx)
+
 	go mc.PruneStorageWorker(ctx, time.Minute*5, mc.getPruneCountRoundStorage(), mc.MagicBlockStorage, mc.roundDkg)
 	go mc.UpdateMagicBlockWorker(ctx)
 	//TODO uncomment it, atm it breaks executing faucet pour somehow

--- a/code/go/0chain.net/sharder/block_test.go
+++ b/code/go/0chain.net/sharder/block_test.go
@@ -1,4 +1,4 @@
-package sharder_test
+package sharder
 
 import (
 	"context"
@@ -20,14 +20,13 @@ import (
 	dmocks "0chain.net/core/datastore/mocks"
 	"0chain.net/core/ememorystore"
 	"0chain.net/core/encryption"
-	"0chain.net/sharder"
 	"0chain.net/sharder/blockstore"
 	bsmocks "0chain.net/sharder/blockstore/mocks"
 )
 
 func init() {
 	store := dmocks.NewStoreMock()
-	sharder.SetupBlockSummaries()
+	SetupBlockSummaries()
 	block.SetupBlockSummaryEntity(store)
 	block.SetupEntity(store)
 	block.SetupMagicBlockMapEntity(store)
@@ -97,28 +96,15 @@ func initDBs(t *testing.T) (closeAndClear func()) {
 	return
 }
 
-func makeTestChain(t *testing.T) *sharder.Chain {
-	ch, ok := chain.Provider().(*chain.Chain)
-	if !ok {
-		t.Fatal("types missmatching")
-	}
-	conf := chain.NewConfigImpl(&chain.ConfigData{BlockSize: 1024})
-	ch.Config = conf
-	ch.Initialize()
-	sharder.SetupSharderChain(ch)
-	chain.SetServerChain(ch)
-	return sharder.GetSharderChain()
-}
-
 func TestNewBlockSummaries(t *testing.T) {
-	want, ok := datastore.GetEntityMetadata("block_summaries").Instance().(*sharder.BlockSummaries)
+	want, ok := datastore.GetEntityMetadata("block_summaries").Instance().(*BlockSummaries)
 	if !ok {
 		t.Fatal("types missmatching")
 	}
 
 	tests := []struct {
 		name string
-		want *sharder.BlockSummaries
+		want *BlockSummaries
 	}{
 		{
 			name: "Test_NewBlockSummaries_OK",
@@ -128,7 +114,7 @@ func TestNewBlockSummaries(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			if got := sharder.NewBlockSummaries(); !reflect.DeepEqual(got, tt.want) {
+			if got := NewBlockSummaries(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewBlockSummaries() = %v, want %v", got, tt.want)
 			}
 		})
@@ -142,13 +128,13 @@ func TestBlockSummariesProvider(t *testing.T) {
 	}{
 		{
 			name: "Test_BlockSummariesProvider_OK",
-			want: &sharder.BlockSummaries{},
+			want: &BlockSummaries{},
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			if got := sharder.BlockSummariesProvider(); !reflect.DeepEqual(got, tt.want) {
+			if got := BlockSummariesProvider(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("BlockSummariesProvider() = %v, want %v", got, tt.want)
 			}
 		})
@@ -168,9 +154,9 @@ func TestChain_GetBlockBySummary(t *testing.T) {
 		RoundChannel   chan *round.Round
 		BlockCache     cache.Cache
 		BlockTxnCache  cache.Cache
-		SharderStats   sharder.Stats
-		BlockSyncStats *sharder.SyncStats
-		TieringStats   *sharder.MinioStats
+		SharderStats   Stats
+		BlockSyncStats *SyncStats
+		TieringStats   *MinioStats
 	}
 	type args struct {
 		ctx context.Context
@@ -185,7 +171,7 @@ func TestChain_GetBlockBySummary(t *testing.T) {
 	}{
 		{
 			name:    "Test_Chain_GetBlockBySummary_OK",
-			fields:  fields{Chain: sharder.GetSharderChain().Chain},
+			fields:  fields{Chain: GetSharderChain().Chain},
 			args:    args{bs: &block.BlockSummary{Hash: b.Hash}},
 			want:    b,
 			wantErr: false,
@@ -193,9 +179,9 @@ func TestChain_GetBlockBySummary(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc := &sharder.Chain{
+			sc := &Chain{
 				Chain:          tt.fields.Chain,
-				BlockChannel:   tt.fields.BlockChannel,
+				blockChannel:   tt.fields.BlockChannel,
 				RoundChannel:   tt.fields.RoundChannel,
 				BlockCache:     tt.fields.BlockCache,
 				BlockTxnCache:  tt.fields.BlockTxnCache,
@@ -219,7 +205,7 @@ func TestChain_GetBlockFromHash(t *testing.T) {
 	b := block.NewBlock("", 1)
 	b.HashBlock()
 	makeTestChain(t)
-	sharder.GetSharderChain().AddBlock(b)
+	GetSharderChain().AddBlock(b)
 
 	type fields struct {
 		Chain          *chain.Chain
@@ -227,9 +213,9 @@ func TestChain_GetBlockFromHash(t *testing.T) {
 		RoundChannel   chan *round.Round
 		BlockCache     cache.Cache
 		BlockTxnCache  cache.Cache
-		SharderStats   sharder.Stats
-		BlockSyncStats *sharder.SyncStats
-		TieringStats   *sharder.MinioStats
+		SharderStats   Stats
+		BlockSyncStats *SyncStats
+		TieringStats   *MinioStats
 	}
 	type args struct {
 		ctx      context.Context
@@ -245,7 +231,7 @@ func TestChain_GetBlockFromHash(t *testing.T) {
 	}{
 		{
 			name:    "Test_Chain_GetBlockFromHash_OK",
-			fields:  fields{Chain: sharder.GetSharderChain().Chain},
+			fields:  fields{Chain: GetSharderChain().Chain},
 			args:    args{hash: b.Hash},
 			want:    b,
 			wantErr: false,
@@ -254,9 +240,9 @@ func TestChain_GetBlockFromHash(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			sc := &sharder.Chain{
+			sc := &Chain{
 				Chain:          tt.fields.Chain,
-				BlockChannel:   tt.fields.BlockChannel,
+				blockChannel:   tt.fields.BlockChannel,
 				RoundChannel:   tt.fields.RoundChannel,
 				BlockCache:     tt.fields.BlockCache,
 				BlockTxnCache:  tt.fields.BlockTxnCache,
@@ -291,9 +277,9 @@ func TestChain_StoreBlockSummaryFromBlock(t *testing.T) {
 		RoundChannel   chan *round.Round
 		BlockCache     cache.Cache
 		BlockTxnCache  cache.Cache
-		SharderStats   sharder.Stats
-		BlockSyncStats *sharder.SyncStats
-		TieringStats   *sharder.MinioStats
+		SharderStats   Stats
+		BlockSyncStats *SyncStats
+		TieringStats   *MinioStats
 	}
 	type args struct {
 		ctx context.Context
@@ -314,9 +300,9 @@ func TestChain_StoreBlockSummaryFromBlock(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			sc := &sharder.Chain{
+			sc := &Chain{
 				Chain:          tt.fields.Chain,
-				BlockChannel:   tt.fields.BlockChannel,
+				blockChannel:   tt.fields.BlockChannel,
 				RoundChannel:   tt.fields.RoundChannel,
 				BlockCache:     tt.fields.BlockCache,
 				BlockTxnCache:  tt.fields.BlockTxnCache,
@@ -344,9 +330,9 @@ func TestChain_StoreBlockSummary(t *testing.T) {
 		RoundChannel   chan *round.Round
 		BlockCache     cache.Cache
 		BlockTxnCache  cache.Cache
-		SharderStats   sharder.Stats
-		BlockSyncStats *sharder.SyncStats
-		TieringStats   *sharder.MinioStats
+		SharderStats   Stats
+		BlockSyncStats *SyncStats
+		TieringStats   *MinioStats
 	}
 	type args struct {
 		ctx context.Context
@@ -367,9 +353,9 @@ func TestChain_StoreBlockSummary(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			sc := &sharder.Chain{
+			sc := &Chain{
 				Chain:          tt.fields.Chain,
-				BlockChannel:   tt.fields.BlockChannel,
+				blockChannel:   tt.fields.BlockChannel,
 				RoundChannel:   tt.fields.RoundChannel,
 				BlockCache:     tt.fields.BlockCache,
 				BlockTxnCache:  tt.fields.BlockTxnCache,

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -151,22 +151,15 @@ func (sc *Chain) GetRoundFromStore(ctx context.Context, roundNum int64) (*round.
 /*GetBlockHash - get the block hash for a given round */
 func (sc *Chain) GetBlockHash(ctx context.Context, roundNumber int64) (string, error) {
 	var err error
-	//var fromStore bool
 	r := sc.GetSharderRound(roundNumber)
 	if r == nil {
 		r, err = sc.GetRoundFromStore(ctx, roundNumber)
 		if err != nil {
 			return "", err
 		}
-		//fromStore = true
 	}
 	if r.BlockHash == "" {
 		return "", fmt.Errorf("round %d has empty block hash", roundNumber)
-		//Logger.Error("get_block_hash",
-		//	zap.Int64("round", roundNumber),
-		//	zap.Bool("from_store", fromStore),
-		//	zap.Error(err))
-		//return "", err
 	}
 	return r.BlockHash, nil
 }

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -139,22 +139,22 @@ func (sc *Chain) GetRoundFromStore(ctx context.Context, roundNum int64) (*round.
 /*GetBlockHash - get the block hash for a given round */
 func (sc *Chain) GetBlockHash(ctx context.Context, roundNumber int64) (string, error) {
 	var err error
-	var fromStore bool
+	//var fromStore bool
 	r := sc.GetSharderRound(roundNumber)
 	if r == nil {
 		r, err = sc.GetRoundFromStore(ctx, roundNumber)
 		if err != nil {
 			return "", err
 		}
-		fromStore = true
+		//fromStore = true
 	}
 	if r.BlockHash == "" {
-		err = fmt.Errorf("round %d has empty block hash", roundNumber)
-		Logger.Error("get_block_hash",
-			zap.Int64("round", roundNumber),
-			zap.Bool("from_store", fromStore),
-			zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("round %d has empty block hash", roundNumber)
+		//Logger.Error("get_block_hash",
+		//	zap.Int64("round", roundNumber),
+		//	zap.Bool("from_store", fromStore),
+		//	zap.Error(err))
+		//return "", err
 	}
 	return r.BlockHash, nil
 }

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -213,9 +213,10 @@ func (sc *Chain) setupLatestBlocks(ctx context.Context, bl *blocksLoaded) (
 
 	sc.SetRandomSeed(bl.r, bl.r.GetRandomSeed())
 	bl.r.Block = bl.lfb
+	bl.r.BlockHash = bl.lfb.Hash
 
 	// set LFB and LFMB of the Chain, add the block to internal Chain's map
-	sc.AddLoadedFinalizedBlocks(bl.lfb, bl.lfmb)
+	sc.AddLoadedFinalizedBlocks(bl.lfb, bl.lfmb, bl.r)
 
 	// check is it notarized
 	err = sc.VerifyBlockNotarization(ctx, bl.lfb)

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -403,6 +403,9 @@ func (sc *Chain) iterateRoundsLookingForLFB(ctx context.Context) *blocksLoaded {
 		return nil // the nil is 'use genesis'
 	}
 
+	magicBlockMiners := sc.GetMiners(bl.r.GetRoundNumber())
+	bl.r.SetRandomSeedForNotarizedBlock(bl.lfb.GetRoundRandomSeed(), magicBlockMiners.Size())
+
 	// and then, check out related LFMB can be missing
 	bl.lfmb, err = sc.loadLatestFinalizedMagicBlockFromStore(ctx, bl.lfb)
 	if err != nil {

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -2,6 +2,7 @@ package sharder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -75,14 +76,12 @@ type Chain struct {
 }
 
 // PushToBlockProcessor pushs the block to processor,
-func (sc *Chain) PushToBlockProcessor(ctx context.Context, b *block.Block) error {
-	cctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
+func (sc *Chain) PushToBlockProcessor(b *block.Block) error {
 	select {
 	case sc.blockChannel <- b:
 		return nil
-	case <-cctx.Done():
-		return cctx.Err()
+	case <-time.After(3 * time.Second):
+		return errors.New("push to block processor timeout")
 	}
 }
 

--- a/code/go/0chain.net/sharder/handler.go
+++ b/code/go/0chain.net/sharder/handler.go
@@ -8,12 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"0chain.net/chaincore/config"
-	"0chain.net/chaincore/node"
-
 	"0chain.net/chaincore/block"
 	"0chain.net/chaincore/chain"
+	"0chain.net/chaincore/config"
 	"0chain.net/chaincore/diagnostics"
+	"0chain.net/chaincore/node"
 	"0chain.net/core/common"
 )
 
@@ -62,12 +61,14 @@ func BlockHandler(ctx context.Context, r *http.Request) (interface{}, error) {
 		if roundEntity == nil {
 			_, err = sc.GetRoundFromStore(ctx, roundNumber)
 			if err != nil {
+				fmt.Println("get round from store failed", err)
 				return nil, err
 			}
 		}
 
 		hash, err = sc.GetBlockHash(ctx, roundNumber)
 		if err != nil {
+			fmt.Println("get block hash failed", err)
 			return nil, err
 		}
 	}
@@ -87,9 +88,11 @@ func BlockHandler(ctx context.Context, r *http.Request) (interface{}, error) {
 	for roundEntity := lfb.Round; roundEntity > 0; roundEntity -= sc.RoundRange() {
 		b, err = sc.GetBlockFromStore(hash, roundEntity)
 		if err != nil {
+			fmt.Println("get block from store 2 failed", err)
 			return nil, err
 		}
 	}
+	fmt.Println("here")
 	return chain.GetBlockResponse(b, parts)
 }
 

--- a/code/go/0chain.net/sharder/handler.go
+++ b/code/go/0chain.net/sharder/handler.go
@@ -3,7 +3,6 @@ package sharder
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -62,14 +61,12 @@ func BlockHandler(ctx context.Context, r *http.Request) (interface{}, error) {
 		if roundEntity == nil {
 			_, err = sc.GetRoundFromStore(ctx, roundNumber)
 			if err != nil {
-				log.Println("get round from store failed:", err)
 				return nil, err
 			}
 		}
 
 		hash, err = sc.GetBlockHash(ctx, roundNumber)
 		if err != nil {
-			fmt.Println("get block hash failed", err)
 			return nil, err
 		}
 	}
@@ -89,11 +86,9 @@ func BlockHandler(ctx context.Context, r *http.Request) (interface{}, error) {
 	for roundEntity := lfb.Round; roundEntity > 0; roundEntity -= sc.RoundRange() {
 		b, err = sc.GetBlockFromStore(hash, roundEntity)
 		if err != nil {
-			fmt.Println("get block from store 2 failed", err)
 			return nil, err
 		}
 	}
-	fmt.Println("here")
 	return chain.GetBlockResponse(b, parts)
 }
 

--- a/code/go/0chain.net/sharder/handler.go
+++ b/code/go/0chain.net/sharder/handler.go
@@ -3,6 +3,7 @@ package sharder
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -61,7 +62,7 @@ func BlockHandler(ctx context.Context, r *http.Request) (interface{}, error) {
 		if roundEntity == nil {
 			_, err = sc.GetRoundFromStore(ctx, roundNumber)
 			if err != nil {
-				fmt.Println("get round from store failed", err)
+				log.Println("get round from store failed:", err)
 				return nil, err
 			}
 		}

--- a/code/go/0chain.net/sharder/handler_test.go
+++ b/code/go/0chain.net/sharder/handler_test.go
@@ -1,4 +1,4 @@
-package sharder_test
+package sharder
 
 import (
 	"net/http"
@@ -9,7 +9,6 @@ import (
 	"0chain.net/chaincore/block"
 	"0chain.net/core/common"
 	"0chain.net/core/encryption"
-	"0chain.net/sharder"
 )
 
 func init() {
@@ -84,7 +83,7 @@ func TestBlockHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(common.UserRateLimit(common.ToJSONResponse(sharder.BlockHandler)))
+			handler := http.HandlerFunc(common.UserRateLimit(common.ToJSONResponse(BlockHandler)))
 
 			handler.ServeHTTP(rr, tt.request)
 
@@ -122,7 +121,7 @@ func TestChainStatsWriter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(common.UserRateLimit(sharder.ChainStatsWriter))
+			handler := http.HandlerFunc(common.UserRateLimit(ChainStatsWriter))
 
 			handler.ServeHTTP(rr, tt.request)
 

--- a/code/go/0chain.net/sharder/m_handler.go
+++ b/code/go/0chain.net/sharder/m_handler.go
@@ -153,13 +153,6 @@ func (sc *Chain) cacheProcessingBlock(hash string) bool {
 	_, err := sc.processingBlocks.Get(hash)
 	switch err {
 	case cache.ErrKeyNotFound:
-		// check if block is processed
-		//_, err := sc.GetBlock(context.Background(), hash)
-		//if err == nil {
-		//	sc.pbMutex.Unlock()
-		//	return false
-		//}
-
 		if err := sc.processingBlocks.Add(hash, struct{}{}); err != nil {
 			Logger.Warn("cache process block failed",
 				zap.String("block", hash),

--- a/code/go/0chain.net/sharder/m_handler.go
+++ b/code/go/0chain.net/sharder/m_handler.go
@@ -117,7 +117,7 @@ func NotarizedBlockKickHandler(sc Chainer) datastore.JSONEntityReqResponderF {
 		sc.GetBlockChannel() <- b // even if we have the block
 
 		// force notify block finalization process
-		sc.ForceFinalizeRound()
+		//sc.ForceFinalizeRound()
 		return true, nil
 	}
 }

--- a/code/go/0chain.net/sharder/m_handler.go
+++ b/code/go/0chain.net/sharder/m_handler.go
@@ -163,11 +163,11 @@ func (sc *Chain) cacheProcessingBlock(hash string) bool {
 	switch err {
 	case cache.ErrKeyNotFound:
 		// check if block is processed
-		_, err := sc.GetBlock(context.Background(), hash)
-		if err == nil {
-			sc.pbMutex.Unlock()
-			return false
-		}
+		//_, err := sc.GetBlock(context.Background(), hash)
+		//if err == nil {
+		//	sc.pbMutex.Unlock()
+		//	return false
+		//}
 
 		if err := sc.processingBlocks.Add(hash, struct{}{}); err != nil {
 			Logger.Warn("cache process block failed",

--- a/code/go/0chain.net/sharder/m_handler.go
+++ b/code/go/0chain.net/sharder/m_handler.go
@@ -77,9 +77,13 @@ func NotarizedBlockHandler(sc Chainer) datastore.JSONEntityReqResponderF {
 			return true, nil // doesn't need a not. block for the round
 		}
 
-		if b.Round != sc.GetCurrentRound()+1 {
-			return true, nil
-		}
+		//cr := sc.GetCurrentRound()
+		//if b.Round != cr+1 {
+		//	Logger.Debug("received notarized block, skip not connect to current round",
+		//		zap.Int64("round", b.Round),
+		//		zap.Int64("current round", cr))
+		//	return true, nil
+		//}
 
 		_, err := sc.GetBlock(ctx, b.Hash)
 		if err == nil {
@@ -115,9 +119,9 @@ func NotarizedBlockKickHandler(sc Chainer) datastore.JSONEntityReqResponderF {
 			return true, nil // doesn't need a not. block for the round
 		}
 
-		if b.Round != sc.GetCurrentRound()+1 {
-			return true, nil
-		}
+		//if b.Round != sc.GetCurrentRound()+1 {
+		//	return true, nil
+		//}
 
 		if err := node.ValidateSenderSignature(ctx); err != nil {
 			return false, err

--- a/code/go/0chain.net/sharder/m_handler.go
+++ b/code/go/0chain.net/sharder/m_handler.go
@@ -29,7 +29,7 @@ type Chainer interface {
 	GetCurrentRound() int64
 	GetLatestFinalizedBlock() *block.Block
 	GetBlock(ctx context.Context, hash datastore.Key) (*block.Block, error)
-	PushToBlockProcessor(ctx context.Context, b *block.Block) error
+	PushToBlockProcessor(b *block.Block) error
 	ForceFinalizeRound()
 }
 
@@ -86,7 +86,7 @@ func NotarizedBlockHandler(sc Chainer) datastore.JSONEntityReqResponderF {
 			return false, err
 		}
 
-		if err := sc.PushToBlockProcessor(ctx, b); err != nil {
+		if err := sc.PushToBlockProcessor(b); err != nil {
 			Logger.Error("NotarizedBlockHandler, push notarized block to channel failed",
 				zap.Int64("round", b.Round), zap.Error(err))
 			return false, nil
@@ -113,7 +113,7 @@ func NotarizedBlockKickHandler(sc Chainer) datastore.JSONEntityReqResponderF {
 			return false, err
 		}
 
-		if err := sc.PushToBlockProcessor(ctx, b); err != nil {
+		if err := sc.PushToBlockProcessor(b); err != nil {
 			Logger.Debug("Notarized block kick, push block to process channel failed",
 				zap.Int64("round", b.Round), zap.Error(err))
 		}

--- a/code/go/0chain.net/sharder/m_handler_test.go
+++ b/code/go/0chain.net/sharder/m_handler_test.go
@@ -1,4 +1,4 @@
-package sharder_test
+package sharder
 
 import (
 	"context"
@@ -18,7 +18,6 @@ import (
 	"0chain.net/core/datastore"
 	"0chain.net/core/encryption"
 	"0chain.net/core/logging"
-	"0chain.net/sharder"
 )
 
 func init() {
@@ -51,12 +50,12 @@ func TestLatestFinalizedBlockHandler(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			sc := &sharder.MockChainer{}
+			sc := &MockChainer{}
 			sc.On("GetLatestFinalizedBlock").Return(b)
 			sc.On("GetBlockChannel").Return(make(chan *block.Block, 1))
 			sc.On("ForceFinalizeRound()")
 
-			got, err := sharder.LatestFinalizedBlockHandler(sc)(tt.args.ctx, tt.args.r)
+			got, err := LatestFinalizedBlockHandler(sc)(tt.args.ctx, tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LatestFinalizedBlockHandler() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -80,9 +79,9 @@ func TestChain_AcceptMessage(t *testing.T) {
 		RoundChannel   chan *round.Round
 		BlockCache     cache.Cache
 		BlockTxnCache  cache.Cache
-		SharderStats   sharder.Stats
-		BlockSyncStats *sharder.SyncStats
-		TieringStats   *sharder.MinioStats
+		SharderStats   Stats
+		BlockSyncStats *SyncStats
+		TieringStats   *MinioStats
 	}
 	type args struct {
 		entityName string
@@ -102,7 +101,7 @@ func TestChain_AcceptMessage(t *testing.T) {
 		{
 			name: "Test_Chain_AcceptMessage_Existing_Block_FALSE",
 			fields: fields{
-				Chain: sharder.GetSharderChain().Chain,
+				Chain: GetSharderChain().Chain,
 			},
 			args: args{entityName: "block", entityID: b.Hash},
 			want: false,
@@ -110,7 +109,7 @@ func TestChain_AcceptMessage(t *testing.T) {
 		{
 			name: "Test_Chain_AcceptMessage_Not_Existing_Block_TRUE",
 			fields: fields{
-				Chain: sharder.GetSharderChain().Chain,
+				Chain: GetSharderChain().Chain,
 			},
 			args: args{entityName: "block", entityID: encryption.Hash("Test_Chain_AcceptMessage_Not_Existing_Block_TRUE")},
 			want: true,
@@ -121,7 +120,7 @@ func TestChain_AcceptMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			sc := &sharder.Chain{
+			sc := &Chain{
 				Chain:          tt.fields.Chain,
 				blockChannel:   tt.fields.BlockChannel,
 				RoundChannel:   tt.fields.RoundChannel,
@@ -167,11 +166,11 @@ func TestNotarizedBlockHandler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc := &sharder.MockChainer{}
+			sc := &MockChainer{}
 			sc.On("GetLatestFinalizedBlock").Return(b)
 			sc.On("GetBlock", mock.Anything, mock.Anything).Return(b, nil)
 
-			got, err := sharder.NotarizedBlockHandler(sc)(tt.args.ctx, tt.args.entity)
+			got, err := NotarizedBlockHandler(sc)(tt.args.ctx, tt.args.entity)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NotarizedBlockHandler() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -215,12 +214,12 @@ func TestNotarizedBlockKickHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			sc := &sharder.MockChainer{}
+			sc := &MockChainer{}
 			sc.On("GetLatestFinalizedBlock").Return(b)
 			sc.On("GetBlockChannel").Return(make(chan *block.Block, 1))
 			sc.On("ForceFinalizeRound()")
 
-			got, err := sharder.NotarizedBlockKickHandler(sc)(tt.args.ctx, tt.args.entity)
+			got, err := NotarizedBlockKickHandler(sc)(tt.args.ctx, tt.args.entity)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NotarizedBlockKickHandler() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/code/go/0chain.net/sharder/m_handler_test.go
+++ b/code/go/0chain.net/sharder/m_handler_test.go
@@ -123,7 +123,7 @@ func TestChain_AcceptMessage(t *testing.T) {
 
 			sc := &sharder.Chain{
 				Chain:          tt.fields.Chain,
-				BlockChannel:   tt.fields.BlockChannel,
+				blockChannel:   tt.fields.BlockChannel,
 				RoundChannel:   tt.fields.RoundChannel,
 				BlockCache:     tt.fields.BlockCache,
 				BlockTxnCache:  tt.fields.BlockTxnCache,

--- a/code/go/0chain.net/sharder/protocol_block.go
+++ b/code/go/0chain.net/sharder/protocol_block.go
@@ -183,6 +183,7 @@ func (sc *Chain) AfterFetch(ctx context.Context, b *block.Block) (err error) {
 
 func (sc *Chain) processBlock(ctx context.Context, b *block.Block) {
 	if !sc.cacheProcessingBlock(b.Hash) {
+		Logger.Debug("process block, being processed", zap.Int64("round", b.Round))
 		return
 	}
 

--- a/code/go/0chain.net/sharder/protocol_block.go
+++ b/code/go/0chain.net/sharder/protocol_block.go
@@ -181,12 +181,11 @@ func (sc *Chain) AfterFetch(ctx context.Context, b *block.Block) (err error) {
 	return // everything is done
 }
 
-// TODO: return error if previous block is not connected
-// the previous round added may not finalized yet, so need to check again to
-// ensure that the finalized one is saved.
 func (sc *Chain) processBlock(ctx context.Context, b *block.Block) error {
 	if !sc.cacheProcessingBlock(b.Hash) {
-		Logger.Debug("process block, being processed", zap.Int64("round", b.Round))
+		Logger.Debug("process block, being processed",
+			zap.Int64("round", b.Round),
+			zap.String("block", b.Hash))
 		return nil
 	}
 

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -27,10 +27,6 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 
 	_, ok := r.AddNotarizedBlock(b)
 
-	if !ok && shouldNotFinalize(r) {
-		return errors.New("add notarized block to round failed")
-	}
-
 	if sc.BlocksToSharder == chain.FINALIZED {
 		nb := r.GetNotarizedBlocks()
 		if len(nb) > 0 {
@@ -93,6 +89,12 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 
 	sc.SetCurrentRound(r.GetRoundNumber())
 	sc.UpdateNodeState(b)
+
+	if !ok && shouldNotFinalize(r) {
+		return errors.New("add notarized block to round failed")
+	}
+	// TODO: issue, new finalize block for the same round could override and will lead to
+	// break chain, need to fix this.
 
 	go sc.FinalizeRound(r)
 	return nil

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -25,7 +25,7 @@ func shouldNotFinalize(r round.RoundI) bool {
 func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 	b *block.Block) error {
 
-	_, ok := r.AddNotarizedBlock(b)
+	_, _ = r.AddNotarizedBlock(b)
 
 	if sc.BlocksToSharder == chain.FINALIZED {
 		nb := r.GetNotarizedBlocks()
@@ -90,9 +90,9 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 	sc.SetCurrentRound(r.GetRoundNumber())
 	sc.UpdateNodeState(b)
 
-	if !ok && shouldNotFinalize(r) {
-		return errors.New("add notarized block to round failed")
-	}
+	//if !ok && shouldNotFinalize(r) {
+	//	return errors.New("add notarized block to round failed")
+	//}
 	// TODO: issue, new finalize block for the same round could override and will lead to
 	// break chain, need to fix this.
 

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -90,12 +90,6 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 	sc.SetCurrentRound(r.GetRoundNumber())
 	sc.UpdateNodeState(b)
 
-	//if !ok && shouldNotFinalize(r) {
-	//	return errors.New("add notarized block to round failed")
-	//}
-	// TODO: issue, new finalize block for the same round could override and will lead to
-	// break chain, need to fix this.
-
 	go sc.FinalizeRound(r)
 	return nil
 }

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -17,10 +17,6 @@ import (
 
 var ErrNoPreviousBlock = errors.New("previous block does not exist")
 
-func shouldNotFinalize(r round.RoundI) bool {
-	return r.IsFinalizing() || r.IsFinalized()
-}
-
 // AddNotarizedBlock - add a notarized block for a given round.
 func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 	b *block.Block) error {

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -29,7 +29,6 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 		return errors.New("add notarized block to round failed")
 	}
 
-	sc.SetCurrentRound(r.GetRoundNumber())
 	if sc.BlocksToSharder == chain.FINALIZED {
 		nb := r.GetNotarizedBlocks()
 		if len(nb) > 0 {
@@ -38,8 +37,6 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 				zap.Any("existing_block", nb[0].Hash))
 		}
 	}
-	sc.UpdateNodeState(b)
-
 	errC := make(chan error)
 	doneC := make(chan struct{})
 	t := time.Now()
@@ -81,6 +78,9 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 			return err
 		}
 	}
+
+	sc.SetCurrentRound(r.GetRoundNumber())
+	sc.UpdateNodeState(b)
 
 	go sc.FinalizeRound(r)
 	return nil

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -25,11 +25,11 @@ func shouldNotFinalize(r round.RoundI) bool {
 func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 	b *block.Block) error {
 
-	_, _ = r.AddNotarizedBlock(b)
+	_, ok := r.AddNotarizedBlock(b)
 
-	//if !ok && shouldNotFinalize(r) {
-	//	return errors.New("add notarized block to round failed")
-	//}
+	if !ok && shouldNotFinalize(r) {
+		return errors.New("add notarized block to round failed")
+	}
 
 	if sc.BlocksToSharder == chain.FINALIZED {
 		nb := r.GetNotarizedBlocks()

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -25,11 +25,11 @@ func shouldNotFinalize(r round.RoundI) bool {
 func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 	b *block.Block) error {
 
-	_, ok := r.AddNotarizedBlock(b)
+	_, _ = r.AddNotarizedBlock(b)
 
-	if !ok && shouldNotFinalize(r) {
-		return errors.New("add notarized block to round failed")
-	}
+	//if !ok && shouldNotFinalize(r) {
+	//	return errors.New("add notarized block to round failed")
+	//}
 
 	if sc.BlocksToSharder == chain.FINALIZED {
 		nb := r.GetNotarizedBlocks()

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -15,6 +15,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var ErrNoPreviousBlock = errors.New("previous block does not exist")
+
 func shouldNotFinalize(r round.RoundI) bool {
 	return r.IsFinalizing() || r.IsFinalized()
 }
@@ -40,7 +42,7 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 
 	pb, _ := sc.GetBlock(ctx, b.PrevHash)
 	if pb == nil {
-		return errors.New("previous block does not exist")
+		return ErrNoPreviousBlock
 	}
 
 	if pb.ClientState == nil || pb.GetStateStatus() != block.StateSuccessful {

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -37,6 +37,16 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 				zap.Any("existing_block", nb[0].Hash))
 		}
 	}
+
+	pb, _ := sc.GetBlock(ctx, b.PrevHash)
+	if pb == nil {
+		return errors.New("previous block does not exist")
+	}
+
+	if pb.ClientState == nil || pb.GetStateStatus() != block.StateSuccessful {
+		return errors.New("previous block state is not computed")
+	}
+
 	errC := make(chan error)
 	doneC := make(chan struct{})
 	t := time.Now()

--- a/code/go/0chain.net/sharder/s_handler_test.go
+++ b/code/go/0chain.net/sharder/s_handler_test.go
@@ -1,4 +1,4 @@
-package sharder_test
+package sharder
 
 import (
 	"fmt"
@@ -10,7 +10,6 @@ import (
 	"0chain.net/chaincore/chain"
 	"0chain.net/chaincore/round"
 	"0chain.net/core/common"
-	"0chain.net/sharder"
 )
 
 func TestLatestRoundRequestHandler(t *testing.T) {
@@ -46,7 +45,7 @@ func TestLatestRoundRequestHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(common.UserRateLimit(common.ToJSONResponse(sharder.LatestRoundRequestHandler)))
+			handler := http.HandlerFunc(common.UserRateLimit(common.ToJSONResponse(LatestRoundRequestHandler)))
 
 			handler.ServeHTTP(rr, tt.request)
 
@@ -99,7 +98,7 @@ func TestBlockSummaryRequestHandler(t *testing.T) {
 			defer cl()
 
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(common.UserRateLimit(common.ToJSONResponse(sharder.BlockSummaryRequestHandler)))
+			handler := http.HandlerFunc(common.UserRateLimit(common.ToJSONResponse(BlockSummaryRequestHandler)))
 
 			handler.ServeHTTP(rr, tt.request)
 
@@ -140,7 +139,7 @@ func TestRoundBlockRequestHandler(t *testing.T) {
 			t.Parallel()
 
 			rr := httptest.NewRecorder()
-			handler := http.HandlerFunc(common.UserRateLimit(common.ToJSONResponse(sharder.RoundBlockRequestHandler)))
+			handler := http.HandlerFunc(common.UserRateLimit(common.ToJSONResponse(RoundBlockRequestHandler)))
 
 			handler.ServeHTTP(rr, tt.request)
 

--- a/code/go/0chain.net/sharder/sharder/main.go
+++ b/code/go/0chain.net/sharder/sharder/main.go
@@ -204,6 +204,12 @@ func main() {
 		Logger.Panic("node definition for self node doesn't exist")
 	}
 
+	// start sharding from the LFB stored
+	if err = sc.LoadLatestBlocksFromStore(common.GetRootContext()); err != nil {
+		Logger.Error("load latest blocks from store: " + err.Error())
+		return
+	}
+
 	var mb = sc.GetLatestMagicBlock()
 	if !mb.IsActiveNode(selfNode.GetKey(), 0) {
 		hostName, n2nHost, portNum, path, description, err := readNonGenesisHostAndPort(keysFile)
@@ -269,12 +275,6 @@ func main() {
 	common.ConfigRateLimits()
 	initN2NHandlers(sc)
 	initWorkers(ctx)
-
-	// start sharding from the LFB stored
-	if err = sc.LoadLatestBlocksFromStore(common.GetRootContext()); err != nil {
-		Logger.Error("load latest blocks from store: " + err.Error())
-		return
-	}
 
 	startBlocksInfoLogs(sc)
 

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -76,9 +76,9 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 			)
 
 			cr := sc.GetCurrentRound()
-			if cr > lfbTk.Round {
-				continue
-			}
+			//if cr > lfbTk.Round {
+			//	continue
+			//}
 
 			if cr < lfb.Round {
 				sc.SetCurrentRound(lfb.Round)

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -113,7 +113,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 		case b := <-sc.blockChannel:
 			cr := sc.GetCurrentRound()
 			//lfb := sc.GetLatestFinalizedBlock()
-			if b.Round >= sc.GetCurrentRound()+1 {
+			if b.Round > sc.GetCurrentRound()+1 {
 				//if b.Round >= lfb.Round+aheadN {
 				logging.Logger.Debug("process block skip",
 					zap.Int64("block round", b.Round),

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -166,7 +166,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 				zap.Int64("lfb round", sc.GetLatestFinalizedBlock().Round),
 				zap.Int64("lfb ticket round", lfbTk.Round))
 
-			if b.Round+aheadN >= endRound {
+			if b.Round >= lfb.Round+aheadN {
 				syncing = false
 				if b.Round < lfbTk.Round {
 					logging.Logger.Debug("process block, hit end, trigger sync",

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -112,7 +112,9 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 			go sc.requestBlocks(ctx, cr, reqNum)
 		case b := <-sc.blockChannel:
 			cr := sc.GetCurrentRound()
+			//lfb := sc.GetLatestFinalizedBlock()
 			if b.Round != sc.GetCurrentRound()+1 {
+				//if b.Round >= lfb.Round+aheadN {
 				logging.Logger.Debug("process block skip",
 					zap.Int64("block round", b.Round),
 					zap.Int64("current round", cr),
@@ -166,14 +168,14 @@ func (sc *Chain) requestBlocks(ctx context.Context, startRound, reqNum int64) in
 			cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
 			defer cancel()
 			// check local to see if exist
-			hash, err := sc.GetBlockHash(cctx, r)
-			if err == nil {
-				b, err := sc.GetBlockFromHash(cctx, hash, r)
-				if err == nil {
-					blocks[idx] = b
-					return
-				}
-			}
+			//hash, err := sc.GetBlockHash(cctx, r)
+			//if err == nil {
+			//	b, err := sc.GetBlockFromHash(cctx, hash, r)
+			//	if err == nil {
+			//		blocks[idx] = b
+			//		return
+			//	}
+			//}
 
 			// this will save block to local and create related round
 			b, err := sc.GetNotarizedBlockFromSharders(cctx, "", r)

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -130,11 +130,11 @@ func (sc *Chain) requestBlocks(ctx context.Context, startRound, reqNum int64) {
 	//
 	blocks := make([]*block.Block, reqNum)
 	wg := sync.WaitGroup{}
-	for i := int64(1); i <= reqNum; i++ {
+	for i := int64(0); i < reqNum; i++ {
 		wg.Add(1)
 		go func(idx int64) {
 			defer wg.Done()
-			r := startRound + idx
+			r := startRound + idx + 1
 			var cancel func()
 			cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
 			defer cancel()

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -110,24 +110,21 @@ func (sc *Chain) requestBlocks(ctx context.Context, startRound, endRound int64) 
 			defer cancel()
 			// check local to see if exist
 			hash, err := sc.GetBlockHash(ctx, r)
-			if err != nil {
-				logging.Logger.Debug("request block could not get hash in local store",
-					zap.Int64("round", r), zap.Error(err))
-			}
-
-			b, err := sc.GetBlockFromHash(ctx, hash, r)
-			if err != nil {
-				logging.Logger.Debug("request block could not find block in local store",
-					zap.Int64("round", r), zap.Error(err))
-
-				// this will save block to local and create related round
-				b, err = sc.GetNotarizedBlockFromSharders(ctx, "", r)
-				if err != nil {
-					logging.Logger.Error("request block from sharders failed",
-						zap.Int64("round", r),
-						zap.Error(err))
+			if err == nil {
+				b, err := sc.GetBlockFromHash(ctx, hash, r)
+				if err == nil {
+					blocks[idx] = b
 					return
 				}
+			}
+
+			// this will save block to local and create related round
+			b, err := sc.GetNotarizedBlockFromSharders(ctx, "", r)
+			if err != nil {
+				logging.Logger.Error("request block from sharders failed",
+					zap.Int64("round", r),
+					zap.Error(err))
+				return
 			}
 
 			blocks[idx] = b

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -83,6 +83,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 					zap.Int64("block round", b.Round), zap.Int64("current round", cr))
 				continue
 			}
+			logging.Logger.Debug("process block", zap.Int64("round", b.Round))
 			sc.processBlock(ctx, b)
 		}
 	}

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -148,7 +148,9 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 			cr := sc.GetCurrentRound()
 			if b.Round != sc.GetCurrentRound()+1 {
 				logging.Logger.Debug("process block skip",
-					zap.Int64("block round", b.Round), zap.Int64("current round", cr))
+					zap.Int64("block round", b.Round),
+					zap.Int64("current round", cr),
+					zap.Bool("syncing", synching))
 
 				if !synching {
 					syncBlocksTimer.Reset(0)
@@ -209,9 +211,8 @@ func (sc *Chain) requestBlocks(ctx context.Context, startRound, reqNum int64) in
 					logging.Logger.Error("request block failed",
 						zap.Int64("round", r),
 						zap.Error(err))
+					return
 				}
-
-				return
 			}
 
 			blocks[idx] = b

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -106,12 +106,12 @@ func (sc *Chain) requestBlocks(ctx context.Context, startRound, endRound int64) 
 			defer wg.Done()
 			r := startRound + idx
 			var cancel func()
-			ctx, cancel = context.WithTimeout(ctx, 8*time.Second)
+			cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
 			defer cancel()
 			// check local to see if exist
-			hash, err := sc.GetBlockHash(ctx, r)
+			hash, err := sc.GetBlockHash(cctx, r)
 			if err == nil {
-				b, err := sc.GetBlockFromHash(ctx, hash, r)
+				b, err := sc.GetBlockFromHash(cctx, hash, r)
 				if err == nil {
 					blocks[idx] = b
 					return
@@ -119,7 +119,7 @@ func (sc *Chain) requestBlocks(ctx context.Context, startRound, endRound int64) 
 			}
 
 			// this will save block to local and create related round
-			b, err := sc.GetNotarizedBlockFromSharders(ctx, "", r)
+			b, err := sc.GetNotarizedBlockFromSharders(cctx, "", r)
 			if err != nil {
 				logging.Logger.Error("request block from sharders failed",
 					zap.Int64("round", r),

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -59,7 +59,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 		aheadN          = int64(config.GetLFBTicketAhead())
 	)
 
-	const maxRequestBlocks = 20
+	const maxRequestBlocks = 5
 
 	for {
 		select {
@@ -166,7 +166,8 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 				zap.Int64("lfb round", sc.GetLatestFinalizedBlock().Round),
 				zap.Int64("lfb ticket round", lfbTk.Round))
 
-			if b.Round+aheadN >= endRound {
+			//if b.Round+aheadN >= endRound {
+			if b.Round >= endRound {
 				syncing = false
 				if b.Round < lfbTk.Round {
 					logging.Logger.Debug("process block, hit end, trigger sync",

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -124,7 +124,15 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 
 				continue
 			}
-			sc.processBlock(ctx, b)
+
+			if err := sc.processBlock(ctx, b); err != nil {
+				logging.Logger.Error("process block failed",
+					zap.Error(err),
+					zap.Int64("round", b.Round),
+					zap.String("block", b.Hash))
+
+				continue
+			}
 
 			lfbTk := sc.GetLatestLFBTicket(ctx)
 			logging.Logger.Debug("process block",

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -108,8 +108,11 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 				cr = lfb.Round
 			}
 
+			if cr > lfbTk.Round {
+				continue
+			}
+
 			endRound = lfbTk.Round + aheadN
-			//endRound = lfbTk.Round
 
 			if endRound <= cr {
 				continue

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -112,9 +112,9 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 			go sc.requestBlocks(ctx, cr, reqNum)
 		case b := <-sc.blockChannel:
 			cr := sc.GetCurrentRound()
-			//lfb := sc.GetLatestFinalizedBlock()
-			if b.Round > sc.GetCurrentRound()+1 {
-				//if b.Round >= lfb.Round+aheadN {
+			lfb := sc.GetLatestFinalizedBlock()
+			//if b.Round > sc.GetCurrentRound()+1 {
+			if b.Round > lfb.Round+aheadN {
 				logging.Logger.Debug("process block skip",
 					zap.Int64("block round", b.Round),
 					zap.Int64("current round", cr),

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -166,7 +166,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 				zap.Int64("lfb round", sc.GetLatestFinalizedBlock().Round),
 				zap.Int64("lfb ticket round", lfbTk.Round))
 
-			if b.Round >= lfb.Round+aheadN {
+			if b.Round >= lfb.Round+aheadN || b.Round >= endRound {
 				syncing = false
 				if b.Round < lfbTk.Round {
 					logging.Logger.Debug("process block, hit end, trigger sync",

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -166,8 +166,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 				zap.Int64("lfb round", sc.GetLatestFinalizedBlock().Round),
 				zap.Int64("lfb ticket round", lfbTk.Round))
 
-			//if b.Round+aheadN >= endRound {
-			if b.Round >= endRound {
+			if b.Round+aheadN >= endRound {
 				syncing = false
 				if b.Round < lfbTk.Round {
 					logging.Logger.Debug("process block, hit end, trigger sync",

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -52,6 +52,11 @@ func SetupWorkers(ctx context.Context) {
 /*BlockWorker - stores the blocks */
 func (sc *Chain) BlockWorker(ctx context.Context) {
 	syncBlocksTicker := time.NewTicker(time.Minute)
+	lfb := sc.GetLatestFinalizedBlock()
+	cr := sc.GetCurrentRound()
+	if cr < lfb.Round {
+		sc.SetCurrentRound(lfb.Round)
+	}
 
 	for {
 		select {

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -65,34 +65,6 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 		case <-ctx.Done():
 			logging.Logger.Error("BlockWorker exit", zap.Error(ctx.Err()))
 			return
-		//case <-lfbCheckTimer.C:
-		//	lfbCheckTimer.Reset(3 * time.Second)
-		//
-		//	lfb := sc.GetLatestFinalizedBlock()
-		//	lfbTk := sc.GetLatestLFBTicket(ctx)
-		//
-		//	if lfb.Round+aheadN+1 < endRound {
-		//		logging.Logger.Debug("process block, lfb.Round < endRound, continue",
-		//			zap.Int64("lfb round", lfb.Round),
-		//			zap.Int64("end round", endRound),
-		//			zap.Int64("lfb ticket round", lfbTk.Round))
-		//		continue
-		//	}
-		//
-		//	// lfb is >= endRound, but still <= LFB ticket, continue request
-		//	if endRound <= lfbTk.Round {
-		//		logging.Logger.Debug("process block, endRound <= lfbTk.Round, trigger sync",
-		//			zap.Int64("end round", endRound),
-		//			zap.Int64("lfb ticket round", lfbTk.Round))
-		//		syncBlocksTimer.Reset(0)
-		//		continue
-		//	}
-		//
-		//	logging.Logger.Debug("process block, endRound > lfbTk.Round, reset to 1 minute",
-		//		zap.Int64("end round", endRound),
-		//		zap.Int64("lfb ticket round", lfbTk.Round))
-		//	syncBlocksTimer.Reset(time.Minute)
-		//
 		case <-syncBlocksTimer.C:
 			// reset sync timer to 1 minute
 			syncBlocksTimer.Reset(time.Minute)

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -52,7 +52,7 @@ func SetupWorkers(ctx context.Context) {
 /*BlockWorker - stores the blocks */
 func (sc *Chain) BlockWorker(ctx context.Context) {
 	syncBlocksTimer := time.NewTimer(7 * time.Second)
-	lfbCheckTimer := time.NewTimer(3 * time.Second)
+	//lfbCheckTimer := time.NewTimer(3 * time.Second)
 	aheadN := int64(config.GetLFBTicketAhead())
 	endRound := int64(0)
 
@@ -63,33 +63,34 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 		case <-ctx.Done():
 			logging.Logger.Error("BlockWorker exit", zap.Error(ctx.Err()))
 			return
-		case <-lfbCheckTimer.C:
-			lfbCheckTimer.Reset(3 * time.Second)
-
-			lfb := sc.GetLatestFinalizedBlock()
-			lfbTk := sc.GetLatestLFBTicket(ctx)
-
-			if lfb.Round+aheadN < endRound {
-				logging.Logger.Debug("process block, lfb.Round < endRound, continue",
-					zap.Int64("lfb round", lfb.Round),
-					zap.Int64("end round", endRound))
-				continue
-			}
-
-			// lfb is >= endRound, but still <= LFB ticket, continue request
-			if endRound <= lfbTk.Round {
-				logging.Logger.Debug("process block, endRound <= lfbTk.Round, trigger sync",
-					zap.Int64("end round", endRound),
-					zap.Int64("lfb ticket round", lfbTk.Round))
-				syncBlocksTimer.Reset(0)
-				continue
-			}
-
-			logging.Logger.Debug("process block, endRound > lfbTk.Round, reset to 1 minute",
-				zap.Int64("end round", endRound),
-				zap.Int64("lfb ticket round", lfbTk.Round))
-			syncBlocksTimer.Reset(time.Minute)
-
+		//case <-lfbCheckTimer.C:
+		//	lfbCheckTimer.Reset(3 * time.Second)
+		//
+		//	lfb := sc.GetLatestFinalizedBlock()
+		//	lfbTk := sc.GetLatestLFBTicket(ctx)
+		//
+		//	if lfb.Round+aheadN+1 < endRound {
+		//		logging.Logger.Debug("process block, lfb.Round < endRound, continue",
+		//			zap.Int64("lfb round", lfb.Round),
+		//			zap.Int64("end round", endRound),
+		//			zap.Int64("lfb ticket round", lfbTk.Round))
+		//		continue
+		//	}
+		//
+		//	// lfb is >= endRound, but still <= LFB ticket, continue request
+		//	if endRound <= lfbTk.Round {
+		//		logging.Logger.Debug("process block, endRound <= lfbTk.Round, trigger sync",
+		//			zap.Int64("end round", endRound),
+		//			zap.Int64("lfb ticket round", lfbTk.Round))
+		//		syncBlocksTimer.Reset(0)
+		//		continue
+		//	}
+		//
+		//	logging.Logger.Debug("process block, endRound > lfbTk.Round, reset to 1 minute",
+		//		zap.Int64("end round", endRound),
+		//		zap.Int64("lfb ticket round", lfbTk.Round))
+		//	syncBlocksTimer.Reset(time.Minute)
+		//
 		case <-syncBlocksTimer.C:
 			// reset sync timer to 1 minute
 			syncBlocksTimer.Reset(time.Minute)
@@ -131,8 +132,11 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 				zap.Int64("end round", endRound),
 				zap.Int64("lfb round", sc.GetLatestFinalizedBlock().Round))
 			sc.processBlock(ctx, b)
-			if b.Round >= endRound {
-				lfbCheckTimer.Reset(0)
+			if b.Round+aheadN >= endRound {
+				logging.Logger.Debug("process block, hit end, trigger sync",
+					zap.Int64("round", b.Round),
+					zap.Int64("end round", endRound))
+				syncBlocksTimer.Reset(0)
 			}
 		}
 	}

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -113,7 +113,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 		case b := <-sc.blockChannel:
 			cr := sc.GetCurrentRound()
 			//lfb := sc.GetLatestFinalizedBlock()
-			if b.Round != sc.GetCurrentRound()+1 {
+			if b.Round > sc.GetCurrentRound()+1 {
 				//if b.Round >= lfb.Round+aheadN {
 				logging.Logger.Debug("process block skip",
 					zap.Int64("block round", b.Round),

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -217,7 +217,7 @@ func (sc *Chain) requestBlocks(ctx context.Context, startRound, reqNum int64) in
 			return 0
 		}
 
-		if err := sc.PushToBlockProcessor(ctx, b); err != nil {
+		if err := sc.PushToBlockProcessor(b); err != nil {
 			logging.Logger.Debug("requested block, but failed to pushed to process channel",
 				zap.Int64("round", b.Round), zap.Error(err))
 		}

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -113,7 +113,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 		case b := <-sc.blockChannel:
 			cr := sc.GetCurrentRound()
 			//lfb := sc.GetLatestFinalizedBlock()
-			if b.Round > sc.GetCurrentRound()+1 {
+			if b.Round >= sc.GetCurrentRound()+1 {
 				//if b.Round >= lfb.Round+aheadN {
 				logging.Logger.Debug("process block skip",
 					zap.Int64("block round", b.Round),

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -118,7 +118,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 				continue
 			}
 
-			// trunk to send at most 20 blocks each time
+			// trunc to send at most 20 blocks each time
 			reqNum := endRound - cr
 			if reqNum > maxRequestBlocks {
 				reqNum = maxRequestBlocks
@@ -137,12 +137,15 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 					zap.Int64("block round", b.Round), zap.Int64("current round", cr))
 				continue
 			}
+			lfbTk := sc.GetLatestLFBTicket(ctx)
 			logging.Logger.Debug("process block",
 				zap.Int64("round", b.Round),
 				zap.Int64("end round", endRound),
-				zap.Int64("lfb round", sc.GetLatestFinalizedBlock().Round))
+				zap.Int64("lfb round", sc.GetLatestFinalizedBlock().Round),
+				zap.Int64("lfb ticket round", lfbTk.Round))
+
 			sc.processBlock(ctx, b)
-			if b.Round+aheadN >= endRound {
+			if b.Round+aheadN >= endRound && lfbTk.Round-b.Round > 1 {
 				logging.Logger.Debug("process block, hit end, trigger sync",
 					zap.Int64("round", b.Round),
 					zap.Int64("end round", endRound),

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -118,6 +118,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 				logging.Logger.Debug("process block skip",
 					zap.Int64("block round", b.Round),
 					zap.Int64("current round", cr),
+					zap.Int64("lfb", lfb.Round),
 					zap.Bool("syncing", syncing))
 
 				if !syncing {

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -107,6 +107,13 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 			}
 
 			endRound = lfbTk.Round + aheadN
+
+			logging.Logger.Debug("process block, sync triggered",
+				zap.Int64("lfb", lfb.Round),
+				zap.Int64("lfb ticket", lfbTk.Round),
+				zap.Int64("current round", cr),
+				zap.Int64("end round", endRound))
+
 			if endRound <= cr {
 				continue
 			}
@@ -119,6 +126,9 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 
 			endRound = cr + reqNum
 
+			logging.Logger.Debug("process block, sync blocks",
+				zap.Int64("start round", cr+1),
+				zap.Int64("end round", cr+reqNum+1))
 			go sc.requestBlocks(ctx, cr, reqNum)
 		case b := <-sc.GetBlockChannel():
 			cr := sc.GetCurrentRound()
@@ -135,7 +145,8 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 			if b.Round+aheadN >= endRound {
 				logging.Logger.Debug("process block, hit end, trigger sync",
 					zap.Int64("round", b.Round),
-					zap.Int64("end round", endRound))
+					zap.Int64("end round", endRound),
+					zap.Int64("current round", cr))
 				syncBlocksTimer.Reset(0)
 			}
 		}

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -70,7 +70,7 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 			logging.Logger.Error("BlockWorker exit", zap.Error(ctx.Err()))
 			return
 		case <-stuckCheckTimer.C:
-			logging.Logger.Debug("finalize block, detected stuck, trigger sync",
+			logging.Logger.Debug("process block, detected stuck, trigger sync",
 				zap.Int64("round", sc.GetCurrentRound()),
 				zap.Int64("lfb", sc.GetLatestFinalizedBlock().Round))
 			stuckCheckTimer.Reset(stuckDuration)


### PR DESCRIPTION
## Fixes
- Event db inconsistent issue caused by missing blocks
- Issue on getting genesis block from `/v1/block/get`. Previously genesis block is not added to local store, so basically we can not get it by calling the API.

## Changes
- Run sharders in full node mode so that all sharders will have full node data, no block should be missed
- Update block fetcher to support getting finalized block by round number from sharders. Previously, the block hash must be provided, otherwise it can not return full block data. But since sharder need to sync finalized blocks from others, so updated the fetcher to support it.
- Stricter finalize process. For sharders, the finalizing block must connect to the latest finalized block, also it must have at least 3 successors, i.e., there are 3 more blocks extended from it. 

## Need to be mentioned in CHANGELOG.md?
Yes.

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
