### PR TITLE
go mod tidy and doc-fix the command to burn tokens in zcn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Then execute `choco install make` command in shell, now you will be able to use `make` on Windows.
 
 
-ifeq ($(OS),Windows_NT) 
+ifeq ($(OS),Windows_NT)
     detected_OS := Windows
 		detected_ARCH := x86_64
 else
@@ -51,7 +51,7 @@ install-mockery:
 	&& cp ./tmp/mockery/mockery $(GOPATH)/bin/ \
 	&& rm -rf ./tmp
 
-build-mocks: 
+build-mocks:
 	./generate_mocks.sh
 
 install-msgp:

--- a/code/go/0chain.net/go.mod
+++ b/code/go/0chain.net/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/didip/tollbooth v4.0.2+incompatible
 	github.com/go-openapi/runtime v0.24.1
 	github.com/go-playground/validator/v10 v10.11.0
-	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/gocql/gocql v1.1.0
 	github.com/golang/snappy v0.0.4
 	github.com/gomodule/redigo v1.8.8

--- a/code/go/0chain.net/go.sum
+++ b/code/go/0chain.net/go.sum
@@ -147,8 +147,6 @@ github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/j
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
 github.com/go-playground/validator/v10 v10.11.0 h1:0W+xRM511GY47Yy3bZUbJVitCNg2BOGlCyvTqsp/xIw=
 github.com/go-playground/validator/v10 v10.11.0/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
-github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
-github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=

--- a/code/go/0chain.net/smartcontract/zcnsc/README.MD
+++ b/code/go/0chain.net/smartcontract/zcnsc/README.MD
@@ -185,7 +185,7 @@ done
 Using this command burn some tokens in ZCN
 
 ```shell
-./zwallet bridge-burn-zcn --amount 1 
+./zwallet bridge-burn-zcn --token 1 
 ```
 
 5. Mint WZCN tokens


### PR DESCRIPTION
## Fixes
1. documentation fix: correct the command to burn tokens in zcn
2. run `go mod tidy` to make sure that all the go mod is properly updated3. 

## Changes
the command to burn tokens in zcn

## Need to be mentioned in CHANGELOG.md?
no

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
