### PR TITLE
random RegisterNode (Sharder)

### DIFF
--- a/code/go/0chain.net/chaincore/chain/handler.go
+++ b/code/go/0chain.net/chaincore/chain/handler.go
@@ -1297,8 +1297,11 @@ func (c *Chain) N2NStatsWriter(w http.ResponseWriter, r *http.Request) {
 func PutTransaction(ctx context.Context, entity datastore.Entity) (interface{}, error) {
 	txn, ok := entity.(*transaction.Transaction)
 	if !ok {
-		return nil, fmt.Errorf("invalid request %T", entity)
+		return nil, fmt.Errorf("put_transaction: invalid request %T", entity)
 	}
+
+	logging.Logger.Info("put_transaction",
+		zap.Any("transaction", txn))
 
 	sc := GetServerChain()
 	if sc.TxnMaxPayload() > 0 {

--- a/code/go/0chain.net/chaincore/chain/handler.go
+++ b/code/go/0chain.net/chaincore/chain/handler.go
@@ -1300,9 +1300,6 @@ func PutTransaction(ctx context.Context, entity datastore.Entity) (interface{}, 
 		return nil, fmt.Errorf("put_transaction: invalid request %T", entity)
 	}
 
-	logging.Logger.Info("put_transaction",
-		zap.Any("transaction", txn))
-
 	sc := GetServerChain()
 	if sc.TxnMaxPayload() > 0 {
 		if len(txn.TransactionData) > sc.TxnMaxPayload() {

--- a/code/go/0chain.net/chaincore/chain/protocol_view_change.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change.go
@@ -276,7 +276,9 @@ func (c *Chain) RegisterNode() (*httpclientutil.Transaction, error) {
 	txn.PublicKey = selfNode.PublicKey
 	mb := c.GetCurrentMagicBlock()
 	var minerUrls = mb.Miners.N2NURLs()
-	logging.Logger.Debug("Register nodes to", zap.Strings("urls", minerUrls))
+	logging.Logger.Debug("Register nodes to",
+		zap.Strings("urls", minerUrls),
+		zap.String("id", mn.ID))
 	err = httpclientutil.SendSmartContractTxn(txn, minersc.ADDRESS, 0, 0, scData, minerUrls, mb.Sharders.N2NURLs())
 	return txn, err
 }

--- a/code/go/0chain.net/chaincore/chain/protocol_view_change.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change.go
@@ -183,14 +183,20 @@ func (c *Chain) isRegisteredEx(ctx context.Context, getStatePath func(n *node.No
 	return false
 }
 
-func (c *Chain) ConfirmTransaction(ctx context.Context, t *httpclientutil.Transaction) bool {
+// ConfirmTransaction adding a new parameter timeout as we're not sure what all it can break
+// without making a lot of changes, to fix a confirmTransaction in SetupSC a new param timeout is added
+// if value 0 is passed it'll work like earlier, but anything apart from 0 will result in setting that as timeout
+func (c *Chain) ConfirmTransaction(ctx context.Context, t *httpclientutil.Transaction, timeoutSec int64) bool {
+	if timeoutSec == 0 {
+		timeoutSec = transaction.TXN_TIME_TOLERANCE
+	}
 	var (
 		active = c.IsActiveInChain()
 		mb     = c.GetCurrentMagicBlock()
 
 		found, pastTime bool
 		urls            []string
-		cctx, cancel    = context.WithTimeout(ctx, time.Duration(transaction.TXN_TIME_TOLERANCE)*time.Second)
+		cctx, cancel    = context.WithTimeout(ctx, time.Duration(timeoutSec)*time.Second)
 	)
 
 	defer cancel()

--- a/code/go/0chain.net/chaincore/chain/protocol_view_change_integration_tests.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change_integration_tests.go
@@ -61,7 +61,7 @@ func (c *Chain) SetupSC(ctx context.Context) {
 					return
 				}
 
-				if txn != nil && c.ConfirmTransaction(ctx, txn) {
+				if txn != nil && c.ConfirmTransaction(ctx, txn, 0) {
 					logging.Logger.Debug("Register node transaction confirmed")
 					return
 				}

--- a/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
@@ -26,7 +26,10 @@ func (c *Chain) SetupSC(ctx context.Context) {
 			func() {
 				isRegisteredC := make(chan bool)
 				cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				defer cancel()
+				defer func() {
+					logging.Logger.Info("cancelling setup sc context")
+					cancel()
+				}()
 
 				go func() {
 					isRegistered := c.isRegistered(cctx)

--- a/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
@@ -14,7 +14,7 @@ import (
 func (c *Chain) SetupSC(ctx context.Context) {
 	logging.Logger.Info("SetupSC start...")
 	// create timer with 0 duration to start it immediately
-	tm := time.NewTimer(0)
+	tm := time.NewTimer(5 * time.Second)
 	for {
 		select {
 		case <-ctx.Done():

--- a/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
@@ -14,7 +14,7 @@ import (
 func (c *Chain) SetupSC(ctx context.Context) {
 	logging.Logger.Info("SetupSC start...")
 	// create timer with 0 duration to start it immediately
-	tm := time.NewTimer(5 * time.Second)
+	tm := time.NewTimer(0)
 	for {
 		select {
 		case <-ctx.Done():

--- a/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
@@ -59,7 +59,7 @@ func (c *Chain) SetupSC(ctx context.Context) {
 					return
 				}
 
-				if txn != nil && c.ConfirmTransaction(ctx, txn) {
+				if txn != nil && c.ConfirmTransaction(ctx, txn, 30) {
 					logging.Logger.Debug("Register node transaction confirmed")
 					return
 				}

--- a/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
+++ b/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
@@ -151,6 +151,9 @@ func SendTransaction(txn *Transaction, urls []string, ID string, pkey string) {
 		txnURL := fmt.Sprintf("%v/%v", u, txnSubmitURL)
 		go func(url string) {
 			if _, err := sendTransactionToURL(url, txn, ID, pkey, nil); err != nil {
+				logging.Logger.Error("send transaction failed",
+					zap.String("url", url),
+					zap.Error(err))
 				logging.N2n.Error("send transaction failed",
 					zap.String("url", url),
 					zap.Error(err))

--- a/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
+++ b/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
@@ -145,7 +145,8 @@ func SendTransaction(txn *Transaction, urls []string, ID string, pkey string) {
 	logging.Logger.Info("send_transaction",
 		zap.Strings("urls", urls),
 		zap.String("id", ID),
-		zap.String("p_key", pkey))
+		zap.String("p_key", pkey),
+		zap.String("txn_data", txn.TransactionData))
 	for _, u := range urls {
 		txnURL := fmt.Sprintf("%v/%v", u, txnSubmitURL)
 		go func(url string) {

--- a/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
+++ b/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
@@ -146,7 +146,7 @@ func SendTransaction(txn *Transaction, urls []string, ID string, pkey string) {
 		zap.Strings("urls", urls),
 		zap.String("id", ID),
 		zap.String("p_key", pkey),
-		zap.String("txn_data", txn.TransactionData))
+		zap.Any("txn", *txn))
 	for _, u := range urls {
 		txnURL := fmt.Sprintf("%v/%v", u, txnSubmitURL)
 		go func(url string) {

--- a/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
+++ b/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
@@ -142,11 +142,6 @@ func SendPostRequest(url string, data []byte, ID string, pkey string, wg *sync.W
 
 //SendTransaction send a transaction
 func SendTransaction(txn *Transaction, urls []string, ID string, pkey string) {
-	logging.Logger.Info("send_transaction",
-		zap.Strings("urls", urls),
-		zap.String("id", ID),
-		zap.String("p_key", pkey),
-		zap.Any("txn", *txn))
 	for _, u := range urls {
 		txnURL := fmt.Sprintf("%v/%v", u, txnSubmitURL)
 		go func(url string) {

--- a/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
+++ b/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
@@ -142,6 +142,10 @@ func SendPostRequest(url string, data []byte, ID string, pkey string, wg *sync.W
 
 //SendTransaction send a transaction
 func SendTransaction(txn *Transaction, urls []string, ID string, pkey string) {
+	logging.Logger.Info("send_transaction",
+		zap.Strings("urls", urls),
+		zap.String("id", ID),
+		zap.String("p_key", pkey))
 	for _, u := range urls {
 		txnURL := fmt.Sprintf("%v/%v", u, txnSubmitURL)
 		go func(url string) {

--- a/code/go/0chain.net/miner/protocol_view_change.go
+++ b/code/go/0chain.net/miner/protocol_view_change.go
@@ -217,7 +217,7 @@ func (mc *Chain) DKGProcess(ctx context.Context) {
 			zap.Any("next_phase", pn),
 			zap.Any("txn", txn))
 
-		if txn == nil || (txn != nil && mc.ConfirmTransaction(ctx, txn)) {
+		if txn == nil || (txn != nil && mc.ConfirmTransaction(ctx, txn, 0)) {
 			prevPhase := mc.CurrentPhase()
 			mc.SetCurrentPhase(pn.Phase)
 			phaseStartRound = pn.StartRound

--- a/code/go/0chain.net/sharder/sharder/main.go
+++ b/code/go/0chain.net/sharder/sharder/main.go
@@ -310,7 +310,7 @@ func main() {
 
 	go sc.RegisterClient()
 	if sc.ChainConfig.IsFeeEnabled() {
-		logging.Logger.Info("setting up sharder")
+		logging.Logger.Info("setting up sharder(sc)")
 		go sc.SetupSC(ctx)
 	}
 

--- a/code/go/0chain.net/sharder/sharder/main.go
+++ b/code/go/0chain.net/sharder/sharder/main.go
@@ -237,7 +237,7 @@ func main() {
 			Logger.Panic("Failed to read initialStates", zap.Any("Error", initStateErr))
 		}
 	}
-	if node.NodeType(selfNode.Type) != node.NodeTypeSharder {
+	if selfNode.Type != node.NodeTypeSharder {
 		Logger.Panic("node not configured as sharder")
 	}
 

--- a/code/go/0chain.net/sharder/sharder/main.go
+++ b/code/go/0chain.net/sharder/sharder/main.go
@@ -310,6 +310,7 @@ func main() {
 
 	go sc.RegisterClient()
 	if sc.ChainConfig.IsFeeEnabled() {
+		logging.Logger.Info("setting up sharder")
 		go sc.SetupSC(ctx)
 	}
 

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -351,7 +351,7 @@ func (sc *Chain) RegisterSharderKeepWorker(ctx context.Context) {
 
 		// so, transaction sent, let's verify it
 
-		if !sc.ConfirmTransaction(ctx, txn) {
+		if !sc.ConfirmTransaction(ctx, txn, 0) {
 			logging.Logger.Debug("register_sharder_keep_worker -- failed "+
 				"to confirm transaction", zap.Any("txn", txn))
 			continue

--- a/code/go/0chain.net/smartcontract/minersc/sharder.go
+++ b/code/go/0chain.net/smartcontract/minersc/sharder.go
@@ -127,6 +127,7 @@ func (msc *MinerSmartContract) AddSharder(
 	if err == nil {
 		// and found in all
 		if allSharders.FindNodeById(newSharder.ID) != nil {
+			logging.Logger.Info("add_sharder: found node by id")
 			return string(newSharder.Encode()), nil
 		}
 		// otherwise the sharder has saved by block sharders reward


### PR DESCRIPTION
## Fixes
- fixed sharder registration delay in case miners were not up in network

## Changes
- confirm transaction was blocking goroutine for `server_chain.transaction.timeout`
- if transaction.timeout was long, delay for retry of register sharder would be long.
- clients confirm txn timeout is now independent of transaction.timeout in global config

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
