### PR TITLE
fixed client event wrong ordering

### DIFF
--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -709,9 +709,9 @@ func (c *Chain) emitUserEvent(sc bcstate.StateContextI, usr *event.User) error {
 		return nil
 	}
 
-	sc.EmitEvent(event.TypeStats, event.TagAddOrOverwriteUser, "", usr, func(events []event.Event, current event.Event) []event.Event {
-		return append([]event.Event{current}, events...)
-	})
-
+	//sc.EmitEvent(event.TypeStats, event.TagAddOrOverwriteUser, "", usr, func(events []event.Event, current event.Event) []event.Event {
+	//	return append([]event.Event{current}, events...)
+	//})
+	sc.EmitEvent(event.TypeStats, event.TagAddOrOverwriteUser, "", usr)
 	return nil
 }

--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -334,9 +334,10 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		}
 	}
 
+	ue := make(map[string]*event.User)
 	for _, transfer := range sctx.GetTransfers() {
-		err = c.transferAmount(sctx, transfer.ClientID, transfer.ToClientID, transfer.Amount)
-		if err != nil {
+		tEvents, er := c.transferAmount(sctx, transfer.ClientID, transfer.ToClientID, transfer.Amount)
+		if er != nil {
 			logging.Logger.Error("Failed to transfer amount",
 				zap.Any("txn type", txn.TransactionType),
 				zap.String("txn data", txn.TransactionData),
@@ -346,37 +347,58 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				zap.Error(err))
 			return
 		}
+		for _, e := range tEvents {
+			ue[e.UserID] = e
+		}
 	}
 
 	for _, signedTransfer := range sctx.GetSignedTransfers() {
-		err = c.transferAmount(sctx, signedTransfer.ClientID,
+		tEvents, er := c.transferAmount(sctx, signedTransfer.ClientID,
 			signedTransfer.ToClientID, signedTransfer.Amount)
-		if err != nil {
+		if er != nil {
 			logging.Logger.Error("Failed to process signed transfer",
 				zap.Any("signedTransfer_ClientID", signedTransfer.ClientID),
 				zap.Any("signedTransfer_to_ClientID", signedTransfer.ToClientID),
 				zap.Any("signedTransfer_amount", signedTransfer.Amount))
 			return
 		}
+		for _, e := range tEvents {
+			ue[e.UserID] = e
+		}
 	}
 
 	for _, mint := range sctx.GetMints() {
-		err = c.mintAmount(sctx, mint.ToClientID, mint.Amount)
-		if err != nil {
+		u, er := c.mintAmount(sctx, mint.ToClientID, mint.Amount)
+		if er != nil {
 			logging.Logger.Error("mint error", zap.Any("error", err),
 				zap.Any("transaction", txn.Hash),
 				zap.String("to clientID", mint.ToClientID))
 			return
 		}
+		if u != nil {
+			ue[u.UserID] = u
+		}
 	}
 
-	if err = c.incrementNonce(sctx, txn.ClientID); err != nil {
+	u, err := c.incrementNonce(sctx, txn.ClientID)
+	if err != nil {
 		logging.Logger.Error("update nonce error", zap.Any("error", err),
 			zap.Any("transaction", txn.Hash),
 			zap.String("clientID", txn.ClientID))
 		return
 	}
+	if u != nil {
+		ue[u.UserID] = u
+	}
 
+	for _, e := range ue {
+		if err = c.emitUserEvent(sctx, e); err != nil {
+			logging.Logger.Error("could not emit event", zap.Any("error", err),
+				zap.Any("transaction", txn.Hash),
+				zap.String("clientID", txn.ClientID))
+			return
+		}
+	}
 	// commit transaction
 	if err = bState.MergeMPTChanges(clientState); err != nil {
 		if state.DebugTxn() {
@@ -423,12 +445,12 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 *   when there is an error getting the state of the from or to account (other than no value), the error is simply returned back
 *   when there is an error inserting/deleting the state of the from or to account, this results in fatal error when state is enabled
  */
-func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient datastore.Key, amount currency.Coin) error {
+func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient datastore.Key, amount currency.Coin) ([]*event.User, error) {
 	if amount == 0 {
-		return nil
+		return nil, nil
 	}
 	if fromClient == toClient {
-		return common.InvalidRequest("from and to client should be different for balance transfer")
+		return nil, common.InvalidRequest("from and to client should be different for balance transfer")
 	}
 	b := sctx.GetBlock()
 	clientState := sctx.GetState()
@@ -447,13 +469,13 @@ func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient 
 			block.PrintStates(clientState, b.ClientState)
 			logging.Logger.DPanic(fmt.Sprintf("transfer amount - error getting state value: %v %v", fromClient, err))
 		}
-		return err
+		return nil, err
 	}
 	if fs.Balance < amount {
 		logging.Logger.Error("transfer amount - insufficient balance",
 			zap.Any("balance", fs.Balance),
 			zap.Any("transfer", amount))
-		return transaction.ErrInsufficientBalance
+		return nil, transaction.ErrInsufficientBalance
 	}
 	ts, err := c.GetStateById(clientState, toClient)
 	if !isValid(err) {
@@ -469,7 +491,7 @@ func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient 
 			block.PrintStates(clientState, b.ClientState)
 			logging.Logger.DPanic(fmt.Sprintf("transfer amount - error getting state value: %v %v", toClient, err))
 		}
-		return err
+		return nil, err
 	}
 
 	if err := sctx.SetStateContext(fs); err != nil {
@@ -477,7 +499,7 @@ func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient 
 			zap.Int64("round", b.Round),
 			zap.String("state txn hash", fs.TxnHash),
 			zap.Error(err))
-		return err
+		return nil, err
 	}
 	fs.Balance -= amount
 	_, err = clientState.Insert(util.Path(fromClient), fs)
@@ -490,14 +512,14 @@ func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient 
 				logging.Logger.Error("transfer amount - error", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Any("txn", txn), zap.Error(err))
 			}
 		}
-		return err
+		return nil, err
 	}
 	if err := sctx.SetStateContext(ts); err != nil {
 		logging.Logger.Error("transfer amount - set state context failed",
 			zap.Int64("round", b.Round),
 			zap.String("state txn hash", fs.TxnHash),
 			zap.Error(err))
-		return err
+		return nil, err
 	}
 	ts.Balance += amount
 	_, err = clientState.Insert(util.Path(toClient), ts)
@@ -510,23 +532,15 @@ func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient 
 				logging.Logger.Error("transfer amount - error", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Any("txn", txn), zap.Error(err))
 			}
 		}
-		return err
+		return nil, err
 	}
 
-	if err = c.emitUserEvent(sctx, stateToUser(fromClient, fs)); err != nil {
-		return common.NewError("transfer_amount", "could not emit event")
-	}
-
-	if err = c.emitUserEvent(sctx, stateToUser(toClient, ts)); err != nil {
-		return common.NewError("transfer_amount", "could not emit event")
-	}
-
-	return nil
+	return []*event.User{stateToUser(fromClient, fs), stateToUser(toClient, ts)}, nil
 }
 
-func (c *Chain) mintAmount(sctx bcstate.StateContextI, toClient datastore.Key, amount currency.Coin) error {
+func (c *Chain) mintAmount(sctx bcstate.StateContextI, toClient datastore.Key, amount currency.Coin) (*event.User, error) {
 	if amount == 0 {
-		return nil
+		return nil, nil
 	}
 	b := sctx.GetBlock()
 	clientState := sctx.GetState()
@@ -548,13 +562,13 @@ func (c *Chain) mintAmount(sctx bcstate.StateContextI, toClient datastore.Key, a
 		if state.Debug() {
 			logging.Logger.Error("transfer amount - error", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Any("txn", txn), zap.Error(err))
 		}
-		return common.NewError("mint_amount - get state", err.Error())
+		return nil, common.NewError("mint_amount - get state", err.Error())
 	}
 	if err := sctx.SetStateContext(ts); err != nil {
 		logging.Logger.Error("transfer amount - set state context failed",
 			zap.String("txn hash", ts.TxnHash),
 			zap.Error(err))
-		return err
+		return nil, err
 	}
 
 	ts.Balance += amount
@@ -577,14 +591,10 @@ func (c *Chain) mintAmount(sctx bcstate.StateContextI, toClient datastore.Key, a
 		if state.Debug() {
 			logging.Logger.Error("transfer amount - error", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Any("txn", txn), zap.Error(err))
 		}
-		return common.NewError("mint_amount - insert", err.Error())
+		return nil, common.NewError("mint_amount - insert", err.Error())
 	}
 
-	if err = c.emitUserEvent(sctx, stateToUser(toClient, ts)); err != nil {
-		return common.NewError("mint_amount", "could not emit event")
-	}
-
-	return nil
+	return stateToUser(toClient, ts), nil
 }
 
 func (c *Chain) validateNonce(sctx bcstate.StateContextI, fromClient datastore.Key, txnNonce int64) error {
@@ -607,29 +617,25 @@ func (c *Chain) validateNonce(sctx bcstate.StateContextI, fromClient datastore.K
 	return nil
 }
 
-func (c *Chain) incrementNonce(sctx bcstate.StateContextI, fromClient datastore.Key) error {
+func (c *Chain) incrementNonce(sctx bcstate.StateContextI, fromClient datastore.Key) (*event.User, error) {
 	sc := sctx.GetState()
 	s, err := c.GetStateById(sc, fromClient)
 	if !isValid(err) {
-		return err
+		return nil, err
 	}
 	if s == nil {
 		s = &state.State{}
 	}
 	if err := sctx.SetStateContext(s); err != nil {
-		return err
+		return nil, err
 	}
 	s.Nonce += 1
 	if _, err := sc.Insert(util.Path(fromClient), s); err != nil {
-		return err
+		return nil, err
 	}
 	logging.Logger.Debug("Updating nonce", zap.String("client", fromClient), zap.Int64("new_nonce", s.Nonce))
 
-	if err = c.emitUserEvent(sctx, stateToUser(fromClient, s)); err != nil {
-		return common.NewError("increment_nonce", "could not emit event")
-	}
-
-	return nil
+	return stateToUser(fromClient, s), nil
 }
 
 func CreateTxnMPT(mpt util.MerklePatriciaTrieI) util.MerklePatriciaTrieI {

--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -709,7 +709,9 @@ func (c *Chain) emitUserEvent(sc bcstate.StateContextI, usr *event.User) error {
 		return nil
 	}
 
-	sc.EmitEvent(event.TypeStats, event.TagAddOrOverwriteUser, "", usr)
+	sc.EmitEvent(event.TypeStats, event.TagAddOrOverwriteUser, "", usr, func(events []event.Event, current event.Event) []event.Event {
+		return append([]event.Event{current}, events...)
+	})
 
 	return nil
 }

--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -709,9 +709,8 @@ func (c *Chain) emitUserEvent(sc bcstate.StateContextI, usr *event.User) error {
 		return nil
 	}
 
-	//sc.EmitEvent(event.TypeStats, event.TagAddOrOverwriteUser, "", usr, func(events []event.Event, current event.Event) []event.Event {
-	//	return append([]event.Event{current}, events...)
-	//})
-	sc.EmitEvent(event.TypeStats, event.TagAddOrOverwriteUser, "", usr)
+	sc.EmitEvent(event.TypeStats, event.TagAddOrOverwriteUser, "", usr, func(events []event.Event, current event.Event) []event.Event {
+		return append([]event.Event{current}, events...)
+	})
 	return nil
 }

--- a/code/go/0chain.net/smartcontract/minersc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/minersc/balances_test.go
@@ -3,6 +3,7 @@ package minersc
 import (
 	"testing"
 
+	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/currency"
 
 	"0chain.net/chaincore/block"
@@ -69,18 +70,19 @@ func (tb *testBalances) GetBlockSharders(*block.Block) []string {
 }
 
 // stubs
-func (tb *testBalances) GetState() util.MerklePatriciaTrieI                             { return nil }
-func (tb *testBalances) GetTransaction() *transaction.Transaction                       { return nil }
-func (tb *testBalances) Validate() error                                                { return nil }
-func (tb *testBalances) GetMints() []*state.Mint                                        { return nil }
-func (tb *testBalances) SetStateContext(*state.State) error                             { return nil }
-func (tb *testBalances) GetTransfers() []*state.Transfer                                { return nil }
-func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer)                     {}
-func (tb *testBalances) GetEventDB() *event.EventDb                                     { return nil }
-func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, interface{}) {}
-func (tb *testBalances) EmitError(error)                                                {}
-func (tb *testBalances) GetEvents() []event.Event                                       { return nil }
-func (tb *testBalances) GetLatestFinalizedBlock() *block.Block                          { return nil }
+func (tb *testBalances) GetState() util.MerklePatriciaTrieI         { return nil }
+func (tb *testBalances) GetTransaction() *transaction.Transaction   { return nil }
+func (tb *testBalances) Validate() error                            { return nil }
+func (tb *testBalances) GetMints() []*state.Mint                    { return nil }
+func (tb *testBalances) SetStateContext(*state.State) error         { return nil }
+func (tb *testBalances) GetTransfers() []*state.Transfer            { return nil }
+func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer) {}
+func (tb *testBalances) GetEventDB() *event.EventDb                 { return nil }
+func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, interface{}, ...cstate.Appender) {
+}
+func (tb *testBalances) EmitError(error)                       {}
+func (tb *testBalances) GetEvents() []event.Event              { return nil }
+func (tb *testBalances) GetLatestFinalizedBlock() *block.Block { return nil }
 func (tb *testBalances) GetSignedTransfers() []*state.SignedTransfer {
 	return nil
 }

--- a/code/go/0chain.net/smartcontract/minersc/helper2_test.go
+++ b/code/go/0chain.net/smartcontract/minersc/helper2_test.go
@@ -41,7 +41,7 @@ func (sc *mockStateContext) GetClientBalance(_ datastore.Key) (currency.Coin, er
 	return 0, nil
 }
 func (sc *mockStateContext) GetChainCurrentMagicBlock() *block.MagicBlock { return nil }
-func (sc *mockStateContext) EmitEvent(eventType event.EventType, tag event.EventTag, index string, data interface{}) {
+func (sc *mockStateContext) EmitEvent(eventType event.EventType, tag event.EventTag, index string, data interface{}, appender ...cstate.Appender) {
 	sc.events = append(sc.events, event.Event{
 		BlockNumber: sc.block.Round,
 		Type:        int(eventType),

--- a/code/go/0chain.net/smartcontract/stakepool/balances_test.go
+++ b/code/go/0chain.net/smartcontract/stakepool/balances_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/currency"
 
 	"0chain.net/smartcontract/dbs/event"
@@ -66,23 +67,24 @@ func (tb *testBalances) GetTransaction() *transaction.Transaction {
 }
 
 // stubs
-func (tb *testBalances) GetBlock() *block.Block                                         { return &block.Block{} }
-func (tb *testBalances) GetState() util.MerklePatriciaTrieI                             { return nil }
-func (tb *testBalances) GetBlockSharders(b *block.Block) []string                       { return nil }
-func (tb *testBalances) Validate() error                                                { return nil }
-func (tb *testBalances) GetMints() []*state.Mint                                        { return nil }
-func (tb *testBalances) SetStateContext(*state.State) error                             { return nil }
-func (tb *testBalances) AddMint(*state.Mint) error                                      { return nil }
-func (tb *testBalances) GetTransfers() []*state.Transfer                                { return nil }
-func (tb *testBalances) SetMagicBlock(block *block.MagicBlock)                          {}
-func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer)                     {}
-func (tb *testBalances) GetSignedTransfers() []*state.SignedTransfer                    { return nil }
-func (tb *testBalances) GetEventDB() *event.EventDb                                     { return nil }
-func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, interface{}) {}
-func (tb *testBalances) EmitError(error)                                                {}
-func (tb *testBalances) GetEvents() []event.Event                                       { return nil }
-func (tb *testBalances) GetChainCurrentMagicBlock() *block.MagicBlock                   { return nil }
-func (tb *testBalances) GetLatestFinalizedBlock() *block.Block                          { return nil }
+func (tb *testBalances) GetBlock() *block.Block                      { return &block.Block{} }
+func (tb *testBalances) GetState() util.MerklePatriciaTrieI          { return nil }
+func (tb *testBalances) GetBlockSharders(b *block.Block) []string    { return nil }
+func (tb *testBalances) Validate() error                             { return nil }
+func (tb *testBalances) GetMints() []*state.Mint                     { return nil }
+func (tb *testBalances) SetStateContext(*state.State) error          { return nil }
+func (tb *testBalances) AddMint(*state.Mint) error                   { return nil }
+func (tb *testBalances) GetTransfers() []*state.Transfer             { return nil }
+func (tb *testBalances) SetMagicBlock(block *block.MagicBlock)       {}
+func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer)  {}
+func (tb *testBalances) GetSignedTransfers() []*state.SignedTransfer { return nil }
+func (tb *testBalances) GetEventDB() *event.EventDb                  { return nil }
+func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, interface{}, ...cstate.Appender) {
+}
+func (tb *testBalances) EmitError(error)                              {}
+func (tb *testBalances) GetEvents() []event.Event                     { return nil }
+func (tb *testBalances) GetChainCurrentMagicBlock() *block.MagicBlock { return nil }
+func (tb *testBalances) GetLatestFinalizedBlock() *block.Block        { return nil }
 func (tb *testBalances) DeleteTrieNode(key datastore.Key) (datastore.Key, error) {
 
 	if tb.mpts != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/balances_test.go
@@ -3,6 +3,7 @@ package storagesc
 import (
 	"testing"
 
+	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/currency"
 
 	"0chain.net/smartcontract/dbs/event"
@@ -65,23 +66,24 @@ func (tb *testBalances) GetTransaction() *transaction.Transaction {
 }
 
 // stubs
-func (tb *testBalances) GetBlock() *block.Block                                         { return &block.Block{} }
-func (tb *testBalances) GetState() util.MerklePatriciaTrieI                             { return nil }
-func (tb *testBalances) GetBlockSharders(b *block.Block) []string                       { return nil }
-func (tb *testBalances) Validate() error                                                { return nil }
-func (tb *testBalances) GetMints() []*state.Mint                                        { return nil }
-func (tb *testBalances) SetStateContext(*state.State) error                             { return nil }
-func (tb *testBalances) AddMint(*state.Mint) error                                      { return nil }
-func (tb *testBalances) GetTransfers() []*state.Transfer                                { return nil }
-func (tb *testBalances) SetMagicBlock(block *block.MagicBlock)                          {}
-func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer)                     {}
-func (tb *testBalances) GetSignedTransfers() []*state.SignedTransfer                    { return nil }
-func (tb *testBalances) GetEventDB() *event.EventDb                                     { return nil }
-func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, interface{}) {}
-func (tb *testBalances) EmitError(error)                                                {}
-func (tb *testBalances) GetEvents() []event.Event                                       { return nil }
-func (tb *testBalances) GetChainCurrentMagicBlock() *block.MagicBlock                   { return nil }
-func (tb *testBalances) GetLatestFinalizedBlock() *block.Block                          { return nil }
+func (tb *testBalances) GetBlock() *block.Block                      { return &block.Block{} }
+func (tb *testBalances) GetState() util.MerklePatriciaTrieI          { return nil }
+func (tb *testBalances) GetBlockSharders(b *block.Block) []string    { return nil }
+func (tb *testBalances) Validate() error                             { return nil }
+func (tb *testBalances) GetMints() []*state.Mint                     { return nil }
+func (tb *testBalances) SetStateContext(*state.State) error          { return nil }
+func (tb *testBalances) AddMint(*state.Mint) error                   { return nil }
+func (tb *testBalances) GetTransfers() []*state.Transfer             { return nil }
+func (tb *testBalances) SetMagicBlock(block *block.MagicBlock)       {}
+func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer)  {}
+func (tb *testBalances) GetSignedTransfers() []*state.SignedTransfer { return nil }
+func (tb *testBalances) GetEventDB() *event.EventDb                  { return nil }
+func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, interface{}, ...cstate.Appender) {
+}
+func (tb *testBalances) EmitError(error)                              {}
+func (tb *testBalances) GetEvents() []event.Event                     { return nil }
+func (tb *testBalances) GetChainCurrentMagicBlock() *block.MagicBlock { return nil }
+func (tb *testBalances) GetLatestFinalizedBlock() *block.Block        { return nil }
 func (tb *testBalances) DeleteTrieNode(key datastore.Key) (datastore.Key, error) {
 
 	if tb.mpts != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -1542,7 +1542,7 @@ func (srh *StorageRestHandler) getAllocations(w http.ResponseWriter, r *http.Req
 // Gets allocation object
 //
 // parameters:
-//    + name: transaction_hash
+//    + name: allocation
 //      description: offset
 //      required: true
 //      in: query

--- a/code/go/0chain.net/smartcontract/storagesc/helper2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/helper2_test.go
@@ -52,14 +52,15 @@ func (sc *mockStateContext) GetSignatureScheme() encryption.SignatureScheme {
 	return encryption.NewBLS0ChainScheme()
 }
 
-func (tb *mockStateContext) EmitEvent(event.EventType, event.EventTag, string, interface{}) {}
-func (sc *mockStateContext) EmitError(error)                                                {}
-func (sc *mockStateContext) GetEvents() []event.Event                                       { return nil }
-func (tb *mockStateContext) GetEventDB() *event.EventDb                                     { return nil }
-func (sc *mockStateContext) AddSignedTransfer(_ *state.SignedTransfer)                      {}
-func (sc *mockStateContext) DeleteTrieNode(_ datastore.Key) (datastore.Key, error)          { return "", nil }
-func (sc *mockStateContext) GetChainCurrentMagicBlock() *block.MagicBlock                   { return nil }
-func (sc *mockStateContext) GetLatestFinalizedBlock() *block.Block                          { return nil }
+func (tb *mockStateContext) EmitEvent(event.EventType, event.EventTag, string, interface{}, ...cstate.Appender) {
+}
+func (sc *mockStateContext) EmitError(error)                                       {}
+func (sc *mockStateContext) GetEvents() []event.Event                              { return nil }
+func (tb *mockStateContext) GetEventDB() *event.EventDb                            { return nil }
+func (sc *mockStateContext) AddSignedTransfer(_ *state.SignedTransfer)             {}
+func (sc *mockStateContext) DeleteTrieNode(_ datastore.Key) (datastore.Key, error) { return "", nil }
+func (sc *mockStateContext) GetChainCurrentMagicBlock() *block.MagicBlock          { return nil }
+func (sc *mockStateContext) GetLatestFinalizedBlock() *block.Block                 { return nil }
 func (sc *mockStateContext) GetClientBalance(_ datastore.Key) (currency.Coin, error) {
 	return sc.clientBalance, nil
 }

--- a/code/go/0chain.net/smartcontract/vestingsc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/balances_test.go
@@ -2,6 +2,7 @@ package vestingsc
 
 import (
 	"0chain.net/chaincore/block"
+	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/currency"
 	"0chain.net/chaincore/state"
 	"0chain.net/chaincore/transaction"
@@ -35,23 +36,24 @@ func (tb *testBalances) setBalance(key datastore.Key, b currency.Coin) { //nolin
 }
 
 // stubs
-func (tb *testBalances) GetBlock() *block.Block                                         { return nil }
-func (tb *testBalances) GetState() util.MerklePatriciaTrieI                             { return nil }
-func (tb *testBalances) GetTransaction() *transaction.Transaction                       { return nil }
-func (tb *testBalances) GetBlockSharders(b *block.Block) []string                       { return nil }
-func (tb *testBalances) Validate() error                                                { return nil }
-func (tb *testBalances) GetMints() []*state.Mint                                        { return nil }
-func (tb *testBalances) SetStateContext(*state.State) error                             { return nil }
-func (tb *testBalances) AddMint(*state.Mint) error                                      { return nil }
-func (tb *testBalances) GetTransfers() []*state.Transfer                                { return nil }
-func (tb *testBalances) GetChainCurrentMagicBlock() *block.MagicBlock                   { return nil }
-func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer)                     {}
-func (tb *testBalances) GetEventDB() *event.EventDb                                     { return nil }
-func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, interface{}) {}
-func (tb *testBalances) EmitError(error)                                                {}
-func (tb *testBalances) GetEvents() []event.Event                                       { return nil }
-func (tb *testBalances) GetLatestFinalizedBlock() *block.Block                          { return nil }
-func (tb *testBalances) SetMagicBlock(block *block.MagicBlock)                          {}
+func (tb *testBalances) GetBlock() *block.Block                       { return nil }
+func (tb *testBalances) GetState() util.MerklePatriciaTrieI           { return nil }
+func (tb *testBalances) GetTransaction() *transaction.Transaction     { return nil }
+func (tb *testBalances) GetBlockSharders(b *block.Block) []string     { return nil }
+func (tb *testBalances) Validate() error                              { return nil }
+func (tb *testBalances) GetMints() []*state.Mint                      { return nil }
+func (tb *testBalances) SetStateContext(*state.State) error           { return nil }
+func (tb *testBalances) AddMint(*state.Mint) error                    { return nil }
+func (tb *testBalances) GetTransfers() []*state.Transfer              { return nil }
+func (tb *testBalances) GetChainCurrentMagicBlock() *block.MagicBlock { return nil }
+func (tb *testBalances) AddSignedTransfer(st *state.SignedTransfer)   {}
+func (tb *testBalances) GetEventDB() *event.EventDb                   { return nil }
+func (tb *testBalances) EmitEvent(event.EventType, event.EventTag, string, interface{}, ...cstate.Appender) {
+}
+func (tb *testBalances) EmitError(error)                       {}
+func (tb *testBalances) GetEvents() []event.Event              { return nil }
+func (tb *testBalances) GetLatestFinalizedBlock() *block.Block { return nil }
+func (tb *testBalances) SetMagicBlock(block *block.MagicBlock) {}
 func (tb *testBalances) GetLastestFinalizedMagicBlock() *block.Block {
 	return nil
 }


### PR DESCRIPTION
## Changes
Client events are executed before all others for current transaction. It will allow not to break foreign key to client on different tables in case that added client is the new one.