### PR TITLE
[FEAT] blobber challenge update weight

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -789,7 +789,15 @@ func (sc *StorageSmartContract) blobberAddAllocation(txn *transaction.Transactio
 	logging.Logger.Info("commit_connection, add blobber to challenge ready partitions",
 		zap.String("blobber", txn.ClientID))
 
-	crbLoc, err := partitionsChallengeReadyBlobbersAdd(balances, txn.ClientID, blobUsedCapacity)
+	sp, err := getStakePool(blobAlloc.BlobberID, balances)
+	if err != nil {
+		return common.NewError("blobber_add_allocation",
+			"unable to fetch blobbers stake pool")
+	}
+	stakedAlloc := sp.cleanStake()
+	weight := uint64(stakedAlloc) * blobUsedCapacity
+
+	crbLoc, err := partitionsChallengeReadyBlobbersAdd(balances, txn.ClientID, weight)
 	if err != nil {
 		return fmt.Errorf("could not add blobber to challenge ready partitions")
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -706,7 +706,7 @@ func selectBlobberForChallenge(selection challengeBlobberSelection, challengeBlo
 		const maxBlobbersSelect = 5
 
 		var challengeBlobber ChallengeReadyBlobber
-		var maxUsedCap uint64
+		var maxWeight uint64
 
 		var blobbersSelected = make([]ChallengeReadyBlobber, 0, maxBlobbersSelect)
 		if len(challengeBlobbers) <= maxBlobbersSelect {
@@ -719,8 +719,8 @@ func selectBlobberForChallenge(selection challengeBlobberSelection, challengeBlo
 		}
 
 		for _, bc := range blobbersSelected {
-			if bc.UsedCapacity > maxUsedCap {
-				maxUsedCap = bc.UsedCapacity
+			if bc.Weight > maxWeight {
+				maxWeight = bc.Weight
 				challengeBlobber = bc
 			}
 		}

--- a/code/go/0chain.net/smartcontract/storagesc/challenge_ready_partition.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge_ready_partition.go
@@ -20,8 +20,8 @@ func partitionsChallengeReadyBlobbers(balances state.StateContextI) (*partitions
 // ChallengeReadyBlobber represents a node that is ready to be challenged,
 // it will be saved in challenge ready blobbers partitions.
 type ChallengeReadyBlobber struct {
-	BlobberID    string `json:"blobber_id"`
-	UsedCapacity uint64 `json:"used_capacity"`
+	BlobberID string `json:"blobber_id"`
+	Weight    uint64 `json:"weight"`
 }
 
 func (bc *ChallengeReadyBlobber) GetID() string {
@@ -29,15 +29,15 @@ func (bc *ChallengeReadyBlobber) GetID() string {
 }
 
 func partitionsChallengeReadyBlobbersAdd(state state.StateContextI,
-	blobberID string, blobUsedCapacity uint64) (*partitions.PartitionLocation, error) {
+	blobberID string, weight uint64) (*partitions.PartitionLocation, error) {
 	challengeReadyParts, err := partitionsChallengeReadyBlobbers(state)
 	if err != nil {
 		return nil, fmt.Errorf("could not get challenge ready partitions, %v", err)
 	}
 
 	partIdx, err := challengeReadyParts.AddItem(state, &ChallengeReadyBlobber{
-		BlobberID:    blobberID,
-		UsedCapacity: blobUsedCapacity,
+		BlobberID: blobberID,
+		Weight:    weight,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not add blobber to challenge ready partition, %v", err)

--- a/code/go/0chain.net/smartcontract/storagesc/challenge_ready_partition_gen.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge_ready_partition_gen.go
@@ -13,9 +13,9 @@ func (z ChallengeReadyBlobber) MarshalMsg(b []byte) (o []byte, err error) {
 	// string "BlobberID"
 	o = append(o, 0x82, 0xa9, 0x42, 0x6c, 0x6f, 0x62, 0x62, 0x65, 0x72, 0x49, 0x44)
 	o = msgp.AppendString(o, z.BlobberID)
-	// string "UsedCapacity"
-	o = append(o, 0xac, 0x55, 0x73, 0x65, 0x64, 0x43, 0x61, 0x70, 0x61, 0x63, 0x69, 0x74, 0x79)
-	o = msgp.AppendUint64(o, z.UsedCapacity)
+	// string "Weight"
+	o = append(o, 0xa6, 0x57, 0x65, 0x69, 0x67, 0x68, 0x74)
+	o = msgp.AppendUint64(o, z.Weight)
 	return
 }
 
@@ -43,10 +43,10 @@ func (z *ChallengeReadyBlobber) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "BlobberID")
 				return
 			}
-		case "UsedCapacity":
-			z.UsedCapacity, bts, err = msgp.ReadUint64Bytes(bts)
+		case "Weight":
+			z.Weight, bts, err = msgp.ReadUint64Bytes(bts)
 			if err != nil {
-				err = msgp.WrapError(err, "UsedCapacity")
+				err = msgp.WrapError(err, "Weight")
 				return
 			}
 		default:
@@ -63,6 +63,6 @@ func (z *ChallengeReadyBlobber) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z ChallengeReadyBlobber) Msgsize() (s int) {
-	s = 1 + 10 + msgp.StringPrefixSize + len(z.BlobberID) + 13 + msgp.Uint64Size
+	s = 1 + 10 + msgp.StringPrefixSize + len(z.BlobberID) + 7 + msgp.Uint64Size
 	return
 }


### PR DESCRIPTION
earlier weight for selection of blobber of challenge was just used_capacity.
The weights are now updated to: `used_capacity * staked_allocation`

## Fixes

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
