### PR TITLE
Remove (allocation,blobber) from challenge partition if blobber is empty now

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -671,7 +671,13 @@ func (sc *StorageSmartContract) commitBlobberConnection(
 	}
 
 	// the first time the allocation is added  to the blobber, created related resources
-	if blobAlloc.BlobberAllocationsPartitionLoc == nil {
+	if blobAlloc.Stats.UsedSize == 0 {
+		err = removeAllocationFromBlobber(sc, t.ClientID, blobAlloc.BlobberAllocationsPartitionLoc, alloc.ID, balances)
+		if err != nil {
+			return "", common.NewErrorf("commit_connection_failed",
+				"removing allocation from blobAlloc partition: %v")
+		}
+	} else if blobAlloc.BlobberAllocationsPartitionLoc == nil {
 		if err := sc.blobberAddAllocation(t, blobAlloc, uint64(blobber.BytesWritten), balances); err != nil {
 			return "", common.NewErrorf("commit_connection_failed", err.Error())
 		}

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -675,7 +675,7 @@ func (sc *StorageSmartContract) commitBlobberConnection(
 		err = removeAllocationFromBlobber(sc, t.ClientID, blobAlloc.BlobberAllocationsPartitionLoc, alloc.ID, balances)
 		if err != nil {
 			return "", common.NewErrorf("commit_connection_failed",
-				"removing allocation from blobAlloc partition: %v")
+				"removing allocation from blobAlloc partition: %v", err)
 		}
 	} else if blobAlloc.BlobberAllocationsPartitionLoc == nil {
 		if err := sc.blobberAddAllocation(t, blobAlloc, uint64(blobber.BytesWritten), balances); err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -677,7 +677,7 @@ func (sc *StorageSmartContract) commitBlobberConnection(
 				"removing allocation from blobAlloc partition: %v", err)
 		}
 	} else if blobAlloc.BlobberAllocationsPartitionLoc == nil {
-		if err := sc.blobberAddAllocation(t, blobAlloc, uint64(blobber.BytesWritten), balances); err != nil {
+		if err := sc.blobberAddAllocation(t, blobAlloc, uint64(blobber.SavedData), balances); err != nil {
 			return "", common.NewErrorf("commit_connection_failed", err.Error())
 		}
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -672,7 +672,7 @@ func (sc *StorageSmartContract) commitBlobberConnection(
 
 	// the first time the allocation is added  to the blobber, created related resources
 	if blobAlloc.Stats.UsedSize == 0 {
-		err = removeAllocationFromBlobber(sc, t.ClientID, blobAlloc.BlobberAllocationsPartitionLoc, alloc.ID, balances)
+		err = removeAllocationFromBlobber(sc, blobAlloc, alloc.ID, balances)
 		if err != nil {
 			return "", common.NewErrorf("commit_connection_failed",
 				"removing allocation from blobAlloc partition: %v", err)


### PR DESCRIPTION
## Fixes

## Changes
- remove allocation from blobber_allocation_challenge partition, if blobber.UsedSize is now empty

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
