### PR TITLE
fix: error result on `/alloc-written-size-per-period`

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
@@ -57,7 +57,7 @@ func (edb *EventDb) GetAllocationWrittenSizeInLastNBlocks(blockNumber int64, all
 func (edb *EventDb) GetAllocationWrittenSizeInBlocks(startBlockNum, endBlockNum int64) (int64, error) {
 	var total int64
 	return total, edb.Store.Get().Model(&WriteMarker{}).
-		Select("sum(size)").
+		Select("COALESCE(SUM(size),0)").
 		Where("block_number > ? AND block_number < ?", startBlockNum, endBlockNum).
 		Find(&total).Error
 }


### PR DESCRIPTION
## Fixes
* In case of no writeMarkers available the query returned "{"error":"sql: Scan error on column index 0, name \"sum\": converting NULL to int64 is unsupported"}"
* Updated query to return 0 in case when sum is `null`

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
