### PR TITLE
Stake Validator as provider in StakePool

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/validator.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/validator.go
@@ -59,7 +59,7 @@ func (edb *EventDb) GetValidators(pg common2.Pagination) ([]Validator, error) {
 	var validators []Validator
 	result := edb.Store.Get().Model(&Validator{}).Offset(pg.Offset).Limit(pg.Limit).Order(clause.OrderByColumn{
 		Column: clause.Column{Name: "id"},
-		Desc: pg.IsDescending,
+		Desc:   pg.IsDescending,
 	}).Find(&validators)
 
 	return validators, result.Error
@@ -80,9 +80,13 @@ func (edb *EventDb) validatorAggregateStats(id string) (*providerAggregateStats,
 }
 
 func (edb *EventDb) updateValidator(updates dbs.DbUpdates) error {
-	result := edb.Store.Get().
+	delegateWallet := ""
+	if updates.Updates["delegate_wallet"] != nil {
+		delegateWallet = updates.Updates["delegate_wallet"].(string)
+	}
+
+	return edb.Store.Get().
 		Model(&Validator{}).
-		Where(&Validator{ValidatorID: updates.Id}).
-		Updates(updates.Updates)
-	return result.Error
+		Where(&Validator{ValidatorID: updates.Id, DelegateWallet: delegateWallet}).
+		Updates(updates.Updates).Error
 }

--- a/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/smartcontract/stakepool/spenum"
 	"encoding/json"
 	"os"
 	"strconv"
@@ -382,7 +383,7 @@ func testCancelAllocation(
 	require.NoError(t, err)
 	var sps []*stakePool
 	for _, blobber := range blobbers {
-		sp, err := ssc.getStakePool(blobber.ID, ctx)
+		sp, err := ssc.getStakePool(spenum.Blobber, blobber.ID, ctx)
 		require.NoError(t, err)
 		sps = append(sps, sp)
 	}
@@ -429,7 +430,7 @@ func testFinalizeAllocation(
 	require.NoError(t, err)
 	var sps []*stakePool
 	for _, blobber := range blobbers {
-		sp, err := ssc.getStakePool(blobber.ID, ctx)
+		sp, err := ssc.getStakePool(spenum.Blobber, blobber.ID, ctx)
 		require.NoError(t, err)
 		sps = append(sps, sp)
 	}
@@ -545,7 +546,7 @@ func setupMocksFinishAllocation(
 			sp.Pools["paula "+id+" "+jd] = delegatePool
 		}
 		sp.Settings.DelegateWallet = blobberId + " " + id + " wallet"
-		require.NoError(t, sp.save(ssc.ID, blobber.ID, ctx))
+		require.NoError(t, sp.save(spenum.Blobber, blobber.ID, ctx))
 
 		_, err = ctx.InsertTrieNode(blobber.GetKey(ssc.ID), blobber)
 		require.NoError(t, err)
@@ -765,7 +766,7 @@ func testNewAllocation(t *testing.T, request newAllocationRequest, blobbers Sort
 		var stakePool = newStakePool()
 		stakePool.Pools["paula"] = &stakepool.DelegatePool{}
 		stakePool.Pools["paula"].Balance = currency.Coin(stakes[i])
-		require.NoError(t, stakePool.save(ssc.ID, blobber.ID, ctx))
+		require.NoError(t, stakePool.save(spenum.Blobber, blobber.ID, ctx))
 	}
 
 	_, err = ctx.InsertTrieNode(scConfigKey(ssc.ID), &scYaml)
@@ -798,7 +799,7 @@ func testNewAllocation(t *testing.T, request newAllocationRequest, blobbers Sort
 
 	var newStakePools = []*stakePool{}
 	for _, blobber := range individualBlobbers {
-		var sp, err = ssc.getStakePool(blobber.ID, ctx)
+		var sp, err = ssc.getStakePool(spenum.Blobber, blobber.ID, ctx)
 		require.NoError(t, err)
 		newStakePools = append(newStakePools, sp)
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -127,7 +127,7 @@ func (sc *StorageSmartContract) filterBlobbersByFreeSpace(now common.Timestamp,
 	size int64, balances chainstate.CommonStateContextI) (filter filterBlobberFunc) {
 
 	return filterBlobberFunc(func(b *StorageNode) (kick bool) {
-		var sp, err = sc.getStakePool(b.ID, balances)
+		var sp, err = sc.getStakePool(spenum.Blobber, b.ID, balances)
 		if err != nil {
 			return true // kick off
 		}
@@ -282,7 +282,7 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 				zap.Error(err))
 			return "", fmt.Errorf("ading offer: %v", err)
 		}
-		if err = b.Pool.save(sc.ID, b.ID, balances); err != nil {
+		if err = b.Pool.save(spenum.Blobber, b.ID, balances); err != nil {
 			logging.Logger.Error("new_allocation_request_failed: error saving blobber pool",
 				zap.String("txn", txn.Hash),
 				zap.String("blobber", b.ID),
@@ -367,7 +367,7 @@ func (sc *StorageSmartContract) fetchPools(inputBlobbers *StorageNodes, balances
 		go func(blob *StorageNode, ind int) {
 			var sp *stakePool
 			var err error
-			if sp, err = sc.getStakePool(blob.ID, balances); err != nil {
+			if sp, err = sc.getStakePool(spenum.Blobber, blob.ID, balances); err != nil {
 				errs <- common.NewErrorf("allocation_creation_failed", "can't get blobber's stake pool: %v", err)
 				return
 			}
@@ -677,7 +677,7 @@ func (sc *StorageSmartContract) closeAllocation(t *transaction.Transaction,
 
 	for _, ba := range alloc.BlobberAllocs {
 		var sp *stakePool
-		if sp, err = sc.getStakePool(ba.BlobberID, balances); err != nil {
+		if sp, err = sc.getStakePool(spenum.Blobber, ba.BlobberID, balances); err != nil {
 			return "", fmt.Errorf("can't get stake pool of %s: %v", ba.BlobberID,
 				err)
 		}
@@ -685,7 +685,7 @@ func (sc *StorageSmartContract) closeAllocation(t *transaction.Transaction,
 			return "", common.NewError("fini_alloc_failed",
 				"error removing offer: "+err.Error())
 		}
-		if err = sp.save(sc.ID, ba.BlobberID, balances); err != nil {
+		if err = sp.save(spenum.Blobber, ba.BlobberID, balances); err != nil {
 			return "", fmt.Errorf("can't save stake pool of %s: %v", ba.BlobberID,
 				err)
 		}
@@ -932,7 +932,7 @@ func (sc *StorageSmartContract) extendAllocation(
 		newOffer := details.Offer()
 		if newOffer != oldOffer {
 			var sp *stakePool
-			if sp, err = sc.getStakePool(details.BlobberID, balances); err != nil {
+			if sp, err = sc.getStakePool(spenum.Blobber, details.BlobberID, balances); err != nil {
 				return fmt.Errorf("can't get stake pool of %s: %v", details.BlobberID, err)
 			}
 			if newOffer > oldOffer {
@@ -952,7 +952,7 @@ func (sc *StorageSmartContract) extendAllocation(
 					return fmt.Errorf("adding offer: %v", err)
 				}
 			}
-			if err = sp.save(sc.ID, details.BlobberID, balances); err != nil {
+			if err = sp.save(spenum.Blobber, details.BlobberID, balances); err != nil {
 				return fmt.Errorf("can't save stake pool of %s: %v", details.BlobberID,
 					err)
 			}
@@ -1022,7 +1022,7 @@ func (sc *StorageSmartContract) reduceAllocation(
 		newOffer := ba.Offer()
 		if newOffer != oldOffer {
 			var sp *stakePool
-			if sp, err = sc.getStakePool(ba.BlobberID, balances); err != nil {
+			if sp, err = sc.getStakePool(spenum.Blobber, ba.BlobberID, balances); err != nil {
 				return fmt.Errorf("can't get stake pool of %s: %v", ba.BlobberID,
 					err)
 			}
@@ -1037,7 +1037,7 @@ func (sc *StorageSmartContract) reduceAllocation(
 				}
 			}
 
-			if err = sp.save(sc.ID, ba.BlobberID, balances); err != nil {
+			if err = sp.save(spenum.Blobber, ba.BlobberID, balances); err != nil {
 				return fmt.Errorf("can't save stake pool of %s: %v", ba.BlobberID,
 					err)
 			}
@@ -1404,7 +1404,7 @@ func (sc *StorageSmartContract) cancelAllocationRequest(
 	sps := make([]*stakePool, 0, len(alloc.BlobberAllocs))
 	for _, d := range alloc.BlobberAllocs {
 		var sp *stakePool
-		if sp, err = sc.getStakePool(d.BlobberID, balances); err != nil {
+		if sp, err = sc.getStakePool(spenum.Blobber, d.BlobberID, balances); err != nil {
 			return "", common.NewError("fini_alloc_failed",
 				"can't get stake pool of "+d.BlobberID+": "+err.Error())
 		}
@@ -1489,7 +1489,7 @@ func (sc *StorageSmartContract) finalizeAllocation(
 	var sps = []*stakePool{}
 	for _, d := range alloc.BlobberAllocs {
 		var sp *stakePool
-		if sp, err = sc.getStakePool(d.BlobberID, balances); err != nil {
+		if sp, err = sc.getStakePool(spenum.Blobber, d.BlobberID, balances); err != nil {
 			return "", common.NewError("fini_alloc_failed",
 				"can't get stake pool of "+d.BlobberID+": "+err.Error())
 		}
@@ -1614,7 +1614,7 @@ func (sc *StorageSmartContract) finishAllocation(
 			}
 		}
 
-		if err = sps[i].save(sc.ID, d.BlobberID, balances); err != nil {
+		if err = sps[i].save(spenum.Blobber, d.BlobberID, balances); err != nil {
 			return common.NewError("fini_alloc_failed",
 				"saving stake pool of "+d.BlobberID+": "+err.Error())
 		}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/smartcontract/stakepool/spenum"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -113,7 +114,7 @@ func TestSelectBlobbers(t *testing.T) {
 			}
 			sp.Pools[mockPoolId].Balance = mockStatke
 			balances.On("GetTrieNode",
-				stakePoolKey(ssc.ID, mockBlobberId+strconv.Itoa(i)),
+				stakePoolKey(spenum.Blobber, mockBlobberId+strconv.Itoa(i)),
 				mock.MatchedBy(func(s *stakePool) bool {
 					*s = sp
 					return true
@@ -374,7 +375,7 @@ func TestChangeBlobbers(t *testing.T) {
 				},
 			}
 			sp.Pools[mockPoolId].Balance = mockState
-			_, err := balances.InsertTrieNode(stakePoolKey(sc.ID, arg.addBlobberID), &sp)
+			_, err := balances.InsertTrieNode(stakePoolKey(spenum.Blobber, arg.addBlobberID), &sp)
 			require.NoError(t, err)
 		}
 
@@ -658,14 +659,14 @@ func TestExtendAllocation(t *testing.T) {
 				}
 				sp.Pools[mockPoolId].Balance = zcnToBalance(mockStake)
 				balances.On(
-					"GetTrieNode", stakePoolKey(ssc.ID, mockBlobber.ID),
+					"GetTrieNode", stakePoolKey(spenum.Blobber, mockBlobber.ID),
 					mock.MatchedBy(func(s *stakePool) bool {
 						*s = sp
 						return true
 					})).Return(nil).Once()
 				balances.On(
 					"InsertTrieNode",
-					stakePoolKey(ssc.ID, mockBlobber.ID),
+					stakePoolKey(spenum.Blobber, mockBlobber.ID),
 					mock.Anything,
 				).Return("", nil).Once()
 				balances.On(
@@ -1258,8 +1259,8 @@ func TestStorageSmartContract_newAllocationRequest(t *testing.T) {
 		)
 		dp1.Balance, dp2.Balance = 20e10, 20e10
 		sp1.Pools["hash1"], sp2.Pools["hash2"] = dp1, dp2
-		require.NoError(t, sp1.save(ssc.ID, "b1", balances))
-		require.NoError(t, sp2.save(ssc.ID, "b2", balances))
+		require.NoError(t, sp1.save(spenum.Blobber, "b1", balances))
+		require.NoError(t, sp2.save(spenum.Blobber, "b2", balances))
 
 		tx.Value = 0
 		_, err = ssc.newAllocationRequest(&tx, mustEncode(t, &nar), balances, nil)
@@ -1302,8 +1303,8 @@ func TestStorageSmartContract_newAllocationRequest(t *testing.T) {
 		)
 		dp1.Balance, dp2.Balance = 20e10, 20e10
 		sp1.Pools["hash1"], sp2.Pools["hash2"] = dp1, dp2
-		require.NoError(t, sp1.save(ssc.ID, "b1", balances))
-		require.NoError(t, sp2.save(ssc.ID, "b2", balances))
+		require.NoError(t, sp1.save(spenum.Blobber, "b1", balances))
+		require.NoError(t, sp2.save(spenum.Blobber, "b2", balances))
 
 		tx.Value = 400
 		_, err = ssc.newAllocationRequest(&tx, mustEncode(t, &nar), balances, nil)
@@ -1347,8 +1348,8 @@ func TestStorageSmartContract_newAllocationRequest(t *testing.T) {
 		)
 		dp1.Balance, dp2.Balance = 20e10, 20e10
 		sp1.Pools["hash1"], sp2.Pools["hash2"] = dp1, dp2
-		require.NoError(t, sp1.save(ssc.ID, "b1", balances))
-		require.NoError(t, sp2.save(ssc.ID, "b2", balances))
+		require.NoError(t, sp1.save(spenum.Blobber, "b1", balances))
+		require.NoError(t, sp2.save(spenum.Blobber, "b2", balances))
 
 		balances.balances[clientID] = 1100
 
@@ -1428,10 +1429,10 @@ func TestStorageSmartContract_newAllocationRequest(t *testing.T) {
 
 		assert.Equal(t, len(details), len(aresp.BlobberAllocs))
 
-		_, err = ssc.getStakePool("b1", balances)
+		_, err = ssc.getStakePool(spenum.Blobber, "b1", balances)
 		require.NoError(t, err)
 
-		_, err = ssc.getStakePool("b2", balances)
+		_, err = ssc.getStakePool(spenum.Blobber, "b2", balances)
 		require.NoError(t, err)
 
 		// 3. challenge pool existence
@@ -1560,8 +1561,8 @@ func createNewTestAllocation(t *testing.T, ssc *StorageSmartContract,
 	)
 	dp1.Balance, dp2.Balance = 20e10, 20e10
 	sp1.Pools["hash1"], sp2.Pools["hash2"] = dp1, dp2
-	require.NoError(t, sp1.save(ssc.ID, "b1", balances))
-	require.NoError(t, sp2.save(ssc.ID, "b2", balances))
+	require.NoError(t, sp1.save(spenum.Blobber, "b1", balances))
+	require.NoError(t, sp2.save(spenum.Blobber, "b2", balances))
 
 	balances.(*testBalances).balances[clientID] = 1100
 

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
@@ -594,9 +594,6 @@ func GetMockValidatorStakePools(
 	clients []string,
 	balances cstate.StateContextI,
 ) {
-	var sscId = StorageSmartContract{
-		SmartContract: sci.NewSC(ADDRESS),
-	}.ID
 	for i := 0; i < viper.GetInt(sc.NumValidators); i++ {
 		bId := getMockValidatorId(i)
 		sp := &stakePool{
@@ -610,7 +607,7 @@ func GetMockValidatorStakePools(
 			id := getMockValidatorStakePoolId(i, j)
 			sp.Pools[id] = &stakepool.DelegatePool{}
 			sp.Pools[id].Balance = currency.Coin(viper.GetInt64(sc.StorageMaxStake) * 1e10)
-			err := sp.save(sscId, getMockValidatorId(i), balances)
+			err := sp.save(spenum.Validator, getMockValidatorId(i), balances)
 			if err != nil {
 				panic(err)
 			}
@@ -622,12 +619,9 @@ func SaveMockStakePools(
 	sps []*stakePool,
 	balances cstate.StateContextI,
 ) {
-	var sscId = StorageSmartContract{
-		SmartContract: sci.NewSC(ADDRESS),
-	}.ID
 	for i, sp := range sps {
 		bId := getMockBlobberId(i)
-		err := sp.save(sscId, bId, balances)
+		err := sp.save(spenum.Blobber, bId, balances)
 		if err != nil {
 			panic(err)
 		}

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
@@ -621,7 +621,8 @@ func BenchmarkTests(
 			},
 			input: func() []byte {
 				bytes, _ := json.Marshal(&stakePoolRequest{
-					BlobberID: getMockBlobberId(0),
+					ProviderType: spenum.Blobber,
+					ProviderID:   getMockBlobberId(0),
 					//PoolID:    getMockStakePoolId(0, 0, data.Clients),
 					PoolID: getMockBlobberStakePoolId(0, 0),
 				})
@@ -638,8 +639,9 @@ func BenchmarkTests(
 			},
 			input: func() []byte {
 				bytes, _ := json.Marshal(&stakePoolRequest{
-					BlobberID: getMockBlobberId(0),
-					PoolID:    getMockBlobberStakePoolId(0, 0),
+					ProviderType: spenum.Blobber,
+					ProviderID:   getMockBlobberId(0),
+					PoolID:       getMockBlobberStakePoolId(0, 0),
 				})
 				return bytes
 			}(),

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -106,7 +106,7 @@ func (sc *StorageSmartContract) updateBlobber(t *transaction.Transaction,
 
 	// update stake pool settings
 	var sp *stakePool
-	if sp, err = sc.getStakePool(blobber.ID, balances); err != nil {
+	if sp, err = sc.getStakePool(spenum.Blobber, blobber.ID, balances); err != nil {
 		return fmt.Errorf("can't get stake pool:  %v", err)
 	}
 
@@ -130,7 +130,7 @@ func (sc *StorageSmartContract) updateBlobber(t *transaction.Transaction,
 	}
 
 	// save stake pool
-	if err = sp.save(sc.ID, blobber.ID, balances); err != nil {
+	if err = sp.save(spenum.Blobber, blobber.ID, balances); err != nil {
 		return fmt.Errorf("saving stake pool: %v", err)
 	}
 
@@ -250,7 +250,7 @@ func (sc *StorageSmartContract) updateBlobberSettings(t *transaction.Transaction
 	}
 
 	var sp *stakePool
-	if sp, err = sc.getStakePool(updatedBlobber.ID, balances); err != nil {
+	if sp, err = sc.getStakePool(spenum.Blobber, updatedBlobber.ID, balances); err != nil {
 		return "", common.NewError("update_blobber_settings_failed",
 			"can't get related stake pool: "+err.Error())
 	}
@@ -420,7 +420,7 @@ func (sc *StorageSmartContract) commitBlobberRead(t *transaction.Transaction,
 	}
 
 	var sp *stakePool
-	sp, err = sc.getStakePool(commitRead.ReadMarker.BlobberID, balances)
+	sp, err = sc.getStakePool(spenum.Blobber, commitRead.ReadMarker.BlobberID, balances)
 	if err != nil {
 		return "", common.NewErrorf("commit_blobber_read",
 			"can't get related stake pool: %v", err)
@@ -485,7 +485,7 @@ func (sc *StorageSmartContract) commitBlobberRead(t *transaction.Transaction,
 	}
 
 	// save pools
-	err = sp.save(sc.ID, commitRead.ReadMarker.BlobberID, balances)
+	err = sp.save(spenum.Blobber, commitRead.ReadMarker.BlobberID, balances)
 	if err != nil {
 		return "", common.NewErrorf("commit_blobber_read",
 			"can't save stake pool: %v", err)
@@ -865,13 +865,13 @@ func (sc *StorageSmartContract) insertBlobber(t *transaction.Transaction,
 
 	// create stake pool
 	var sp *stakePool
-	sp, err = sc.getOrUpdateStakePool(conf, blobber.ID, spenum.Blobber,
+	sp, err = sc.getOrCreateStakePool(conf, spenum.Blobber, blobber.ID,
 		blobber.StakePoolSettings, balances)
 	if err != nil {
 		return fmt.Errorf("creating stake pool: %v", err)
 	}
 
-	if err = sp.save(sc.ID, t.ClientID, balances); err != nil {
+	if err = sp.save(spenum.Blobber, blobber.ID, balances); err != nil {
 		return fmt.Errorf("saving stake pool: %v", err)
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/smartcontract/stakepool/spenum"
 	"encoding/json"
 	"strconv"
 	"strings"
@@ -329,7 +330,7 @@ func testCommitBlobberRead(
 			RoundCreated: stake.MintAt,
 		}
 	}
-	require.NoError(t, sPool.save(ssc.ID, blobberId, ctx))
+	require.NoError(t, sPool.save(spenum.Blobber, blobberId, ctx))
 
 	resp, err := ssc.commitBlobberRead(txn, input, ctx)
 	if err != nil {
@@ -341,7 +342,7 @@ func testCommitBlobberRead(
 
 	require.NotEqualValues(t, rPool.Balance, newRp.Balance)
 
-	newSp, err := ssc.getStakePool(blobberId, ctx)
+	newSp, err := ssc.getStakePool(spenum.Blobber, blobberId, ctx)
 	require.NoError(t, err)
 
 	confirmCommitBlobberRead(t, f, resp, newSp)

--- a/code/go/0chain.net/smartcontract/storagesc/blobber_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber_test.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/smartcontract/stakepool/spenum"
 	"fmt"
 	"testing"
 	"time"
@@ -649,7 +650,7 @@ func Test_flow_penalty(t *testing.T) {
 		require.NoError(t, err)
 
 		//var sp *stakePool
-		_, err = ssc.getStakePool(b4.id, balances)
+		_, err = ssc.getStakePool(spenum.Blobber, b4.id, balances)
 		require.NoError(t, err)
 
 		// until the end
@@ -728,7 +729,7 @@ func Test_flow_penalty(t *testing.T) {
 			//cpl = cp.Balance
 			//
 			//// offer pool should be reduced (blobber slash)
-			//sp, err = ssc.getStakePool(b4.id, balances)
+			//sp, err = ssc.getStakePool(spenum.Blobber, b4.id, balances)
 			//require.NoError(t, err)
 			//assert.True(t, sp.stake() < spl)
 			//spl = sp.stake()
@@ -739,7 +740,7 @@ func Test_flow_penalty(t *testing.T) {
 			//
 			//// validators reward
 			//for _, val := range valids {
-			//	_, err = ssc.getStakePool(val.id, balances)
+			//	_, err = ssc.getStakePool(spenum.Blobber, val.id, balances)
 			//	require.NoError(t, err)
 			//}
 			//
@@ -941,7 +942,7 @@ func Test_flow_no_challenge_responses_finalize(t *testing.T) {
 				continue
 			}
 			var sp *stakePool
-			sp, err = ssc.getStakePool(b.id, balances)
+			sp, err = ssc.getStakePool(spenum.Blobber, b.id, balances)
 			require.NoError(t, err)
 			spTotal, err := stakePoolTotal(sp)
 			require.NoError(t, err)
@@ -971,7 +972,7 @@ func Test_flow_no_challenge_responses_finalize(t *testing.T) {
 		// no rewards for validators
 		for _, val := range valids {
 			var vsp *stakePool
-			vsp, err = ssc.getStakePool(val.id, balances)
+			vsp, err = ssc.getStakePool(spenum.Blobber, val.id, balances)
 			require.NoError(t, err)
 			assert.Zero(t, vsp.Reward)
 			assert.Zero(t, balances.balances[val.id])
@@ -1075,7 +1076,7 @@ func Test_flow_no_challenge_responses_cancel(t *testing.T) {
 				continue
 			}
 			var sp *stakePool
-			sp, err = ssc.getStakePool(b.id, balances)
+			sp, err = ssc.getStakePool(spenum.Blobber, b.id, balances)
 			require.NoError(t, err)
 			spTotal, err := stakePoolTotal(sp)
 			require.NoError(t, err)
@@ -1165,7 +1166,7 @@ func Test_flow_no_challenge_responses_cancel(t *testing.T) {
 				continue
 			}
 			var sp *stakePool
-			sp, err = ssc.getStakePool(b.id, balances)
+			sp, err = ssc.getStakePool(spenum.Blobber, b.id, balances)
 			require.NoError(t, err)
 			spTotal, err := stakePoolTotal(sp)
 			require.NoError(t, err)
@@ -1194,7 +1195,7 @@ func Test_flow_no_challenge_responses_cancel(t *testing.T) {
 		// no rewards for validators
 		for _, val := range valids {
 			var vsp *stakePool
-			vsp, err = ssc.getStakePool(val.id, balances)
+			vsp, err = ssc.getStakePool(spenum.Validator, val.id, balances)
 			require.NoError(t, err)
 			assert.Zero(t, vsp.Reward)
 			assert.Zero(t, balances.balances[val.id])

--- a/code/go/0chain.net/smartcontract/storagesc/block_reward.go
+++ b/code/go/0chain.net/smartcontract/storagesc/block_reward.go
@@ -85,7 +85,7 @@ func (ssc *StorageSmartContract) blobberBlockRewards(
 		wg.Add(1)
 		go func(b BlobberRewardNode, i int) {
 			defer wg.Done()
-			if sp, err := ssc.getStakePool(b.ID, balances); err != nil {
+			if sp, err := ssc.getStakePool(spenum.Blobber, b.ID, balances); err != nil {
 				errorChan <- err
 			} else {
 				spChan <- spResp{
@@ -210,7 +210,7 @@ func (ssc *StorageSmartContract) blobberBlockRewards(
 	}
 
 	for i, qsp := range stakePools {
-		if err = qsp.save(ssc.ID, qualifyingBlobberIds[i], balances); err != nil {
+		if err = qsp.save(spenum.Blobber, qualifyingBlobberIds[i], balances); err != nil {
 			return common.NewError("blobber_block_rewards_failed",
 				"saving stake pool: "+err.Error())
 		}

--- a/code/go/0chain.net/smartcontract/storagesc/block_reward_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/block_reward_test.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/smartcontract/stakepool/spenum"
 	"math/rand"
 	"os"
 	"strconv"
@@ -60,7 +61,7 @@ func TestStorageSmartContract_blobberBlockRewards(t *testing.T) {
 				dp.DelegateID = dID
 				sp.Pools[dID] = dp
 			}
-			_, err = balances.InsertTrieNode(stakePoolKey(sc.ID, bID), sp)
+			_, err = balances.InsertTrieNode(stakePoolKey(spenum.Blobber, bID), sp)
 			require.NoError(t, err)
 		}
 		err = allBR.Save(balances)
@@ -72,7 +73,7 @@ func TestStorageSmartContract_blobberBlockRewards(t *testing.T) {
 		require.NoError(t, err)
 		for i := 0; i < p.numBlobbers; i++ {
 			bID := "blobber" + strconv.Itoa(i)
-			sp, err := ssc.getStakePool(bID, balances)
+			sp, err := ssc.getStakePool(spenum.Blobber, bID, balances)
 			require.NoError(t, err)
 
 			require.EqualValues(t, r.blobberRewards[i], sp.Reward)

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -161,7 +161,7 @@ func (sc *StorageSmartContract) blobberReward(t *transaction.Transaction,
 	}
 
 	var sp *stakePool
-	if sp, err = sc.getStakePool(blobAlloc.BlobberID, balances); err != nil {
+	if sp, err = sc.getStakePool(spenum.Blobber, blobAlloc.BlobberID, balances); err != nil {
 		return fmt.Errorf("can't get stake pool: %v", err)
 	}
 
@@ -199,7 +199,7 @@ func (sc *StorageSmartContract) blobberReward(t *transaction.Transaction,
 	}
 
 	// save the pools
-	if err = sp.save(sc.ID, blobAlloc.BlobberID, balances); err != nil {
+	if err = sp.save(spenum.Blobber, blobAlloc.BlobberID, balances); err != nil {
 		return fmt.Errorf("can't save sake pool: %v", err)
 	}
 
@@ -222,7 +222,7 @@ func (ssc *StorageSmartContract) validatorsStakePools(
 	sps = make([]*stakePool, 0, len(validators))
 	for _, id := range validators {
 		var sp *stakePool
-		if sp, err = ssc.getStakePool(id, balances); err != nil {
+		if sp, err = ssc.getStakePool(spenum.Validator, id, balances); err != nil {
 			return nil, fmt.Errorf("can't get validator %s stake pool: %v",
 				id, err)
 		}
@@ -236,7 +236,7 @@ func (ssc *StorageSmartContract) saveStakePools(validators []datastore.Key,
 	sps []*stakePool, balances cstate.StateContextI) (err error) {
 
 	for i, sp := range sps {
-		if err = sp.save(ssc.ID, validators[i], balances); err != nil {
+		if err = sp.save(spenum.Validator, validators[i], balances); err != nil {
 			return fmt.Errorf("saving stake pool: %v", err)
 		}
 		staked, err := sp.stake()
@@ -350,7 +350,7 @@ func (sc *StorageSmartContract) blobberPenalty(t *transaction.Transaction,
 
 		// load stake pool
 		var sp *stakePool
-		if sp, err = sc.getStakePool(blobAlloc.BlobberID, balances); err != nil {
+		if sp, err = sc.getStakePool(spenum.Blobber, blobAlloc.BlobberID, balances); err != nil {
 			return fmt.Errorf("can't get blobber's stake pool: %v", err)
 		}
 
@@ -368,7 +368,7 @@ func (sc *StorageSmartContract) blobberPenalty(t *transaction.Transaction,
 		blobAlloc.Penalty = penalty
 
 		// save stake pool
-		if err = sp.save(sc.ID, blobAlloc.BlobberID, balances); err != nil {
+		if err = sp.save(spenum.Blobber, blobAlloc.BlobberID, balances); err != nil {
 			return fmt.Errorf("can't save blobber's stake pool: %v", err)
 		}
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/smartcontract/stakepool/spenum"
 	"errors"
 	"fmt"
 	"strconv"
@@ -450,7 +451,7 @@ func testBlobberPenalty(
 	newVSp, err := ssc.validatorsStakePools(validators, ctx)
 	require.NoError(t, err)
 
-	afterBlobber, err := ssc.getStakePool(blobberId, ctx)
+	afterBlobber, err := ssc.getStakePool(spenum.Blobber, blobberId, ctx)
 	require.NoError(t, err)
 
 	confirmBlobberPenalty(t, f, *newCP, newVSp, *afterBlobber, ctx)
@@ -505,7 +506,7 @@ func testBlobberReward(
 	newVSp, err := ssc.validatorsStakePools(validators, ctx)
 	require.NoError(t, err)
 
-	afterBlobber, err := ssc.getStakePool(blobberId, ctx)
+	afterBlobber, err := ssc.getStakePool(spenum.Blobber, blobberId, ctx)
 	require.NoError(t, err)
 
 	confirmBlobberReward(t, f, *newCP, newVSp, *afterBlobber, ctx)
@@ -599,7 +600,7 @@ func setupChallengeMocks(
 		sp.Pools["paula"+id].DelegateID = "delegate " + id
 	}
 	sp.Settings.DelegateWallet = blobberId + " wallet"
-	require.NoError(t, sp.save(ssc.ID, blobberId, ctx))
+	require.NoError(t, sp.save(spenum.Blobber, blobberId, ctx))
 
 	var validatorsSPs []*stakePool
 	for i, validator := range validators {

--- a/code/go/0chain.net/smartcontract/storagesc/collect_reward.go
+++ b/code/go/0chain.net/smartcontract/storagesc/collect_reward.go
@@ -48,7 +48,7 @@ func (ssc *StorageSmartContract) collectReward(
 			"user %v does not own stake pool %v", txn.ClientID, prr.PoolId)
 	}
 
-	sp, err := ssc.getStakePool(providerID, balances)
+	sp, err := ssc.getStakePool(prr.ProviderType, providerID, balances)
 	if err != nil {
 		return "", common.NewErrorf("collect_reward_failed",
 			"can't get related stake pool: %v", err)
@@ -66,7 +66,7 @@ func (ssc *StorageSmartContract) collectReward(
 			"error saving user stake pool, %v", err)
 	}
 
-	if err := sp.save(ssc.ID, providerID, balances); err != nil {
+	if err := sp.save(spenum.Blobber, providerID, balances); err != nil {
 		return "", common.NewErrorf("collect_reward_failed",
 			"error saving stake pool, %v", err)
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/free_allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/free_allocation_test.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/smartcontract/stakepool/spenum"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -320,13 +321,13 @@ func TestFreeAllocationRequest(t *testing.T) {
 
 		for _, blobber := range mockAllBlobbers.Nodes {
 			balances.On(
-				"GetTrieNode", stakePoolKey(ssc.ID, blobber.ID),
+				"GetTrieNode", stakePoolKey(spenum.Blobber, blobber.ID),
 				mockSetValue(newStakePool())).Return(nil).Once()
 			balances.On(
 				"InsertTrieNode", blobber.GetKey(ssc.ID), mock.Anything,
 			).Return("", nil).Once()
 			balances.On(
-				"InsertTrieNode", stakePoolKey(ssc.ID, blobber.ID), mock.Anything,
+				"InsertTrieNode", stakePoolKey(spenum.Blobber, blobber.ID), mock.Anything,
 			).Return("", nil).Once()
 			balances.On(
 				"GetTrieNode", "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7"+blobber.ID,

--- a/code/go/0chain.net/smartcontract/storagesc/helper_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/helper_test.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/smartcontract/stakepool/spenum"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -105,8 +106,11 @@ func (c *Client) addBlobRequest(t testing.TB) []byte {
 }
 
 func (c *Client) stakeLockRequest(t testing.TB) []byte {
-	var spr stakePoolRequest
-	spr.BlobberID = c.id
+	spr := stakePoolRequest{
+		ProviderType: spenum.Blobber,
+		ProviderID:   c.id,
+	}
+
 	return mustEncode(t, &spr)
 }
 

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -1,6 +1,7 @@
 package storagesc
 
 import (
+	"0chain.net/smartcontract/stakepool/spenum"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -962,7 +963,7 @@ func (sa *StorageAllocation) changeBlobbers(
 	sa.BlobberAllocs = append(sa.BlobberAllocs, ba)
 
 	var sp *stakePool
-	if sp, err = ssc.getStakePool(addedBlobber.ID, balances); err != nil {
+	if sp, err = ssc.getStakePool(spenum.Blobber, addedBlobber.ID, balances); err != nil {
 		return nil, fmt.Errorf("can't get blobber's stake pool: %v", err)
 	}
 	if err := sa.validateAllocationBlobber(addedBlobber, sp, now); err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool.go
@@ -70,8 +70,8 @@ func newStakePool() *stakePool {
 }
 
 // stake pool key for the storage SC and  blobber
-func stakePoolKey(scKey, blobberID string) datastore.Key {
-	return scKey + ":stakepool:" + blobberID
+func stakePoolKey(providerType spenum.Provider, providerID string) datastore.Key {
+	return providerType.String() + ":stakepool:" + providerID
 }
 
 // Encode to []byte
@@ -89,21 +89,30 @@ func (sp *stakePool) Decode(input []byte) error {
 }
 
 // save the stake pool
-func (sp *stakePool) save(sscKey, blobberID string,
+func (sp *stakePool) save(providerType spenum.Provider, providerID string,
 	balances chainstate.StateContextI) (err error) {
-
-	r, err := balances.InsertTrieNode(stakePoolKey(sscKey, blobberID), sp)
+	r, err := balances.InsertTrieNode(stakePoolKey(providerType, providerID), sp)
 	logging.Logger.Debug("after stake pool save", zap.String("root", r))
 
-	data := dbs.DbUpdates{
-		Id: blobberID,
-		Updates: map[string]interface{}{
-			"offers_total": int64(sp.TotalOffers),
-		},
-	}
-	balances.EmitEvent(event.TypeStats, event.TagUpdateBlobber, blobberID, data)
+	sp.emitSaveEvent(providerType, providerID, balances)
 
 	return
+}
+
+func (sp *stakePool) emitSaveEvent(providerType spenum.Provider, providerID string, balances chainstate.StateContextI) {
+	data := dbs.DbUpdates{
+		Id: providerID,
+		Updates: map[string]interface{}{},
+	}
+	switch providerType {
+	case spenum.Blobber:
+		data.Updates["offers_total"] = int64(sp.TotalOffers)
+		balances.EmitEvent(event.TypeStats, event.TagUpdateBlobber, providerID, data)
+	case spenum.Validator:
+		//todo: emit validator event
+	default:
+		logging.Logger.Error("invalid providerType in stakepool SaveEvent")
+	}
 }
 
 // The cleanStake() is stake amount without delegate pools want to unstake.
@@ -112,7 +121,18 @@ func (sp *stakePool) cleanStake() (stake currency.Coin, err error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return staked - sp.TotalUnStake, nil
+}
+
+func (sp *stakePool) stakeByProvider(providerType spenum.Provider, providerID string, balances chainstate.StateContextI) error{
+	staked, err := sp.stake()
+	if err != nil {
+		return err
+	}
+	sp.emitStakeEvent(providerType, providerID, staked, balances)
+
+	return nil
 }
 
 // The stake() returns total stake size including delegate pools want to unstake.
@@ -126,6 +146,24 @@ func (sp *stakePool) stake() (stake currency.Coin, err error) {
 		stake = newStake
 	}
 	return
+}
+
+func (sp *stakePool) emitStakeEvent(providerType spenum.Provider, providerID string,staked currency.Coin, balances chainstate.StateContextI)  {
+	logging.Logger.Info("emitting stake event")
+	data := dbs.DbUpdates{
+		Id: providerID,
+		Updates: map[string]interface{}{},
+	}
+	switch providerType {
+	case spenum.Blobber:
+		data.Updates["total_stake"] = int64(staked)
+		balances.EmitEvent(event.TypeStats, event.TagUpdateBlobber, providerID, data)
+	case spenum.Validator:
+		data.Updates["stake"] = int64(staked)
+		balances.EmitEvent(event.TypeStats, event.TagUpdateValidator, providerID, data)
+	default:
+		logging.Logger.Error("invalid providerType in stakepool StakeEvent")
+	}
 }
 
 // empty a delegate pool if possible, call update before the empty
@@ -351,11 +389,10 @@ type stakePoolStat struct {
 //
 
 // getStakePool of given blobber
-func (ssc *StorageSmartContract) getStakePool(blobberID datastore.Key,
+func (ssc *StorageSmartContract) getStakePool(providerType spenum.Provider, providerID string,
 	balances chainstate.CommonStateContextI) (sp *stakePool, err error) {
-
 	sp = newStakePool()
-	err = balances.GetTrieNode(stakePoolKey(ssc.ID, blobberID), sp)
+	err = balances.GetTrieNode(stakePoolKey(providerType, providerID), sp)
 	if err != nil {
 		return nil, err
 	}
@@ -367,7 +404,7 @@ func getStakePool(
 	blobberID datastore.Key, balances chainstate.CommonStateContextI,
 ) (sp *stakePool, err error) {
 	sp = newStakePool()
-	err = balances.GetTrieNode(stakePoolKey(ADDRESS, blobberID), sp)
+	err = balances.GetTrieNode(stakePoolKey(spenum.Blobber, blobberID), sp)
 	if err != nil {
 		return nil, err
 	}
@@ -379,10 +416,10 @@ func getStakePool(
 // SC functions
 
 // get existing stake pool or create new one not saving it
-func (ssc *StorageSmartContract) getOrUpdateStakePool(
+func (ssc *StorageSmartContract) getOrCreateStakePool(
 	conf *Config,
-	providerId datastore.Key,
 	providerType spenum.Provider,
+	providerId datastore.Key,
 	settings stakepool.Settings,
 	balances chainstate.StateContextI,
 ) (*stakePool, error) {
@@ -391,7 +428,7 @@ func (ssc *StorageSmartContract) getOrUpdateStakePool(
 	}
 
 	// the stake pool can be created by related validator
-	sp, err := ssc.getStakePool(providerId, balances)
+	sp, err := ssc.getStakePool(providerType, providerId, balances)
 	if err != nil {
 		if err != util.ErrValueNotPresent {
 			return nil, fmt.Errorf("unexpected error: %v", err)
@@ -409,8 +446,9 @@ func (ssc *StorageSmartContract) getOrUpdateStakePool(
 }
 
 type stakePoolRequest struct {
-	BlobberID string `json:"blobber_id,omitempty"`
-	PoolID    string `json:"pool_id,omitempty"`
+	ProviderType spenum.Provider `json:"provider_type,omitempty"`
+	ProviderID   string       `json:"provider_id,omitempty"`
+	PoolID       string       `json:"pool_id,omitempty"`
 }
 
 func (spr *stakePoolRequest) decode(p []byte) (err error) {
@@ -450,7 +488,7 @@ func (ssc *StorageSmartContract) stakePoolLock(t *transaction.Transaction,
 	}
 
 	var sp *stakePool
-	if sp, err = ssc.getStakePool(spr.BlobberID, balances); err != nil {
+	if sp, err = ssc.getStakePool(spr.ProviderType, spr.ProviderID, balances); err != nil {
 		return "", common.NewErrorf("stake_pool_lock_failed",
 			"can't get stake pool: %v", err)
 	}
@@ -461,30 +499,22 @@ func (ssc *StorageSmartContract) stakePoolLock(t *transaction.Transaction,
 			conf.MaxDelegates)
 	}
 
-	err = sp.LockPool(t, spenum.Blobber, spr.BlobberID, spenum.Active, balances)
+	err = sp.LockPool(t, spr.ProviderType, spr.ProviderID, spenum.Active, balances)
 	if err != nil {
 		return "", common.NewErrorf("stake_pool_lock_failed",
 			"stake pool digging error: %v", err)
 	}
 
-	if err = sp.save(ssc.ID, spr.BlobberID, balances); err != nil {
+	if err = sp.save(spr.ProviderType, spr.ProviderID, balances); err != nil {
 		return "", common.NewErrorf("stake_pool_lock_failed",
 			"saving stake pool: %v", err)
 	}
 
-	staked, err := sp.stake()
+	err = sp.stakeByProvider(spr.ProviderType, spr.ProviderID, balances)
 	if err != nil {
 		return "", common.NewErrorf("stake_pool_lock_failed",
 			"stake pool staking error: %v", err)
 	}
-
-	data := dbs.DbUpdates{
-		Id: spr.BlobberID,
-		Updates: map[string]interface{}{
-			"total_stake": int64(staked),
-		},
-	}
-	balances.EmitEvent(event.TypeStats, event.TagUpdateBlobber, spr.BlobberID, data)
 
 	return
 }
@@ -501,7 +531,7 @@ func (ssc *StorageSmartContract) stakePoolUnlock(
 			"can't decode request: %v", err)
 	}
 	var sp *stakePool
-	if sp, err = ssc.getStakePool(spr.BlobberID, balances); err != nil {
+	if sp, err = ssc.getStakePool(spr.ProviderType, spr.ProviderID, balances); err != nil {
 		return "", common.NewErrorf("stake_pool_unlock_failed",
 			"can't get related stake pool: %v", err)
 	}
@@ -530,48 +560,35 @@ func (ssc *StorageSmartContract) stakePoolUnlock(
 	// as 'unstake' and returns maximal time to wait to unlock the pool
 	if !unstake {
 		// save the pool and return special result
-		if err = sp.save(ssc.ID, spr.BlobberID, balances); err != nil {
+		if err = sp.save(spr.ProviderType, spr.ProviderID, balances); err != nil {
 			return "", common.NewErrorf("stake_pool_unlock_failed",
 				"saving stake pool: %v", err)
 		}
-		staked, err := sp.stake()
+		err = sp.stakeByProvider(spr.ProviderType, spr.ProviderID, balances)
 		if err != nil {
 			return "", common.NewErrorf("stake_pool_unlock_failed",
 				"stake pool staking error: %v", err)
 		}
-		data := dbs.DbUpdates{
-			Id: spr.BlobberID,
-			Updates: map[string]interface{}{
-				"total_stake": int64(staked),
-			},
-		}
-		balances.EmitEvent(event.TypeStats, event.TagUpdateBlobber, spr.BlobberID, data)
+
 		return toJson(&unlockResponse{Unstake: false}), nil
 	}
 
-	amount, err := sp.UnlockClientStakePool(t.ClientID, spenum.Blobber, spr.BlobberID, spr.PoolID, balances)
+	amount, err := sp.UnlockClientStakePool(t.ClientID, spr.ProviderType, spr.ProviderID, spr.PoolID, balances)
 	if err != nil {
 		return "", common.NewErrorf("stake_pool_unlock_failed", "%v", err)
 	}
 
 	// save the pool
-	if err = sp.save(ssc.ID, spr.BlobberID, balances); err != nil {
+	if err = sp.save(spr.ProviderType, spr.ProviderID, balances); err != nil {
 		return "", common.NewErrorf("stake_pool_unlock_failed",
 			"saving stake pool: %v", err)
 	}
 
-	staked, err := sp.stake()
+	err = sp.stakeByProvider(spr.ProviderType, spr.ProviderID, balances)
 	if err != nil {
 		return "", common.NewErrorf("stake_pool_unlock_failed",
 			"stake pool staking error: %v", err)
 	}
-	data := dbs.DbUpdates{
-		Id: spr.BlobberID,
-		Updates: map[string]interface{}{
-			"total_stake": int64(staked),
-		},
-	}
-	balances.EmitEvent(event.TypeStats, event.TagUpdateBlobber, spr.BlobberID, data)
 
 	return toJson(&unlockResponse{Unstake: true, Balance: amount}), nil
 }

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool_test.go
@@ -31,7 +31,7 @@ func Test_newStakePool(t *testing.T) {
 }
 
 func Test_stakePoolKey(t *testing.T) {
-	assert.NotZero(t, stakePoolKey("scKey", "blobberID"))
+	assert.NotZero(t, stakePoolKey(spenum.Blobber, "blobberID"))
 }
 
 func Test_stakePool_Encode_Decode(t *testing.T) {
@@ -46,8 +46,8 @@ func Test_stakePool_save(t *testing.T) {
 		sp       = newStakePool()
 		balances = newTestBalances(t, false)
 	)
-	require.NoError(t, sp.save(ADDRESS, blobID, balances))
-	assert.NotZero(t, balances.tree[stakePoolKey(ADDRESS, blobID)])
+	require.NoError(t, sp.save(spenum.Blobber, blobID, balances))
+	assert.NotZero(t, balances.tree[stakePoolKey(spenum.Blobber, blobID)])
 }
 
 type mockStakePool struct {
@@ -147,7 +147,8 @@ func testStakePoolLock(t *testing.T, value, clientBalance currency.Coin, delegat
 	_, err := ctx.InsertTrieNode(scConfigKey(ssc.ID), scYaml)
 	require.NoError(t, err)
 	var spr = &stakePoolRequest{
-		BlobberID: blobberId,
+		ProviderType: spenum.Blobber,
+		ProviderID: blobberId,
 		PoolID:    "paula",
 	}
 	input, err := json.Marshal(spr)
@@ -162,14 +163,14 @@ func testStakePoolLock(t *testing.T, value, clientBalance currency.Coin, delegat
 	}
 	var usp = stakepool.NewUserStakePools()
 	require.NoError(t, usp.Save(spenum.Blobber, txn.ClientID, ctx))
-	require.NoError(t, stakePool.save(ssc.ID, blobberId, ctx))
+	require.NoError(t, stakePool.save(spenum.Blobber, blobberId, ctx))
 
 	resp, err := ssc.stakePoolLock(txn, input, ctx)
 	if err != nil {
 		return err
 	}
 
-	newStakePool, err := ssc.getStakePool(blobberId, ctx)
+	newStakePool, err := ssc.getStakePool(spenum.Blobber, blobberId, ctx)
 	require.NoError(t, err)
 	var newUsp *stakepool.UserStakePools
 	newUsp, err = stakepool.GetUserStakePools(spenum.Blobber, txn.ClientID, ctx)

--- a/code/go/0chain.net/smartcontract/storagesc/validator_eventdb.go
+++ b/code/go/0chain.net/smartcontract/storagesc/validator_eventdb.go
@@ -8,22 +8,6 @@ import (
 	"0chain.net/smartcontract/dbs/event"
 )
 
-func writeMarkerToValidationNode(vn *ValidationNode) *event.Validator { //nolint
-	return &event.Validator{
-		ValidatorID: vn.ID,
-		BaseUrl:     vn.BaseURL,
-		PublicKey:   vn.PublicKey,
-		// TO-DO: Update stake in eventDB
-		Stake: 0,
-
-		DelegateWallet: vn.StakePoolSettings.DelegateWallet,
-		MinStake:       vn.StakePoolSettings.MinStake,
-		MaxStake:       vn.StakePoolSettings.MaxStake,
-		NumDelegates:   vn.StakePoolSettings.MaxNumDelegates,
-		ServiceCharge:  vn.StakePoolSettings.ServiceChargeRatio,
-	}
-}
-
 func validatorTableToValidationNode(v event.Validator) *ValidationNode {
 	return &ValidationNode{
 		ID:        v.ValidatorID,


### PR DESCRIPTION
## Fixes
https://github.com/0chain/0chain/issues/1527
## Changes

Changes stakepool, which would only differentiate between provider by ID. This means providers with same ID would result in unnoticeable conflict. We are now asking providers to introduce themselves by their type and let them create their own separate pool that would not have the aforementioned cross-provider ID conflict.

This is how validator can now be staked with a little modification go-sdk and zbox.

## Need to be mentioned in CHANGELOG.md?
Not sure yet

## Associated PRs (Link as appropriate):
- gosdk: https://github.com/0chain/gosdk/pull/539
- zboxcli: https://github.com/0chain/zboxcli/pull/286
- system_test: https://github.com/0chain/system_test/pull/377
