### PR TITLE
Fix gen_keys.sh script

### DIFF
--- a/docker.local/bin/gen_keys.sh
+++ b/docker.local/bin/gen_keys.sh
@@ -15,12 +15,12 @@ done
 
 docker $cmd -f docker.local/build.genkeys/Dockerfile . -t zchain_genkeys
 
-if [ "$#" -ne 3 ]; 
+if [ "$#" -ne 3 ];
     then echo "illegal number of parameters usage: docker.local/bin/gen_keys.sh signatureScheme [bls0chain or ed25519] absolute_path_to_keyfiles_folder key_file_name"
-    exit 
+    exit
 fi
 
-docker run -v "$2":/mykeys -it zchain_genkeys go run encryption/keys/main.go   --signature_scheme "$1" --keys_file_name "$3" --keys_file_path "/mykeys" --generate_keys true  --timestamp true
+docker run -v "$2":/mykeys -it zchain_genkeys go run -tags bn256 encryption/keys/main.go   --signature_scheme "$1" --keys_file_name "$3" --keys_file_path "/mykeys" --generate_keys true  --timestamp true
 
 retVal=$?
 if [ $retVal -ne 0 ]; then


### PR DESCRIPTION
## Fixes

Run `./docker.local/bin/gen_keys.sh` will fail with error 

```go
# github.com/herumi/bls/ffi/go/bls
In file included from /usr/local/include/bls/bls.h:10,
                 from /go/pkg/mod/github.com/herumi/bls@v0.0.0-20220327072144-7ec09c557eef/ffi/go/bls/bls.go:15:
/usr/local/include/mcl/bn.h:13:3: error: #error "define MCLBN_FP_UNIT_SIZE 4(, 6 or 8)"
   13 |  #error "define MCLBN_FP_UNIT_SIZE 4(, 6 or 8)"
      |   ^~~~~
```

Add `-tags bn256` to fix this

## Need to be mentioned in CHANGELOG.md?
No

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
No
