### PR TITLE
Revert "Checking config on loading lfb when start"

### DIFF
--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -1335,7 +1335,7 @@ func (c *Chain) getClientState(pb *block.Block) (util.MerklePatriciaTrieI, error
 	return pb.ClientState, nil
 }
 
-func GetConfigMap(clientState util.MerklePatriciaTrieI) (*minersc.GlobalSettings, error) {
+func getConfigMap(clientState util.MerklePatriciaTrieI) (*minersc.GlobalSettings, error) {
 	if clientState == nil {
 		return nil, errors.New("client state is nil")
 	}
@@ -1362,7 +1362,7 @@ func (c *Chain) updateConfig(pb *block.Block) {
 		return
 	}
 
-	configMap, err := GetConfigMap(clientState)
+	configMap, err := getConfigMap(clientState)
 	if err != nil {
 		logging.Logger.Info("cannot get global settings",
 			zap.Int64("start of round", pb.Round),

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -7,15 +7,16 @@ import (
 	"sync"
 	"time"
 
+	"0chain.net/core/cache"
+	"0chain.net/core/ememorystore"
+	"0chain.net/core/logging"
+
 	"0chain.net/chaincore/block"
 	"0chain.net/chaincore/chain"
 	"0chain.net/chaincore/round"
 	"0chain.net/chaincore/state"
-	"0chain.net/core/cache"
 	"0chain.net/core/common"
 	"0chain.net/core/datastore"
-	"0chain.net/core/ememorystore"
-	"0chain.net/core/logging"
 	"0chain.net/sharder/blockstore"
 
 	"github.com/0chain/gorocksdb"
@@ -191,7 +192,7 @@ func (sc *Chain) setupLatestBlocks(ctx context.Context, bl *blocksLoaded) (
 	bl.lfb.SetStateStatus(block.StateSuccessful)
 	if err = sc.InitBlockState(bl.lfb); err != nil {
 		bl.lfb.SetStateStatus(0)
-		Logger.Warn("load_lfb -- can't initialize stored block state",
+		Logger.Info("load_lfb -- can't initialize stored block state",
 			zap.Error(err))
 		// return common.NewErrorf("load_lfb",
 		//	"can't init block state: %v", err) // fatal
@@ -345,21 +346,13 @@ func (sc *Chain) walkDownLookingForLFB(iter *gorocksdb.Iterator,
 		// Don't check the state. It can be missing if the state had synced.
 		// But it works fine anyway.
 
-		if !sc.HasClientStateStored(lfb.ClientStateHash) {
-			Logger.Warn("load_lfb, missing corresponding state",
-				zap.Int64("round", r.Number),
-				zap.String("block_hash", r.BlockHash))
-			// we can't use this block, because of missing or malformed state
-			continue
-		}
-
-		// check if we can load config from the lfb, otherwise choose previous one
-		if lfb.Round > 0 && !sc.HasConfig(lfb) {
-			Logger.Warn("load_lfb, missing config",
-				zap.Int64("round", r.Number),
-				zap.String("block_hash", r.BlockHash))
-			continue
-		}
+		// if !sc.HasClientStateStored(lfb.ClientStateHash) {
+		// 	Logger.Warn("load_lfb, missing corresponding state",
+		// 		zap.Int64("round", r.Number),
+		// 		zap.String("block_hash", r.BlockHash))
+		// 	// we can't use this block, because of missing or malformed state
+		// 	continue
+		// }
 
 		return // got it
 	}
@@ -475,19 +468,4 @@ func (sc *Chain) SaveMagicBlockHandler(ctx context.Context,
 // SaveMagicBlock function.
 func (sc *Chain) SaveMagicBlock() chain.MagicBlockSaveFunc {
 	return chain.MagicBlockSaveFunc(sc.SaveMagicBlockHandler)
-}
-
-func (sc *Chain) HasConfig(b *block.Block) bool {
-	if err := sc.InitBlockState(b); err != nil {
-		Logger.Warn("load_lfb, init block state failed", zap.Int64("round", b.Round), zap.String("block", b.Hash))
-		return false
-	}
-
-	_, err := chain.GetConfigMap(b.ClientState)
-	if err != nil {
-		Logger.Warn("load_lfb, can not load config from lfb", zap.Int64("round", b.Round), zap.String("block", b.Hash))
-		return false
-	}
-
-	return true
 }


### PR DESCRIPTION
## Fixes

See comments: https://github.com/0chain/0chain/pull/1445#issuecomment-1172779702

This reverts commit 917c90c25f35f7e009227420595e843ab096d3e1 as the config is not saved in MPT, so it would never be able to find config from MPT when loading lfb, therefore it will cause the sharder roll back to genesis block on restarting, which is not what we expect.


## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
