### PR TITLE
Blobber update validation

### DIFF
--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -759,7 +759,7 @@ func (c *Chain) updateFeeStats(fb *block.Block) error {
 			return err
 		}
 	}
-	meanFees, _, err := currency.DivideCoin(totalFees, int64(len(fb.Txns)))
+	meanFees, _, err := currency.DistributeCoin(totalFees, int64(len(fb.Txns)))
 	if err != nil {
 		return err
 	}

--- a/code/go/0chain.net/chaincore/currency/currency.go
+++ b/code/go/0chain.net/chaincore/currency/currency.go
@@ -147,7 +147,7 @@ func MinusInt64(c Coin, a int64) (Coin, error) {
 	return MinusCoin(c, b)
 }
 
-func DivideCoin(c Coin, a int64) (oCur, bal Coin, err error) {
+func DistributeCoin(c Coin, a int64) (oCur, bal Coin, err error) {
 	d, err := Int64ToCoin(a)
 	if err != nil {
 		return

--- a/code/go/0chain.net/smartcontract/minersc/fees.go
+++ b/code/go/0chain.net/smartcontract/minersc/fees.go
@@ -462,11 +462,11 @@ func (msc *MinerSmartContract) payShardersAndDelegates(
 
 	sn := len(sharders)
 	// fess and mint
-	feeShare, feeLeft, err := currency.DivideCoin(fee, int64(sn))
+	feeShare, feeLeft, err := currency.DistributeCoin(fee, int64(sn))
 	if err != nil {
 		return err
 	}
-	mintShare, mintLeft, err := currency.DivideCoin(mint, int64(sn))
+	mintShare, mintLeft, err := currency.DistributeCoin(mint, int64(sn))
 	if err != nil {
 		return err
 	}
@@ -474,7 +474,7 @@ func (msc *MinerSmartContract) payShardersAndDelegates(
 	totalCoinLeft := feeLeft + mintLeft
 
 	if totalCoinLeft > currency.Coin(sn) {
-		clShare, cl, err := currency.DivideCoin(totalCoinLeft, int64(sn))
+		clShare, cl, err := currency.DistributeCoin(totalCoinLeft, int64(sn))
 		if err != nil {
 			return err
 		}

--- a/code/go/0chain.net/smartcontract/stakepool/stakepool.go
+++ b/code/go/0chain.net/smartcontract/stakepool/stakepool.go
@@ -288,7 +288,7 @@ func (sp *StakePool) equallyDistributeRewards(coins currency.Coin, spUpdate *Sta
 		return strings.Compare(delegates[i].DelegateID, delegates[j].DelegateID) == -1
 	})
 
-	share, r, err := currency.DivideCoin(coins, int64(len(delegates)))
+	share, r, err := currency.DistributeCoin(coins, int64(len(delegates)))
 	if err != nil {
 		return err
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -158,7 +158,7 @@ func (sc *StorageSmartContract) filterBlobbersByFreeSpace(now common.Timestamp,
 			return false // keep, ok or already filtered by bid
 		}
 		// clean capacity (without delegate pools want to 'unstake')
-		var free = sp.cleanCapacity(b.Terms.WritePrice)
+		var free = sp.unallocatedCapacity(b.Terms.WritePrice)
 		return free < size // kick off if it hasn't enough free space
 	})
 }

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -158,7 +158,7 @@ func (sc *StorageSmartContract) filterBlobbersByFreeSpace(now common.Timestamp,
 			return false // keep, ok or already filtered by bid
 		}
 		// clean capacity (without delegate pools want to 'unstake')
-		var free = sp.cleanCapacity(now, b.Terms.WritePrice)
+		var free = sp.cleanCapacity(b.Terms.WritePrice)
 		return free < size // kick off if it hasn't enough free space
 	})
 }

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -1927,7 +1927,7 @@ func TestStorageSmartContract_updateAllocationRequest(t *testing.T) {
 		var blob *StorageNode
 		blob, err = ssc.getBlobber(b.id, balances)
 		require.NoError(t, err)
-		blob.Terms.WritePrice = currency.Coin(1.8 * x10)
+		blob.Terms.WritePrice = currency.Coin(5 * x10)
 		blob.Terms.ReadPrice = currency.Coin(0.8 * x10)
 		_, err = updateBlobber(t, blob, 0, tp, ssc, balances)
 		require.NoError(t, err)

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -101,14 +101,24 @@ func (sc *StorageSmartContract) updateBlobber(t *transaction.Transaction,
 		sc.statIncr(statNumberOfBlobbers) // reborn, if it was "removed"
 	}
 
+	if err = validateStakePoolSettings(blobber.StakePoolSettings, conf); err != nil {
+		return fmt.Errorf("invalid new stake pool settings:  %v", err)
+	}
+
 	// update stake pool settings
 	var sp *stakePool
 	if sp, err = sc.getStakePool(blobber.ID, balances); err != nil {
 		return fmt.Errorf("can't get stake pool:  %v", err)
 	}
 
-	if err = validateStakePoolSettings(blobber.StakePoolSettings, conf); err != nil {
-		return fmt.Errorf("invalid new stake pool settings:  %v", err)
+	stakedCapacity, err := sp.stakedCapacity(blobber.Terms.WritePrice)
+	if err != nil {
+		return fmt.Errorf("error calculating staked capacity: %v", err)
+	}
+
+	if blobber.Capacity < stakedCapacity {
+		return fmt.Errorf("write_price_change: staked capacity(%d) exceeding total_capacity(%d)",
+			stakedCapacity, blobber.Capacity)
 	}
 
 	sp.Settings.MinStake = blobber.StakePoolSettings.MinStake

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -787,8 +787,8 @@ func (sc *StorageSmartContract) blobberAddAllocation(txn *transaction.Transactio
 		return common.NewError("blobber_add_allocation",
 			"unable to fetch blobbers stake pool")
 	}
-	stakedAlloc := sp.cleanStake()
-	weight := uint64(stakedAlloc) * blobUsedCapacity
+	stakedAmount := sp.cleanStake()
+	weight := uint64(stakedAmount) * blobUsedCapacity
 
 	crbLoc, err := partitionsChallengeReadyBlobbersAdd(balances, txn.ClientID, weight)
 	if err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/block_reward.go
+++ b/code/go/0chain.net/smartcontract/storagesc/block_reward.go
@@ -181,7 +181,7 @@ func (ssc *StorageSmartContract) blobberBlockRewards(
 	}
 
 	if rewardBal > 0 {
-		rShare, rl, err := currency.DivideCoin(rewardBal, int64(len(stakePools)))
+		rShare, rl, err := currency.DistributeCoin(rewardBal, int64(len(stakePools)))
 		if err != nil {
 			return err
 		}

--- a/code/go/0chain.net/smartcontract/storagesc/challengepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challengepool.go
@@ -129,7 +129,7 @@ func (cp *challengePool) moveToValidators(sscKey string, reward currency.Coin,
 		return fmt.Errorf("not enough tokens in challenge pool: %v < %v", cp.Balance, reward)
 	}
 
-	oneReward, bal, err := currency.DivideCoin(reward, int64(len(validators)))
+	oneReward, bal, err := currency.DistributeCoin(reward, int64(len(validators)))
 	if err != nil {
 		return err
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -715,9 +715,9 @@ func (sa *StorageAllocation) validateAllocationBlobber(
 		return fmt.Errorf("blobber %s failed health check", blobber.ID)
 	}
 
-	if blobber.Terms.WritePrice > 0 && sp.cleanCapacity(now, blobber.Terms.WritePrice) < bSize {
+	if blobber.Terms.WritePrice > 0 && sp.cleanCapacity(blobber.Terms.WritePrice) < bSize {
 		return fmt.Errorf("blobber %v staked capacity %v is insufficent, wanted %v",
-			blobber.ID, sp.cleanCapacity(now, blobber.Terms.WritePrice), bSize)
+			blobber.ID, sp.cleanCapacity(blobber.Terms.WritePrice), bSize)
 	}
 
 	return nil

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -715,9 +715,9 @@ func (sa *StorageAllocation) validateAllocationBlobber(
 		return fmt.Errorf("blobber %s failed health check", blobber.ID)
 	}
 
-	if blobber.Terms.WritePrice > 0 && sp.cleanCapacity(blobber.Terms.WritePrice) < bSize {
+	if blobber.Terms.WritePrice > 0 && sp.unallocatedCapacity(blobber.Terms.WritePrice) < bSize {
 		return fmt.Errorf("blobber %v staked capacity %v is insufficent, wanted %v",
-			blobber.ID, sp.cleanCapacity(blobber.Terms.WritePrice), bSize)
+			blobber.ID, sp.unallocatedCapacity(blobber.Terms.WritePrice), bSize)
 	}
 
 	return nil

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool.go
@@ -232,9 +232,9 @@ func (sp *stakePool) slash(
 	return
 }
 
-// free staked capacity of related blobber, excluding delegate pools want to
+// unallocated capacity of related blobber, excluding delegate pools want to
 // unstake.
-func (sp *stakePool) cleanCapacity(writePrice currency.Coin) (free int64) {
+func (sp *stakePool) unallocatedCapacity(writePrice currency.Coin) (free int64) {
 
 	var total, offers = sp.cleanStake(), sp.TotalOffers
 	if total <= offers {
@@ -243,6 +243,21 @@ func (sp *stakePool) cleanCapacity(writePrice currency.Coin) (free int64) {
 	}
 	free = int64((float64(total-offers) / float64(writePrice)) * GB)
 	return
+}
+
+func (sp *stakePool) stakedCapacity(writePrice currency.Coin) (int64, error) {
+
+	cleanStake, err := sp.cleanStake().Float64()
+	if err != nil {
+		return 0, err
+	}
+
+	fWritePrice, err := writePrice.Float64()
+	if err != nil {
+		return 0, err
+	}
+
+	return int64((cleanStake / fWritePrice) * GB), nil
 }
 
 type delegatePoolStat struct {

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool.go
@@ -234,8 +234,7 @@ func (sp *stakePool) slash(
 
 // free staked capacity of related blobber, excluding delegate pools want to
 // unstake.
-func (sp *stakePool) cleanCapacity(now common.Timestamp,
-	writePrice currency.Coin) (free int64) {
+func (sp *stakePool) cleanCapacity(writePrice currency.Coin) (free int64) {
 
 	var total, offers = sp.cleanStake(), sp.TotalOffers
 	if total <= offers {

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool.go
@@ -239,8 +239,7 @@ func (sp *stakePool) cleanCapacity(now common.Timestamp,
 
 	var total, offers = sp.cleanStake(), sp.TotalOffers
 	if total <= offers {
-		// zero, since the offer stake (not updated) can be greater
-		// then the clean stake
+		// zero, since the offer stake (not updated) can be greater than the clean stake
 		return
 	}
 	free = int64((float64(total-offers) / float64(writePrice)) * GB)

--- a/docker.local/config/sc.yaml
+++ b/docker.local/config/sc.yaml
@@ -159,7 +159,7 @@ smart_contracts:
     # max prices for blobbers (tokens per GB)
     max_read_price: 100.0
     max_write_price: 100.0
-    # min_write_price: 0.1
+    min_write_price: 0.1
 
     max_blobbers_per_allocation: 40
     # allocation cancellation


### PR DESCRIPTION
## Fixes
- rename cleanCapacity to unallocatedCapacity

## Changes
-  in storagesc that token price config changes cannot be allowed to execute if staked capacity exceeds physical capacity.  e.g. if price of tokens doubles, and blobber halves the token/GB then the staked capacity can be more than physical capacity of the server disk drives
- enabled `min_write_price` config in sc.yaml storagesc

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
