### PR TITLE
Fix get client state API failure on miners to fix fault tolerant byzantine error

### DIFF
--- a/code/go/0chain.net/chaincore/chain/protocol_view_change.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change.go
@@ -277,7 +277,7 @@ func (c *Chain) RegisterNode() (*httpclientutil.Transaction, error) {
 	mb := c.GetCurrentMagicBlock()
 	var minerUrls = mb.Miners.N2NURLs()
 	logging.Logger.Debug("Register nodes to", zap.Strings("urls", minerUrls))
-	err = httpclientutil.SendSmartContractTxn(txn, minersc.ADDRESS, 0, 0, scData, minerUrls)
+	err = httpclientutil.SendSmartContractTxn(txn, minersc.ADDRESS, 0, 0, scData, minerUrls, mb.Sharders.N2NURLs())
 	return txn, err
 }
 
@@ -306,7 +306,7 @@ func (c *Chain) RegisterSharderKeep() (result *httpclientutil.Transaction, err2 
 	txn.PublicKey = selfNode.PublicKey
 	mb := c.GetCurrentMagicBlock()
 	var minerUrls = mb.Miners.N2NURLs()
-	err := httpclientutil.SendSmartContractTxn(txn, minersc.ADDRESS, 0, 0, scData, minerUrls)
+	err := httpclientutil.SendSmartContractTxn(txn, minersc.ADDRESS, 0, 0, scData, minerUrls, mb.Sharders.N2NURLs())
 	return txn, err
 }
 

--- a/code/go/0chain.net/chaincore/chain/state_handler.go
+++ b/code/go/0chain.net/chaincore/chain/state_handler.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strings"
 
-	"0chain.net/chaincore/node"
 	"0chain.net/smartcontract/faucetsc"
 	"0chain.net/smartcontract/minersc"
 	"0chain.net/smartcontract/rest"
@@ -144,32 +143,16 @@ func (c *Chain) GetNodeFromSCState(ctx context.Context, r *http.Request) (interf
 // GetBalanceHandler - get the balance of a client
 func (c *Chain) GetBalanceHandler(ctx context.Context, r *http.Request) (interface{}, error) {
 	clientID := r.FormValue("client_id")
-	if node.Self.IsSharder() {
-		if c.GetEventDb() == nil {
-			return nil, common.NewError("get_balance_error", "event database not enabled")
-		}
-
-		user, err := c.GetEventDb().GetUser(clientID)
-		if err != nil {
-			return nil, err
-		}
-
-		return userToState(user), nil
-	} else {
-		lfb := c.GetLatestFinalizedBlock()
-		if lfb == nil {
-			return nil, common.ErrTemporaryFailure
-		}
-
-		cs, err := c.GetState(lfb, clientID)
-		if err != nil {
-			return nil, err
-		}
-		if err := cs.ComputeProperties(); err != nil {
-			return nil, err
-		}
-		return cs, nil
+	if c.GetEventDb() == nil {
+		return nil, common.NewError("get_balance_error", "event database not enabled")
 	}
+
+	user, err := c.GetEventDb().GetUser(clientID)
+	if err != nil {
+		return nil, err
+	}
+
+	return userToState(user), nil
 }
 
 func (c *Chain) GetSCStats(w http.ResponseWriter, r *http.Request) {

--- a/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
+++ b/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
@@ -267,24 +267,24 @@ func MakeGetRequest(remoteUrl string, result interface{}) (err error) {
 	return // ok
 }
 
-func MakeClientBalanceRequest(clientID string, urls []string, consensus int) (currency.Coin, error) {
-	s, err := MakeClientStateRequest(clientID, urls, consensus)
+func MakeClientBalanceRequest(ctx context.Context, clientID string, urls []string, consensus int) (currency.Coin, error) {
+	s, err := MakeClientStateRequest(ctx, clientID, urls, consensus)
 	if err != nil {
 		return 0, err
 	}
 	return s.Balance, nil
 }
 
-func MakeClientNonceRequest(clientID string, urls []string, consensus int) (int64, error) {
-	s, err := MakeClientStateRequest(clientID, urls, consensus)
+func MakeClientNonceRequest(ctx context.Context, clientID string, urls []string, consensus int) (int64, error) {
+	s, err := MakeClientStateRequest(ctx, clientID, urls, consensus)
 	if err != nil {
 		return 0, err
 	}
 	return s.Nonce, nil
 }
 
-//MakeClientBalanceRequest to get a client's balance
-func MakeClientStateRequest(clientID string, urls []string, consensus int) (state.State, error) {
+// MakeClientStateRequest to get a client's balance
+func MakeClientStateRequest(ctx context.Context, clientID string, urls []string, consensus int) (state.State, error) {
 	//ToDo: This looks a lot like GetTransactionConfirmation. Need code reuse?
 
 	//maxCount := 0
@@ -299,7 +299,15 @@ func MakeClientStateRequest(clientID string, urls []string, consensus int) (stat
 
 		logging.N2n.Info("Running GetClientBalance on", zap.String("url", u))
 
-		response, err := http.Get(u)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			logging.N2n.Error("Error creating request for sc rest api", zap.Any("error", err))
+			numErrs++
+			errString = errString + sharder + ":" + err.Error()
+			continue
+		}
+
+		response, err := httpClient.Do(req)
 		if err != nil {
 			logging.N2n.Error("Error getting response for sc rest api", zap.Any("error", err))
 			numErrs++
@@ -728,7 +736,19 @@ func GetMagicBlockCall(urls []string, magicBlockNumber int64, consensus int) (*b
 
 }
 
-func SendSmartContractTxn(txn *Transaction, address string, value, fee int64, scData *SmartContractTxnData, minerUrls []string) error {
+func syncClientNonce(sharders []string) (int64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	defer cancel()
+	return MakeClientNonceRequest(ctx, node.Self.Underlying().GetKey(), sharders, 33)
+}
+
+func SendSmartContractTxn(txn *Transaction,
+	address string,
+	value, fee int64,
+	scData *SmartContractTxnData,
+	minerUrls []string,
+	sharderUrls []string,
+) error {
 	txn.ToClientID = address
 	txn.Value = value
 	txn.Fee = fee
@@ -742,11 +762,11 @@ func SendSmartContractTxn(txn *Transaction, address string, value, fee int64, sc
 
 	nextNonce := node.Self.GetNextNonce()
 	if nextNonce == 0 {
-		request, err := MakeClientNonceRequest(node.Self.Underlying().GetKey(), minerUrls, 33)
+		nonce, err := syncClientNonce(sharderUrls)
 		if err != nil {
-			logging.Logger.Error("Can't get nonce from remote", zap.Error(err))
+			logging.Logger.Error("can't get nonce from remote", zap.Error(err))
 		}
-		node.Self.SetNonce(request)
+		node.Self.SetNonce(nonce)
 		nextNonce = node.Self.GetNextNonce()
 	}
 	txn.Nonce = nextNonce

--- a/code/go/0chain.net/chaincore/httpclientutil/http_client_util_test.go
+++ b/code/go/0chain.net/chaincore/httpclientutil/http_client_util_test.go
@@ -583,7 +583,7 @@ func TestMakeClientBalanceRequest(t *testing.T) {
 				tt.args.urls = append(tt.args.urls, URL)
 			}
 
-			got, err := MakeClientBalanceRequest(tt.args.clientID, tt.args.urls, tt.args.consensus)
+			got, err := MakeClientBalanceRequest(context.TODO(), tt.args.clientID, tt.args.urls, tt.args.consensus)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MakeClientBalanceRequest() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1148,7 +1148,7 @@ func TestSendSmartContractTxn(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if err := SendSmartContractTxn(tt.args.txn, tt.args.address, tt.args.value, tt.args.fee, tt.args.scData, tt.args.minerUrls); (err != nil) != tt.wantErr {
+			if err := SendSmartContractTxn(tt.args.txn, tt.args.address, tt.args.value, tt.args.fee, tt.args.scData, tt.args.minerUrls, tt.args.minerUrls); (err != nil) != tt.wantErr {
 				t.Errorf("SendSmartContractTxn() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			assert.Equal(t, nonce+2, node.Self.GetNextNonce())

--- a/code/go/0chain.net/miner/protocol_view_chainge_main.go
+++ b/code/go/0chain.net/miner/protocol_view_chainge_main.go
@@ -174,7 +174,7 @@ func (mc *Chain) PublishShareOrSigns(ctx context.Context, lfb *block.Block,
 		minerUrls = append(minerUrls, nodeSend.GetN2NURLBase())
 	}
 	err = httpclientutil.SendSmartContractTxn(tx, minersc.ADDRESS, 0, 0, data,
-		minerUrls)
+		minerUrls, mb.Sharders.N2NURLs())
 	return
 }
 
@@ -232,7 +232,7 @@ func (mc *Chain) ContributeMpk(ctx context.Context, lfb *block.Block,
 	tx.ToClientID = minersc.ADDRESS
 
 	err = httpclientutil.SendSmartContractTxn(tx, minersc.ADDRESS, 0, 0, data,
-		mb.Miners.N2NURLs())
+		mb.Miners.N2NURLs(), mb.Sharders.N2NURLs())
 	return
 }
 

--- a/code/go/0chain.net/miner/protocol_view_change.go
+++ b/code/go/0chain.net/miner/protocol_view_change.go
@@ -578,7 +578,7 @@ func (mc *Chain) waitTransaction(mb *block.MagicBlock) (
 	tx.ToClientID = minersc.ADDRESS
 
 	err = httpclientutil.SendSmartContractTxn(tx, minersc.ADDRESS, 0, 0, data,
-		mb.Miners.N2NURLs())
+		mb.Miners.N2NURLs(), mb.Sharders.N2NURLs())
 	return
 }
 

--- a/code/go/0chain.net/miner/worker.go
+++ b/code/go/0chain.net/miner/worker.go
@@ -235,7 +235,7 @@ func (mc *Chain) MinerHealthCheck(ctx context.Context) {
 			mb := mc.GetCurrentMagicBlock()
 			var minerUrls = mb.Miners.N2NURLs()
 			go func() {
-				if err := httpclientutil.SendSmartContractTxn(txn, minersc.ADDRESS, 0, 0, scData, minerUrls); err != nil {
+				if err := httpclientutil.SendSmartContractTxn(txn, minersc.ADDRESS, 0, 0, scData, minerUrls, mb.Sharders.N2NURLs()); err != nil {
 					logging.Logger.Warn("miner health check -  send smart contract failed",
 						zap.Int("urls len", len(minerUrls)),
 						zap.Error(err))

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -443,7 +443,7 @@ func (sc *Chain) SharderHealthCheck(ctx context.Context) {
 
 			mb := sc.GetCurrentMagicBlock()
 			var minerUrls = mb.Miners.N2NURLs()
-			if err := httpclientutil.SendSmartContractTxn(txn, minersc.ADDRESS, 0, 0, scData, minerUrls); err != nil {
+			if err := httpclientutil.SendSmartContractTxn(txn, minersc.ADDRESS, 0, 0, scData, minerUrls, mb.Sharders.N2NURLs()); err != nil {
 				logging.Logger.Warn("sharder health check failed, try again")
 			}
 

--- a/code/go/0chain.net/smartcontract/multisigsc/test/blockchainclient.go
+++ b/code/go/0chain.net/smartcontract/multisigsc/test/blockchainclient.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -271,7 +272,9 @@ func confirmTransaction(hash string) (httpclientutil.Transaction, error) {
 }
 
 func getBalance(clientID string) currency.Coin {
-	balance, err := httpclientutil.MakeClientBalanceRequest(clientID, members.Sharders, confirmationQuorum)
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	defer cancel()
+	balance, err := httpclientutil.MakeClientBalanceRequest(ctx, clientID, members.Sharders, confirmationQuorum)
 	if err != nil {
 		Logger.Fatal("Couldn't get client balance", zap.Error(err))
 	}

--- a/docker.local/bin/clean.sh
+++ b/docker.local/bin/clean.sh
@@ -23,7 +23,8 @@ do
   rm -rf docker.local/sharder"$i"/data/cassandra/*
   echo "deleting sharder$i rocksdb db"
   rm -rf docker.local/sharder"$i"/data/rocksdb/*
-    rm -rf docker.local/sharder"$i"/data/postgresql/*
+  echo "delete sharder$i postgres db"
+  rm -rf docker.local/sharder"$i"/data/postgresql/*
 done
 
 for i in $(seq 1 4)

--- a/docker.local/bin/start.conductor.sh
+++ b/docker.local/bin/start.conductor.sh
@@ -7,6 +7,8 @@ do
     docker stop "$running"
 done
 
+./clean.sh
+
 # go caches all build by default
 (cd ./code/go/0chain.net/conductor/conductor/ && go build)
 # start the conductor

--- a/docker.local/config/conductor.no-view-change.fault-tolerance.yaml
+++ b/docker.local/config/conductor.no-view-change.fault-tolerance.yaml
@@ -155,14 +155,14 @@ tests:
       - start: ["miner-4"]
       - wait_round:
           shift: 10
-          timeout: "1m"
+          timeout: "3m"
       - command:
           name: "sleep_3m"
       - stop: ["miner-2"]
       - start: ["miner-3"]
       - wait_round:
           shift: 10
-          timeout: "1m"
+          timeout: "3m"
 
   # SHARDERS GO DOWN
   - name: "All sharders go down"
@@ -174,7 +174,7 @@ tests:
           miners: ["miner-1", "miner-2", "miner-3", "miner-4"]
           start: true
       - wait_round:
-          shift: 20   
+          shift: 20
       - stop: ["sharder-1"]
       - wait_no_progress:
           timeout: "5m"
@@ -193,7 +193,7 @@ tests:
       - stop: ["sharder-1"]
       - start: ["sharder-1"]
       - wait_round:
-          shift: 50    
+          shift: 50
 
   - name: "Sharder goes down for 3 minutes simultaneously with coming up of the previous one"
     flow:


### PR DESCRIPTION
## Fixes

Miners and sharders would not be able to sync the transaction nonce after restarting, hence unable to create new transactions, generate blocks, etc and failed the fault tolerant byzantine tests.

## Changes

- Sync client nonce from sharders

- Extend the wait time out time of fault tolerant tests, miners need more time to recover and sync missing state before they could work.

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
