### PR TITLE
Fix conductor standard tests building step

### DIFF
--- a/code/go/0chain.net/miner/protocol_view_chainge_integration_tests.go
+++ b/code/go/0chain.net/miner/protocol_view_chainge_integration_tests.go
@@ -9,7 +9,6 @@ import (
 
 	"0chain.net/chaincore/block"
 	"0chain.net/chaincore/chain"
-	"0chain.net/chaincore/config"
 	"0chain.net/chaincore/httpclientutil"
 	"0chain.net/chaincore/node"
 	"0chain.net/chaincore/threshold/bls"
@@ -35,7 +34,7 @@ func revertString(s string) string {
 // The sendDKGShare sends the generated secShare to the given node.
 func (mc *Chain) sendDKGShare(ctx context.Context, to string) (err error) {
 
-	if !config.DevConfiguration.IsDkgEnabled {
+	if !mc.ChainConfig.IsDkgEnabled() {
 		return common.NewError("send_dkg_share", "dkg is not enabled")
 	}
 


### PR DESCRIPTION
Use global configuration to check DKG is enabled

This PR fixes the building of the miner integration image in the conductor standard tests (https://github.com/0chain/0chain/runs/6944935658?check_suite_focus=true).

@peterlimg I realized this PR change was done by you previously (https://github.com/0chain/0chain/commit/8e107fc0cf4d27d7cb2b72e4e770d476e1a68fa8#diff-2ade906b5071a51cf9366cd5cd98126ad8e9c979fa5649c9e54cef547c526d98R343). For some reason your change was overridden. I recommend finding the root cause as other changes may be overridden as well.