### PR TITLE
Fix/accept round beyond on wait round

### DIFF
--- a/code/go/0chain.net/conductor/conductor/main.go
+++ b/code/go/0chain.net/conductor/conductor/main.go
@@ -635,7 +635,7 @@ func (r *Runner) acceptRound(re *conductrpc.RoundEvent) (err error) {
 	switch {
 	case r.waitRound.Round > re.Round:
 		return // not this round
-	case !r.waitRound.AllowBeyond && r.waitRound.Round < re.Round:
+	case r.waitRound.ForbidBeyond && r.waitRound.Round < re.Round:
 		return fmt.Errorf("missing round: %d, got %d", r.waitRound.Round,
 			re.Round)
 	}

--- a/code/go/0chain.net/conductor/config/waiters.go
+++ b/code/go/0chain.net/conductor/config/waiters.go
@@ -64,10 +64,10 @@ func (wp *WaitPhase) IsZero() bool {
 
 // WaitRound waits a round.
 type WaitRound struct {
-	Round       Round     `json:"round" yaml:"round" mapstructure:"round"`
-	Name        RoundName `json:"name" yaml:"name" mapstructure:"name"`
-	Shift       Round     `json:"shift" yaml:"shift" mapstructure:"shift"`
-	AllowBeyond bool      `json:"allow_beyond" yaml:"allow_beyond" mapstructure:"allow_beyond"`
+	Round        Round     `json:"round" yaml:"round" mapstructure:"round"`
+	Name         RoundName `json:"name" yaml:"name" mapstructure:"name"`
+	Shift        Round     `json:"shift" yaml:"shift" mapstructure:"shift"`
+	ForbidBeyond bool      `json:"forbid_beyond" yaml:"forbid_beyond" mapstructure:"forbid_beyond"`
 }
 
 func (wr *WaitRound) IsZero() bool {

--- a/docker.local/config/conductor.blobber-1.yaml
+++ b/docker.local/config/conductor.blobber-1.yaml
@@ -50,7 +50,6 @@ tests:
           start: true
       - wait_round:
           round: 15 # just wait the BC starts
-          allow_beyond: true
       - start: ['0dns']
       #wait the 0dns starts
       - command:

--- a/docker.local/config/conductor.miners.yaml
+++ b/docker.local/config/conductor.miners.yaml
@@ -65,7 +65,7 @@ tests:
           bad: ["miner-1", "miner-2"]
       - wait_round:
           shift: 10
-          timeout: "3m"
+          timeout: "1m"
           must_fail: true
   - name: "Send VRFS only to group"
     flow:
@@ -109,7 +109,7 @@ tests:
           bad: []
       - wait_round:
           shift: 10
-          timeout: "3m"
+          timeout: "1m"
           must_fail: true
 
   # Round timeout

--- a/docker.local/config/conductor.no-view-change.byzantine.yaml
+++ b/docker.local/config/conductor.no-view-change.byzantine.yaml
@@ -55,8 +55,7 @@ tests:
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
           round: 70
-          allow_beyond: true
-      - make_test_case_check:
+- make_test_case_check:
           wait_time: 5m
       - save_logs: {}
 
@@ -70,8 +69,7 @@ tests:
             round: 50
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70      
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -86,8 +84,7 @@ tests:
             round: 50
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -104,8 +101,7 @@ tests:
             by_node_with_type_rank: 0
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -122,8 +118,7 @@ tests:
             by_node_with_type_rank: 0
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -139,8 +134,7 @@ tests:
           hash: "d0cab02dd0f094eaa2d136fa335d4fbb7858832caebc416982187b2c9b58cecc"
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -158,8 +152,7 @@ tests:
           hash: "d0cab02dd0f094eaa2d136fa335d4fbb7858832caebc416982187b2c9b58cecc"
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -192,8 +185,7 @@ tests:
             by_node_with_type_rank: 1
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -210,8 +202,7 @@ tests:
             by_node_with_type_rank: 0
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -228,11 +219,9 @@ tests:
             by_node_with_type_rank: 0
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
-          allow_beyond: true
       - save_logs: { }
 
   - name: "half nodes down"
@@ -279,8 +268,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -318,8 +306,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -357,8 +344,7 @@ tests:
 
         - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
         - wait_round:
-            round: 70
-            allow_beyond: true
+            round: 70      
         - make_test_case_check:
             wait_time: 5m
         - save_logs: { }
@@ -396,8 +382,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -435,8 +420,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -474,8 +458,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -511,8 +494,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -549,8 +531,7 @@ tests:
                 type_rank: 0
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -588,8 +569,7 @@ tests:
                 type_rank: 0
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -626,8 +606,7 @@ tests:
                 type_rank: 0
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
       - save_logs: { }
@@ -664,8 +643,7 @@ tests:
                 type_rank: 0
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 5m
 
@@ -687,8 +665,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2"]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 3m
       - save_logs: { }
@@ -714,8 +691,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 3m
       - save_logs: { }
@@ -742,8 +718,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 3m
       - save_logs: { }
@@ -769,8 +744,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 3m
       - save_logs: { }
@@ -796,8 +770,7 @@ tests:
 
       - unlock: [ "miner-1", "miner-2", "miner-3", "miner-4", "sharder-1", "sharder-2" ]
       - wait_round:
-          round: 70
-          allow_beyond: true
+          round: 70    
       - make_test_case_check:
           wait_time: 3m
       - save_logs: { }

--- a/docker.local/config/conductor.no-view-change.fault-tolerance.yaml
+++ b/docker.local/config/conductor.no-view-change.fault-tolerance.yaml
@@ -174,8 +174,7 @@ tests:
           miners: ["miner-1", "miner-2", "miner-3", "miner-4"]
           start: true
       - wait_round:
-          shift: 20
-          allow_beyond: true
+          shift: 20   
       - stop: ["sharder-1"]
       - wait_no_progress:
           timeout: "5m"
@@ -194,8 +193,7 @@ tests:
       - stop: ["sharder-1"]
       - start: ["sharder-1"]
       - wait_round:
-          shift: 50
-          allow_beyond: true
+          shift: 50    
 
   - name: "Sharder goes down for 3 minutes simultaneously with coming up of the previous one"
     flow:
@@ -256,21 +254,18 @@ tests:
           start: true
       - wait_round:
           shift: 20
-          allow_beyond: true
       - stop: ["sharder-1", "miner-4"] # all sharders and some miners go down
       - wait_no_progress:
           timeout: "1m"
       - start: ["sharder-1"] # sharder comes up, BC should move
       - wait_round:
           shift: 20
-          allow_beyond: true
       - stop: ["miner-3"] # more than consensus miners are down
       - wait_no_progress:
           timeout: "1m"
       - start: ["miner-4"] # consensus miners are back online
       - wait_round:
           shift: 20
-          allow_beyond: true
       # To be continued
 
   - name: "Generators fail at start of round"

--- a/docker.local/config/conductor.sharders.yaml
+++ b/docker.local/config/conductor.sharders.yaml
@@ -26,7 +26,6 @@ tests:
       - start: ["miner-1", "miner-2", "miner-3"]
       - wait_round:
           round: 100
-          allow_beyond: true
           timeout: "5m"
       - stop: ["miner-1", "miner-2", "miner-3"]
       - finalized_block:
@@ -36,7 +35,6 @@ tests:
       - wait_round:
           shift: 10
           timeout: "5m"
-          allow_beyond: true
 
   - name: "Send bad MB to miners when all miners are down and then they are brought up"
     flow:
@@ -47,7 +45,6 @@ tests:
       - start: ["miner-1", "miner-2", "miner-3"]
       - wait_round:
           round: 100
-          allow_beyond: true
           timeout: "5m"
       - stop: ["miner-1", "miner-2", "miner-3"]
       - magic_block:

--- a/docker.local/config/conductor.view-change.fault-tolerance.yaml
+++ b/docker.local/config/conductor.view-change.fault-tolerance.yaml
@@ -58,7 +58,6 @@ tests:
       - wait_round:
           timeout: "5m"
           round: 1000
-          allow_beyond: true # allow 1001 instead of 1000
       - expect_active_set:
           sharders: ["sharder-1", "sharder-2"]
           miners: ["miner-1", "miner-2", "miner-3", "miner-4"]


### PR DESCRIPTION
This fixes conductor standard tests (https://github.com/0chain/0chain/actions/runs/2528036570).

The tests are failing because while waiting for a round it always goes beyond the specified round. The creation of rounds is too fast. One solution would be to block round creation after reaching the round specified in the test configuration. The solution of this PR allows the creation of rounds higher than the specified in the test configuration.

FYI @rrrooommmaaa I have inverted the behavior of the `allow_beyond`.  