### PR TITLE
chore: include used_allocation field in blobber API response

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -1934,6 +1934,7 @@ type storageNodeResponse struct {
 	StorageNode
 	TotalServiceCharge currency.Coin `json:"total_service_charge"`
 	TotalStake         currency.Coin `json:"total_stake"`
+	UsedAllocation     int64         `json:"used_allocation"`
 }
 
 func blobberTableToStorageNode(blobber event.Blobber) storageNodeResponse {
@@ -1970,6 +1971,7 @@ func blobberTableToStorageNode(blobber event.Blobber) storageNodeResponse {
 		},
 		TotalServiceCharge: blobber.TotalServiceCharge,
 		TotalStake:         blobber.TotalStake,
+		UsedAllocation:     blobber.Used,
 	}
 }
 


### PR DESCRIPTION
## Fixes

## Changes
* New data in response: `/getBlobber` and `/getBlobbers` response now include used storage in allocation. 

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
