### PR TITLE
Fix storagesc update settings

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/config_settigns.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config_settigns.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"0chain.net/core/logging"
+	"go.uber.org/zap"
+
 	"0chain.net/chaincore/currency"
 
 	"0chain.net/chaincore/smartcontractinterface"
@@ -844,6 +847,9 @@ func (ssc *StorageSmartContract) updateSettings(
 	}
 
 	if err := smartcontractinterface.AuthorizeWithOwner("update_settings", func() bool {
+		logging.Logger.Info("storagesc_update_settings",
+			zap.String("owner", conf.OwnerId),
+			zap.String("txn_client", t.ClientID))
 		return conf.OwnerId == t.ClientID
 	}); err != nil {
 		return "", err

--- a/code/go/0chain.net/smartcontract/storagesc/config_settigns.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config_settigns.go
@@ -880,7 +880,12 @@ func (ssc *StorageSmartContract) updateSettings(
 
 	_, err = balances.InsertTrieNode(settingChangesKey, updateChanges)
 	if err != nil {
-		return "", common.NewError("update_settings", err.Error())
+		return "", common.NewError("update_settings save changes", err.Error())
+	}
+
+	_, err = balances.InsertTrieNode(scConfigKey(ssc.ID), conf)
+	if err != nil {
+		return "", common.NewError("update_settings save config", err.Error())
 	}
 
 	return "", nil

--- a/code/go/0chain.net/smartcontract/storagesc/config_settings_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config_settings_test.go
@@ -98,6 +98,14 @@ func TestUpdateSettings(t *testing.T) {
 				return true
 			})).Return(nil).Once()
 
+		err := conf.update(*expected)
+		require.NoError(t, err)
+
+		balances.On(
+			"InsertTrieNode",
+			scConfigKey(ssc.ID), conf,
+		).Return("", nil).Once()
+
 		return args{
 			ssc:      ssc,
 			txn:      txn,


### PR DESCRIPTION
## Fixes
- after updating settings, config was not stored in MPT

## Changes
- Saving config in MPT on update_settings

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
