### PR TITLE
Increment alloc stats reads on "read_redeem" txn

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -426,6 +426,9 @@ func (sc *StorageSmartContract) commitBlobberRead(t *transaction.Transaction,
 			"can't get related stake pool: %v", err)
 	}
 
+	details.Stats.NumReads++
+	alloc.Stats.NumReads++
+
 	resp, err = rp.moveToBlobber(commitRead.ReadMarker.AllocationID,
 		commitRead.ReadMarker.BlobberID, sp, value, balances)
 	if err != nil {
@@ -511,6 +514,8 @@ func (sc *StorageSmartContract) commitBlobberRead(t *transaction.Transaction,
 	if err != nil {
 		return "", common.NewError("saving read marker", err.Error())
 	}
+
+	balances.EmitEvent(event.TypeStats, event.TagUpdateAllocation, alloc.ID, alloc.buildDbUpdates())
 
 	err = emitAddOrOverwriteReadMarker(commitRead.ReadMarker, balances, t)
 	if err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
@@ -290,6 +290,7 @@ func testCommitBlobberRead(
 				Terms: Terms{
 					ReadPrice: zcnToBalance(blobberYaml.readPrice),
 				},
+				Stats: &StorageAllocationStats{},
 			},
 		},
 		Owner: client.id,

--- a/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
@@ -294,6 +294,7 @@ func testCommitBlobberRead(
 			},
 		},
 		Owner: client.id,
+		Stats: &StorageAllocationStats{},
 	}
 	_, err = ctx.InsertTrieNode(storageAllocation.GetKey(ssc.ID), storageAllocation)
 	require.NoError(t, err)


### PR DESCRIPTION
## Fixes

Increment alloc stats reads on "read_redeem" txn

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
