### PR TITLE
Add concurrency safeguards to the current round timeout field on chain

### DIFF
--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"0chain.net/chaincore/currency"
@@ -1134,17 +1135,17 @@ func (c *Chain) GetUnrelatedBlocks(maxBlocks int, b *block.Block) []*block.Block
 
 //ResetRoundTimeoutCount - reset the counter
 func (c *Chain) ResetRoundTimeoutCount() {
-	c.crtCount = 0
+	atomic.SwapInt64(&c.crtCount, 0)
 }
 
 //IncrementRoundTimeoutCount - increment the counter
 func (c *Chain) IncrementRoundTimeoutCount() {
-	c.crtCount++
+	atomic.AddInt64(&c.crtCount, 1)
 }
 
 //GetRoundTimeoutCount - get the counter
 func (c *Chain) GetRoundTimeoutCount() int64 {
-	return c.crtCount
+	return atomic.LoadInt64(&c.crtCount)
 }
 
 //GetSignatureScheme - get the signature scheme used by this chain

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -810,7 +810,7 @@ func txnIterHandlerFunc(mc *Chain,
 			logging.Logger.Debug("Bad transaction cost", zap.Error(err))
 			return true
 		}
-		if int(tii.cost)+cost >= mc.Config.MaxBlockCost() {
+		if tii.cost+cost >= mc.Config.MaxBlockCost() {
 			logging.Logger.Debug("generate block (too big cost, skipping)")
 			return true
 		}
@@ -933,7 +933,7 @@ func (mc *Chain) generateBlock(ctx context.Context, b *block.Block,
 			logging.Logger.Debug("Bad transaction cost", zap.Error(err))
 			break
 		}
-		if int(iterInfo.cost)+cost >= mc.Config.MaxBlockCost() {
+		if iterInfo.cost+cost >= mc.Config.MaxBlockCost() {
 			logging.Logger.Debug("generate block (too big cost, skipping)")
 			break
 		}

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"sort"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	"github.com/rcrowley/go-metrics"
@@ -779,7 +778,7 @@ func txnIterHandlerFunc(mc *Chain,
 	txnProcessor txnProcessorHandler,
 	tii *TxnIterInfo) func(context.Context, datastore.CollectionEntity) bool {
 	return func(ctx context.Context, qe datastore.CollectionEntity) bool {
-		atomic.AddInt32(&tii.count, 1)
+		tii.count++
 		if ctx.Err() != nil {
 			return false
 		}


### PR DESCRIPTION
## Fixes
Add concurrency safeguards to the current round timeout field on chain (#629)
Also, add concurrency safeguards to the transaction cost as the processing of transactions may be done concurrently.

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
