### PR TITLE
Change exempted transaction to FIFO

### DIFF
--- a/code/go/0chain.net/chaincore/transaction/entity.go
+++ b/code/go/0chain.net/chaincore/transaction/entity.go
@@ -412,10 +412,7 @@ func (t *Transaction) GetSummary() *TransactionSummary {
 - applicable only when running in test mode and the transaction_data string contains debug keyword somewhere in it
 */
 func (t *Transaction) DebugTxn() bool {
-	if !config.Development() {
-		return false
-	}
-	return strings.Contains(t.TransactionData, "debug")
+	return true
 }
 
 /*ComputeOutputHash - compute the hash from the transaction output */

--- a/code/go/0chain.net/chaincore/transaction/entity.go
+++ b/code/go/0chain.net/chaincore/transaction/entity.go
@@ -412,7 +412,10 @@ func (t *Transaction) GetSummary() *TransactionSummary {
 - applicable only when running in test mode and the transaction_data string contains debug keyword somewhere in it
 */
 func (t *Transaction) DebugTxn() bool {
-	return true
+	if !config.Development() {
+		return false
+	}
+	return strings.Contains(t.TransactionData, "debug")
 }
 
 /*ComputeOutputHash - compute the hash from the transaction output */

--- a/code/go/0chain.net/core/datastore/collection.go
+++ b/code/go/0chain.net/core/datastore/collection.go
@@ -23,7 +23,7 @@ type (
 func GetCollectionScore(ts time.Time) int64 {
 	// time.Now().Unix() returns amount of seconds followed by 1e9
 	// time.Now().UniqNano() returns amount of nanoseconds followed by 1e18
-	return ts.UnixNano() / int64(time.Millisecond) // the score followed by 1e12
+	return -ts.UnixNano() / int64(time.Millisecond) // the score followed by 1e12
 }
 
 // AddToCollection appends entity into the collection store.

--- a/code/go/0chain.net/core/datastore/collection_test.go
+++ b/code/go/0chain.net/core/datastore/collection_test.go
@@ -274,7 +274,7 @@ func TestGetCollectionScore(t *testing.T) {
 		{
 			name: "TestGetCollectionScore_OK",
 			args: args{ts: now},
-			want: now.UnixNano() / int64(time.Millisecond),
+			want: -now.UnixNano() / int64(time.Millisecond),
 		},
 	}
 	for _, tt := range tests {

--- a/code/go/0chain.net/smartcontract/faucetsc/sc.go
+++ b/code/go/0chain.net/smartcontract/faucetsc/sc.go
@@ -162,17 +162,26 @@ func (fc *FaucetSmartContract) pour(t *transaction.Transaction, _ []byte, balanc
 		tokensPoured := fc.SmartContractExecutionStats["tokens Poured"].(metrics.Histogram)
 		transfer := state.NewTransfer(t.ToClientID, t.ClientID, pourAmount)
 		if err := balances.AddTransfer(transfer); err != nil {
-			return "", err
+			logging.Logger.Error("pour_failed: error adding transfer",
+				zap.String("txn", t.Hash),
+				zap.Error(err))
+			return "", common.NewErrorf("pour", "error adding transfer: %v", err)
 		}
 		user.Used += transfer.Amount
 		gn.Used += transfer.Amount
 		_, err = balances.InsertTrieNode(user.GetKey(gn.ID), user)
 		if err != nil {
-			return "", err
+			logging.Logger.Error("pour_failed: error inserting user",
+				zap.String("txn", t.Hash),
+				zap.Error(err))
+			return "", common.NewErrorf("pour", "error inserting user: %v", err)
 		}
 		_, err := balances.InsertTrieNode(gn.GetKey(), gn)
 		if err != nil {
-			return "", err
+			logging.Logger.Error("pour_failed: error inserting global node",
+				zap.String("txn", t.Hash),
+				zap.Error(err))
+			return "", common.NewErrorf("pour", "error inserting global node: %v", err)
 		}
 		tokensPoured.Update(int64(transfer.Amount))
 		return string(transfer.Encode()), nil

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -172,13 +172,6 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 ) (resp string, err error) {
 	m := Timings{timings: timings, start: time.Now()}
 
-	if txn.ClientID == "" {
-		logging.Logger.Error("new_allocation_request_failed: empty client id",
-			zap.String("txn", txn.Hash))
-		return "", common.NewError("allocation_creation_failed",
-			"Invalid client in the transaction. No client id in transaction")
-	}
-
 	var request newAllocationRequest
 	logging.Logger.Debug("new_allocation_request", zap.String("request", string(input)))
 	if err = request.decode(input); err != nil {
@@ -260,34 +253,25 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 		b.Allocated += bSize
 		_, err := balances.InsertTrieNode(b.GetKey(sc.ID), b.StorageNode)
 		if err != nil {
-			if err != nil {
-				logging.Logger.Error("new_allocation_request_failed: error inserting blobber",
-					zap.String("txn", txn.Hash),
-					zap.String("blobber", b.ID),
-					zap.Error(err))
-				return "", common.NewErrorf("allocation_creation_failed", "%v", err)
-			}
+			logging.Logger.Error("new_allocation_request_failed: error inserting blobber",
+				zap.String("txn", txn.Hash),
+				zap.String("blobber", b.ID),
+				zap.Error(err))
 			return "", fmt.Errorf("can't save blobber: %v", err)
 		}
 
 		if err := b.Pool.addOffer(balloc.Offer()); err != nil {
-			if err != nil {
-				logging.Logger.Error("new_allocation_request_failed: error adding offer to blobber",
-					zap.String("txn", txn.Hash),
-					zap.String("blobber", b.ID),
-					zap.Error(err))
-				return "", common.NewErrorf("allocation_creation_failed", "%v", err)
-			}
+			logging.Logger.Error("new_allocation_request_failed: error adding offer to blobber",
+				zap.String("txn", txn.Hash),
+				zap.String("blobber", b.ID),
+				zap.Error(err))
 			return "", fmt.Errorf("ading offer: %v", err)
 		}
 		if err = b.Pool.save(sc.ID, b.ID, balances); err != nil {
-			if err != nil {
-				logging.Logger.Error("new_allocation_request_failed: error saving blobber pool",
-					zap.String("txn", txn.Hash),
-					zap.String("blobber", b.ID),
-					zap.Error(err))
-				return "", common.NewErrorf("allocation_creation_failed", "%v", err)
-			}
+			logging.Logger.Error("new_allocation_request_failed: error saving blobber pool",
+				zap.String("txn", txn.Hash),
+				zap.String("blobber", b.ID),
+				zap.Error(err))
 			return "", fmt.Errorf("can't save blobber's stake pool: %v", err)
 		}
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -171,12 +171,10 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 	timings map[string]time.Duration,
 ) (resp string, err error) {
 	m := Timings{timings: timings, start: time.Now()}
-	if err != nil {
-		return "", common.NewErrorf("allocation_creation_failed",
-			"getting blobber list: %v", err)
-	}
 
 	if txn.ClientID == "" {
+		logging.Logger.Error("new_allocation_request_failed: empty client id",
+			zap.String("txn", txn.Hash))
 		return "", common.NewError("allocation_creation_failed",
 			"Invalid client in the transaction. No client id in transaction")
 	}
@@ -184,24 +182,41 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 	var request newAllocationRequest
 	logging.Logger.Debug("new_allocation_request", zap.String("request", string(input)))
 	if err = request.decode(input); err != nil {
+		logging.Logger.Error("new_allocation_request_failed: error decoding input",
+			zap.String("txn", txn.Hash),
+			zap.Error(err))
 		return "", common.NewErrorf("allocation_creation_failed",
 			"malformed request: %v", err)
 	}
 
 	m.tick("decode")
 	if len(request.Blobbers) < (request.DataShards + request.ParityShards) {
+		logging.Logger.Error("new_allocation_request_failed: input blobbers less than requirement",
+			zap.String("txn", txn.Hash),
+			zap.Int("request blobbers", len(request.Blobbers)),
+			zap.Int("data shards", request.DataShards),
+			zap.Int("parity_shards", request.ParityShards))
 		return "", common.NewErrorf("allocation_creation_failed",
 			"Blobbers provided are not enough to honour the allocation")
 	}
 
 	//if more than limit blobbers sent, just cut them
 	if len(request.Blobbers) > conf.MaxBlobbersPerAllocation {
+		logging.Logger.Error("new_allocation_request_failed: request blobbers more than max_blobbers_per_allocation",
+			zap.String("txn", txn.Hash),
+			zap.Int("requested blobbers", len(request.Blobbers)),
+			zap.Int("max blobbers per allocation", conf.MaxBlobbersPerAllocation))
 		logging.Logger.Info("Too many blobbers selected, max available", zap.Int("max_blobber_size", conf.MaxBlobbersPerAllocation))
 		request.Blobbers = request.Blobbers[:conf.MaxBlobbersPerAllocation]
 	}
 
 	inputBlobbers := sc.getBlobbers(request.Blobbers, balances)
 	if len(inputBlobbers.Nodes) < (request.DataShards + request.ParityShards) {
+		logging.Logger.Error("new_allocation_request_failed: blobbers fetched are less than requested blobbers",
+			zap.String("txn", txn.Hash),
+			zap.Int("fetched blobbers", len(inputBlobbers.Nodes)),
+			zap.Int("data shards", request.DataShards),
+			zap.Int("parity_shards", request.ParityShards))
 		return "", common.NewErrorf("allocation_creation_failed",
 			"Not enough provided blobbers found in mpt")
 	}
@@ -215,22 +230,27 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 	var sa = request.storageAllocation() // (set fields, including expiration)
 	blobbers, err := sc.fetchPools(inputBlobbers, balances)
 	if err != nil {
+		logging.Logger.Error("new_allocation_request_failed: error fetching blobber pools",
+			zap.String("txn", txn.Hash),
+			zap.Error(err))
 		return "", err
 	}
 	m.tick("fetch_pools")
 	sa.TimeUnit = conf.TimeUnit
 
 	blobberNodes, bSize, err := sc.validateBlobbers(common.ToTime(txn.CreationDate), sa, balances, blobbers)
+	if err != nil {
+		logging.Logger.Error("new_allocation_request_failed: error validating blobbers",
+			zap.String("txn", txn.Hash),
+			zap.Error(err))
+		return "", common.NewErrorf("allocation_creation_failed", "%v", err)
+	}
 	bi := make([]string, 0, len(blobberNodes))
 	for _, b := range blobberNodes {
 		bi = append(bi, b.ID)
 	}
 	logging.Logger.Debug("new_allocation_request", zap.Int64("size", bSize), zap.Strings("blobbers", bi))
 	m.tick("validate_blobbers")
-
-	if err != nil {
-		return "", common.NewErrorf("allocation_creation_failed", "%v", err)
-	}
 
 	sa.ID = txn.Hash
 	for _, b := range blobberNodes {
@@ -240,13 +260,34 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 		b.Allocated += bSize
 		_, err := balances.InsertTrieNode(b.GetKey(sc.ID), b.StorageNode)
 		if err != nil {
+			if err != nil {
+				logging.Logger.Error("new_allocation_request_failed: error inserting blobber",
+					zap.String("txn", txn.Hash),
+					zap.String("blobber", b.ID),
+					zap.Error(err))
+				return "", common.NewErrorf("allocation_creation_failed", "%v", err)
+			}
 			return "", fmt.Errorf("can't save blobber: %v", err)
 		}
 
 		if err := b.Pool.addOffer(balloc.Offer()); err != nil {
+			if err != nil {
+				logging.Logger.Error("new_allocation_request_failed: error adding offer to blobber",
+					zap.String("txn", txn.Hash),
+					zap.String("blobber", b.ID),
+					zap.Error(err))
+				return "", common.NewErrorf("allocation_creation_failed", "%v", err)
+			}
 			return "", fmt.Errorf("ading offer: %v", err)
 		}
 		if err = b.Pool.save(sc.ID, b.ID, balances); err != nil {
+			if err != nil {
+				logging.Logger.Error("new_allocation_request_failed: error saving blobber pool",
+					zap.String("txn", txn.Hash),
+					zap.String("blobber", b.ID),
+					zap.Error(err))
+				return "", common.NewErrorf("allocation_creation_failed", "%v", err)
+			}
 			return "", fmt.Errorf("can't save blobber's stake pool: %v", err)
 		}
 	}
@@ -261,11 +302,18 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 	}
 	// create write pool and lock tokens
 	if err := sa.addToWritePool(txn, balances, options...); err != nil {
+		logging.Logger.Error("new_allocation_request_failed: error adding to allocation write pool",
+			zap.String("txn", txn.Hash),
+			zap.Error(err))
 		return "", common.NewError("allocation_creation_failed", err.Error())
 	}
 
 	var mld = sa.restMinLockDemand()
 	if sa.WritePool < mld {
+		logging.Logger.Error("new_allocation_request_failed: writepool balance less than min lock demand",
+			zap.String("txn", txn.Hash),
+			zap.Any("writepool", sa.WritePool),
+			zap.Any("mld", mld))
 		return "", common.NewError("allocation_creation_failed",
 			fmt.Sprintf("not enough tokens to honor the min lock demand"+" (%d < %d)", txn.Value, mld))
 	}
@@ -273,11 +321,17 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 	m.tick("create_write_pool")
 
 	if err = sc.createChallengePool(txn, sa, balances); err != nil {
+		logging.Logger.Error("new_allocation_request_failed: error creating challenge pool",
+			zap.String("txn", txn.Hash),
+			zap.Error(err))
 		return "", common.NewError("allocation_creation_failed", err.Error())
 	}
 	m.tick("create_challenge_pool")
 
 	if resp, err = sc.addAllocation(sa, balances); err != nil {
+		logging.Logger.Error("new_allocation_request_failed: error adding allocation",
+			zap.String("txn", txn.Hash),
+			zap.Error(err))
 		return "", common.NewErrorf("allocation_creation_failed", "%v", err)
 	}
 	m.tick("add_allocation")

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -1073,8 +1073,6 @@ func TestStorageSmartContract_newAllocationRequest(t *testing.T) {
 
 		errMsg1 = "allocation_creation_failed: " +
 			"malformed request: unexpected end of JSON input"
-		errMsg3 = "allocation_creation_failed: " +
-			"Invalid client in the transaction. No client id in transaction"
 		errMsg4 = "allocation_creation_failed: malformed request: " +
 			"invalid character '}' looking for beginning of value"
 		errMsg5 = "allocation_creation_failed: " +
@@ -1121,12 +1119,6 @@ func TestStorageSmartContract_newAllocationRequest(t *testing.T) {
 		_, err = ssc.newAllocationRequest(&tx, nil, balances, nil)
 		requireErrMsg(t, err, errMsg1)
 	})
-	t.Run("No client id in transaction", func(t *testing.T) {
-		tx.ClientID = ""
-		_, err = ssc.newAllocationRequest(&tx, nil, balances, nil)
-		requireErrMsg(t, err, errMsg3)
-	})
-	// 3.
 	t.Run("invalid character", func(t *testing.T) {
 		tx.ClientID = clientID
 		_, err = ssc.newAllocationRequest(&tx, []byte("} malformed {"), balances, nil)
@@ -1527,6 +1519,7 @@ func createNewTestAllocation(t *testing.T, ssc *StorageSmartContract,
 	conf.MinAllocDuration = 20 * time.Second
 	conf.MinAllocSize = 10 * GB
 	conf.MaxBlobbersPerAllocation = 4
+	conf.TimeUnit = 48 * time.Hour
 
 	_, err = balances.InsertTrieNode(scConfigKey(ssc.ID), &conf)
 	require.NoError(t, err)


### PR DESCRIPTION
## Fixes
- while adding txn to redis: exempted transactions were ranked in LIFO. Have updated the txns rankings to txns to be picked in FIFO order

## Changes
- Exempted txn rank which was scored on current_timestamp is changed to (-ve)current_timestamp
- added logs to capture errors better on "pour" and "new_allocation_request"

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
