### PR TITLE
TotalReward

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -1979,7 +1979,8 @@ type storageNodesResponse struct {
 // StorageNode represents Blobber configurations.
 type storageNodeResponse struct {
 	StorageNode
-	TotalStake currency.Coin `json:"total_stake"`
+	TotalServiceCharge currency.Coin `json:"total_service_charge"`
+	TotalStake         currency.Coin `json:"total_stake"`
 }
 
 func blobberTableToStorageNode(blobber event.Blobber) storageNodeResponse {
@@ -2014,7 +2015,8 @@ func blobberTableToStorageNode(blobber event.Blobber) storageNodeResponse {
 				Description: blobber.Description,
 			},
 		},
-		TotalStake: blobber.TotalStake,
+		TotalServiceCharge: blobber.TotalServiceCharge,
+		TotalStake:         blobber.TotalStake,
 	}
 }
 


### PR DESCRIPTION
## Fixes

## Changes
Add the total reward to blobber info returned for a query. (All-time rewards for blobber.)
```
curl --location -g --request GET http://192.168.1.100:7171/v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/getBlobber?blobber_id=7a90e6790bcd3d78422d7a230390edc102870fe58c15472073922024985b1c7d | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   821  100   821    0     0   801k      0 --:--:-- --:--:-- --:--:--  801k
{
    "allocated": 5243393,
...
    "total_service_charge": 6694755184,
    "total_stake": 4000000000,
    "url": "http://198.18.0.92:5052"
}
```
total_service_charge gives the lifetime reward.
## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
