### PR TITLE
Add a field to identify if the block is finalised or not

### DIFF
--- a/code/go/0chain.net/chaincore/block/block_eventdb.go
+++ b/code/go/0chain.net/chaincore/block/block_eventdb.go
@@ -26,6 +26,7 @@ func blockToBlockEvent(block *Block) *event.Block {
 		RunningTxnCount:       fmt.Sprintf("%d", block.RunningTxnCount),
 		RoundTimeoutCount:     block.RoundTimeoutCount,
 		CreatedAt:             block.CreationDateField.ToTime(),
+		IsFinalised:           block.IsBlockFinalised(),
 	}
 }
 

--- a/code/go/0chain.net/chaincore/block/entity.go
+++ b/code/go/0chain.net/chaincore/block/entity.go
@@ -161,6 +161,7 @@ type Block struct {
 	stateMutex            sync.RWMutex `json:"-" msgpack:"-"`
 	blockState            int8
 	isNotarized           bool
+	isFinalised           bool         // set this field when the block is finalised
 	ticketsMutex          sync.RWMutex `json:"-" msgpack:"-"`
 	verificationStatus    int
 	RunningTxnCount       int64           `json:"running_txn_count"`
@@ -651,6 +652,21 @@ func (b *Block) IsBlockNotarized() bool {
 	defer b.ticketsMutex.RUnlock()
 
 	return b.isNotarized
+}
+
+//SetBlockFinalised - set the block as finalised
+func (b *Block) SetBlockFinalised() {
+	b.ticketsMutex.Lock()
+	defer b.ticketsMutex.Unlock()
+	b.isFinalised = true
+}
+
+//IsBlockFinalised - is block notarized?
+func (b *Block) IsBlockFinalised() bool {
+	b.ticketsMutex.RLock()
+	defer b.ticketsMutex.RUnlock()
+
+	return b.isFinalised
 }
 
 /*SetVerificationStatus - set the verification status of the block by this node */

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -624,6 +624,7 @@ func (mc *Chain) FinalizeBlock(ctx context.Context, b *block.Block) error {
 	for idx, txn := range b.Txns {
 		modifiedTxns[idx] = txn
 	}
+	b.SetBlockFinalised()
 	return mc.deleteTxns(modifiedTxns)
 }
 

--- a/code/go/0chain.net/smartcontract/dbs/event/block.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/block.go
@@ -30,6 +30,7 @@ type Block struct {
 	RunningTxnCount       string    `json:"running_txn_count"`
 	RoundTimeoutCount     int       `json:"round_timeout_count"`
 	CreatedAt             time.Time `json:"created_at"`
+	IsFinalised           bool      `json:"is_finalised"`
 }
 
 func (edb *EventDb) GetBlockByHash(hash string) (Block, error) {


### PR DESCRIPTION
## Fixes
https://github.com/0chain/0chain/issues/1550

## Changes
throughout the lifetime of a block, we emit block events to events db at 2 places:
* when the block is notarized
* when the block is finalised

to differentiate between both the type of block events we add a boolean field that identify the finalised blocks

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
