### PR TITLE
cancellation charge

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -251,7 +251,6 @@ type AllocationQuery struct {
 	}
 	AllocationSize     int64
 	AllocationSizeInGB float64
-	PreferredBlobbers  []string
 	NumberOfDataShards int
 }
 

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -12,17 +12,16 @@ import (
 	"time"
 
 	"0chain.net/chaincore/currency"
-
 	"0chain.net/smartcontract/dbs"
 	"0chain.net/smartcontract/dbs/event"
 	"0chain.net/smartcontract/stakepool/spenum"
 	"github.com/0chain/common/core/logging"
+	"github.com/0chain/common/core/util"
 	"go.uber.org/zap"
 
 	chainstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/transaction"
 	"0chain.net/core/common"
-	"github.com/0chain/common/core/util"
 )
 
 // getAllocation by ID
@@ -104,6 +103,34 @@ func (nar *newAllocationRequest) storageAllocation() (sa *StorageAllocation) {
 	return
 }
 
+func (nar *newAllocationRequest) validate(now time.Time, conf *Config) error {
+	if nar.DataShards <= 0 {
+		return errors.New("invalid number of data shards")
+	}
+
+	if len(nar.Blobbers) < (nar.DataShards + nar.ParityShards) {
+		return errors.New("blobbers provided are not enough to honour the allocation")
+	}
+
+	if !nar.ReadPriceRange.isValid() {
+		return errors.New("invalid read_price range")
+	}
+
+	if !nar.WritePriceRange.isValid() {
+		return errors.New("invalid write_price range")
+	}
+
+	if nar.Size < conf.MinAllocSize {
+		return errors.New("insufficient allocation size")
+	}
+
+	dur := common.ToTime(nar.Expiration).Sub(now)
+	if dur < conf.MinAllocDuration {
+		return errors.New("insufficient allocation duration")
+	}
+	return nil
+}
+
 func (nar *newAllocationRequest) decode(b []byte) error {
 	return json.Unmarshal(b, nar)
 }
@@ -134,8 +161,14 @@ func (sc *StorageSmartContract) filterBlobbersByFreeSpace(now common.Timestamp,
 		if b.Terms.WritePrice == 0 {
 			return false // keep, ok or already filtered by bid
 		}
+		staked, err := sp.stake()
+		if err != nil {
+			logging.Logger.Error("filter blobber for stake, cannot total stake",
+				zap.String("blobber id", b.ID))
+			return true
+		}
 		// clean capacity (without delegate pools want to 'unstake')
-		free, err := sp.unallocatedCapacity(b.Terms.WritePrice)
+		free, err := unallocatedCapacity(b.Terms.WritePrice, staked, sp.TotalOffers)
 		if err != nil {
 			return true // kick off
 		}
@@ -180,10 +213,8 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 	balances chainstate.StateContextI,
 	timings map[string]time.Duration,
 ) (resp string, err error) {
-	m := Timings{timings: timings, start: time.Now()}
-
+	m := Timings{timings: timings, start: common.ToTime(txn.CreationDate)}
 	var request newAllocationRequest
-	logging.Logger.Debug("new_allocation_request", zap.String("request", string(input)))
 	if err = request.decode(input); err != nil {
 		logging.Logger.Error("new_allocation_request_failed: error decoding input",
 			zap.String("txn", txn.Hash),
@@ -191,37 +222,8 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 		return "", common.NewErrorf("allocation_creation_failed",
 			"malformed request: %v", err)
 	}
-
-	m.tick("decode")
-	if len(request.Blobbers) < (request.DataShards + request.ParityShards) {
-		logging.Logger.Error("new_allocation_request_failed: input blobbers less than requirement",
-			zap.String("txn", txn.Hash),
-			zap.Int("request blobbers", len(request.Blobbers)),
-			zap.Int("data shards", request.DataShards),
-			zap.Int("parity_shards", request.ParityShards))
-		return "", common.NewErrorf("allocation_creation_failed",
-			"Blobbers provided are not enough to honour the allocation")
-	}
-
-	//if more than limit blobbers sent, just cut them
-	if len(request.Blobbers) > conf.MaxBlobbersPerAllocation {
-		logging.Logger.Error("new_allocation_request_failed: request blobbers more than max_blobbers_per_allocation",
-			zap.String("txn", txn.Hash),
-			zap.Int("requested blobbers", len(request.Blobbers)),
-			zap.Int("max blobbers per allocation", conf.MaxBlobbersPerAllocation))
-		logging.Logger.Info("Too many blobbers selected, max available", zap.Int("max_blobber_size", conf.MaxBlobbersPerAllocation))
-		request.Blobbers = request.Blobbers[:conf.MaxBlobbersPerAllocation]
-	}
-
-	inputBlobbers := sc.getBlobbers(request.Blobbers, balances)
-	if len(inputBlobbers.Nodes) < (request.DataShards + request.ParityShards) {
-		logging.Logger.Error("new_allocation_request_failed: blobbers fetched are less than requested blobbers",
-			zap.String("txn", txn.Hash),
-			zap.Int("fetched blobbers", len(inputBlobbers.Nodes)),
-			zap.Int("data shards", request.DataShards),
-			zap.Int("parity_shards", request.ParityShards))
-		return "", common.NewErrorf("allocation_creation_failed",
-			"Not enough provided blobbers found in mpt")
+	if err := request.validate(common.ToTime(txn.CreationDate), conf); err != nil {
+		return "", common.NewErrorf("allocation_creation_failed", err.Error())
 	}
 
 	if request.Owner == "" {
@@ -229,44 +231,43 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 		request.OwnerPublicKey = txn.PublicKey
 	}
 
-	logging.Logger.Debug("new_allocation_request", zap.String("t_hash", txn.Hash), zap.Strings("blobbers", request.Blobbers))
-	var sa = request.storageAllocation() // (set fields, including expiration)
-	blobbers, err := sc.fetchPools(inputBlobbers, balances)
-	if err != nil {
-		logging.Logger.Error("new_allocation_request_failed: error fetching blobber pools",
+	inputBlobbers := getBlobbersByIDs(request.Blobbers, balances)
+	if len(inputBlobbers) < (request.DataShards + request.ParityShards) {
+		logging.Logger.Error("new_allocation_request_failed: blobbers fetched are less than requested blobbers",
 			zap.String("txn", txn.Hash),
-			zap.Error(err))
+			zap.Int("fetched blobbers", len(inputBlobbers)),
+			zap.Int("data shards", request.DataShards),
+			zap.Int("parity_shards", request.ParityShards))
+		return "", common.NewErrorf("allocation_creation_failed",
+			"Blobbers provided are not enough to honour the allocation")
+	}
+	spMap, err := getStakePoolsByIDs(request.Blobbers, balances)
+	if err != nil {
+		return "", common.NewErrorf("allocation_creation_failed", "getting stake pools: %v", err)
+	}
+	if len(spMap) != len(inputBlobbers) {
+		return "", common.NewErrorf("allocation_creation_failed", "missing blobber's stake pool: %v", err)
+	}
+	var sns []*storageNodeResponse
+	for i := 0; i < len(inputBlobbers); i++ {
+		stake, err := spMap[inputBlobbers[i].ID].stake()
+		if err != nil {
+			return "", common.NewErrorf("allocation_creation_failed", "cannot total stake pool for blobber %s: %v", inputBlobbers[i].ID, err)
+		}
+		sns = append(sns, &storageNodeResponse{
+			StorageNode: inputBlobbers[i],
+			TotalOffers: spMap[inputBlobbers[i].ID].TotalOffers,
+			TotalStake:  stake,
+		})
+	}
+
+	sa, blobberNodes, err := setupNewAllocation(request, sns, m, txn.CreationDate, conf, txn.Hash)
+	if err != nil {
 		return "", err
 	}
-	m.tick("fetch_pools")
-	sa.TimeUnit = conf.TimeUnit
 
-	blobberNodes, bSize, err := sc.validateBlobbers(common.ToTime(txn.CreationDate), sa, balances, blobbers)
-	if err != nil {
-		logging.Logger.Error("new_allocation_request_failed: error validating blobbers",
-			zap.String("txn", txn.Hash),
-			zap.Error(err))
-		return "", common.NewErrorf("allocation_creation_failed", "%v", err)
-	}
-	bi := make([]string, 0, len(blobberNodes))
 	for _, b := range blobberNodes {
-		bi = append(bi, b.ID)
-	}
-	logging.Logger.Debug("new_allocation_request", zap.Int64("size", bSize), zap.Strings("blobbers", bi))
-	m.tick("validate_blobbers")
-
-	sa.ID = txn.Hash
-	for _, b := range blobberNodes {
-		balloc, err := newBlobberAllocation(bSize, sa, b.StorageNode, txn.CreationDate, conf.TimeUnit)
-		if err != nil {
-			return "", common.NewErrorf("allocation_creation_failed",
-				"can't create blobber allocation: %v", err)
-		}
-
-		sa.BlobberAllocs = append(sa.BlobberAllocs, balloc)
-
-		b.Allocated += bSize
-		_, err = balances.InsertTrieNode(b.GetKey(sc.ID), b.StorageNode)
+		_, err = balances.InsertTrieNode(b.GetKey(sc.ID), b)
 		if err != nil {
 			logging.Logger.Error("new_allocation_request_failed: error inserting blobber",
 				zap.String("txn", txn.Hash),
@@ -275,14 +276,15 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 			return "", fmt.Errorf("can't save blobber: %v", err)
 		}
 
-		if err := b.Pool.addOffer(balloc.Offer()); err != nil {
+		if err := spMap[b.ID].addOffer(sa.BlobberAllocsMap[b.ID].Offer()); err != nil {
 			logging.Logger.Error("new_allocation_request_failed: error adding offer to blobber",
 				zap.String("txn", txn.Hash),
 				zap.String("blobber", b.ID),
 				zap.Error(err))
 			return "", fmt.Errorf("ading offer: %v", err)
 		}
-		if err = b.Pool.save(spenum.Blobber, b.ID, balances); err != nil {
+
+		if err = spMap[b.ID].save(spenum.Blobber, b.ID, balances); err != nil {
 			logging.Logger.Error("new_allocation_request_failed: error saving blobber pool",
 				zap.String("txn", txn.Hash),
 				zap.String("blobber", b.ID),
@@ -290,10 +292,6 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 			return "", fmt.Errorf("can't save blobber's stake pool: %v", err)
 		}
 	}
-	m.tick("add_offer")
-
-	sa.StartTime = txn.CreationDate
-	sa.Tx = txn.Hash
 
 	var options []WithOption
 	if mintNewTokens > 0 {
@@ -307,19 +305,18 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 		return "", common.NewError("allocation_creation_failed", err.Error())
 	}
 
-	mld, err := sa.restMinLockDemand()
+	cost, err := sa.cost()
 	if err != nil {
-		return "", common.NewError("allocation_creation_failed", "error in calculating min lock demand: "+err.Error())
+		return "", err
 	}
-	if sa.WritePool < mld {
-		logging.Logger.Error("new_allocation_request_failed: writepool balance less than min lock demand",
-			zap.String("txn", txn.Hash),
-			zap.Any("writepool", sa.WritePool),
-			zap.Any("mld", mld))
+	if sa.WritePool < cost {
 		return "", common.NewError("allocation_creation_failed",
-			fmt.Sprintf("not enough tokens to honor the min lock demand"+" (%d < %d)", txn.Value, mld))
+			fmt.Sprintf("not enough tokens to cover the allocatin cost"+" (%d < %d)", sa.WritePool, cost))
 	}
 
+	if err := sa.checkFunding(conf.CancellationCharge); err != nil {
+		return "", common.NewError("allocation_creation_failed", err.Error())
+	}
 	m.tick("create_write_pool")
 
 	if err = sc.createChallengePool(txn, sa, balances); err != nil {
@@ -346,6 +343,71 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 	return resp, err
 }
 
+func setupNewAllocation(
+	request newAllocationRequest,
+	blobbers []*storageNodeResponse,
+	m Timings,
+	now common.Timestamp,
+	conf *Config,
+	allocId string,
+) (*StorageAllocation, []*StorageNode, error) {
+	var err error
+	m.tick("decode")
+	if len(request.Blobbers) < (request.DataShards + request.ParityShards) {
+		logging.Logger.Error("new_allocation_request_failed: input blobbers less than requirement",
+			zap.Int("request blobbers", len(request.Blobbers)),
+			zap.Int("data shards", request.DataShards),
+			zap.Int("parity_shards", request.ParityShards))
+		return nil, nil, common.NewErrorf("allocation_creation_failed",
+			"Blobbers provided are not enough to honour the allocation")
+	}
+
+	//if more than limit blobbers sent, just cut them
+	if len(request.Blobbers) > conf.MaxBlobbersPerAllocation {
+		logging.Logger.Error("new_allocation_request_failed: request blobbers more than max_blobbers_per_allocation",
+			zap.Int("requested blobbers", len(request.Blobbers)),
+			zap.Int("max blobbers per allocation", conf.MaxBlobbersPerAllocation))
+		logging.Logger.Info("Too many blobbers selected, max available", zap.Int("max_blobber_size", conf.MaxBlobbersPerAllocation))
+		request.Blobbers = request.Blobbers[:conf.MaxBlobbersPerAllocation]
+	}
+
+	logging.Logger.Debug("new_allocation_request", zap.Strings("blobbers", request.Blobbers))
+	var sa = request.storageAllocation() // (set fields, including expiration)
+	m.tick("fetch_pools")
+	sa.TimeUnit = conf.TimeUnit
+	sa.ID = allocId
+	sa.Tx = allocId
+
+	blobberNodes, bSize, err := validateBlobbers(common.ToTime(now), sa, blobbers, conf)
+	if err != nil {
+		logging.Logger.Error("new_allocation_request_failed: error validating blobbers",
+			zap.Error(err))
+		return nil, nil, common.NewErrorf("allocation_creation_failed", "%v", err)
+	}
+	bi := make([]string, 0, len(blobberNodes))
+	for _, b := range blobberNodes {
+		bi = append(bi, b.ID)
+	}
+	logging.Logger.Debug("new_allocation_request", zap.Int64("size", bSize), zap.Strings("blobbers", bi))
+	m.tick("validate_blobbers")
+
+	sa.BlobberAllocsMap = make(map[string]*BlobberAllocation, len(blobberNodes))
+	for _, b := range blobberNodes {
+		balloc, err := newBlobberAllocation(bSize, sa, b, now, conf.TimeUnit)
+		if err != nil {
+			return nil, nil, common.NewErrorf("allocation_creation_failed",
+				"can't create blobber allocation: %v", err)
+		}
+		sa.BlobberAllocs = append(sa.BlobberAllocs, balloc)
+		sa.BlobberAllocsMap[b.ID] = balloc
+		b.Allocated += bSize
+	}
+	m.tick("add_offer")
+
+	sa.StartTime = now
+	return sa, blobberNodes, nil
+}
+
 type Timings struct {
 	timings map[string]time.Duration
 	start   time.Time
@@ -358,7 +420,65 @@ func (t *Timings) tick(name string) {
 	t.timings[name] = time.Since(t.start)
 }
 
-func (sc *StorageSmartContract) fetchPools(inputBlobbers *StorageNodes, balances chainstate.StateContextI) ([]*blobberWithPool, error) {
+func (sc *StorageSmartContract) fetchStorageNodePlusStake(blobberIds []string, balances chainstate.CommonStateContextI) ([]storageNodeResponse, error) {
+	type indexedBlobber struct {
+		index   int
+		blobber storageNodeResponse
+	}
+	blobbers := make([]indexedBlobber, 0, len(blobberIds))
+	pools := make(chan indexedBlobber, len(blobberIds))
+	errs := make(chan error, len(blobberIds))
+
+	for i, id := range blobberIds {
+		go func(id string, i int) {
+			var err error
+			blobber, err := getBlobber(id, balances)
+			if err != nil || blobber == nil {
+				errs <- err
+				return
+			}
+			sp, err := sc.getStakePool(spenum.Blobber, id, balances)
+			if err != nil {
+				errs <- common.NewErrorf("allocation_creation_failed", "can't get blobber's stake pool: %v", err)
+				return
+			}
+			stake, err := sp.stake()
+			if err != nil {
+				errs <- err
+				return
+			}
+			sns := storageNodeResponse{
+				StorageNode: blobber,
+				TotalStake:  stake,
+				TotalOffers: sp.TotalOffers,
+			}
+			pools <- indexedBlobber{i, sns}
+		}(id, i)
+	}
+
+	for {
+		if len(blobbers) == len(blobberIds) {
+			//ensure ordering
+			sort.Slice(blobbers, func(i, j int) bool {
+				return blobbers[i].index < blobbers[j].index
+			})
+			retBlobbers := make([]storageNodeResponse, 0, len(blobberIds))
+			for _, b := range blobbers {
+				retBlobbers = append(retBlobbers, b.blobber)
+			}
+			return retBlobbers, nil
+		}
+
+		select {
+		case err := <-errs:
+			return nil, err
+		case p := <-pools:
+			blobbers = append(blobbers, p)
+		}
+	}
+}
+
+func (sc *StorageSmartContract) fetchPools(inputBlobbers *StorageNodes, balances chainstate.CommonStateContextI) ([]*blobberWithPool, error) {
 	blobbers := make([]*blobberWithPool, 0, len(inputBlobbers.Nodes))
 	pools := make(chan *blobberWithPool, len(inputBlobbers.Nodes))
 	errs := make(chan error, len(inputBlobbers.Nodes))
@@ -459,30 +579,19 @@ func (_ *StorageSmartContract) getBlobbers(
 	return getBlobbers(blobberIDs, balances)
 }
 
-func (sc *StorageSmartContract) validateBlobbers(
+func validateBlobbers(
 	creationDate time.Time,
 	sa *StorageAllocation,
-	balances chainstate.StateContextI,
-	blobbers []*blobberWithPool,
-) ([]*blobberWithPool, int64, error) {
-	var err error
-	var conf *Config
-	if conf, err = sc.getConfig(balances, true); err != nil {
-		return nil, 0, fmt.Errorf("can't get config: %v", err)
-	}
-
+	blobbers []*storageNodeResponse,
+	conf *Config,
+) ([]*StorageNode, int64, error) {
 	sa.TimeUnit = conf.TimeUnit // keep the initial time unit
-
-	if err = sa.validate(creationDate, conf); err != nil {
-		return nil, 0, fmt.Errorf("invalid request: %v", err)
-	}
 
 	// number of blobbers required
 	var size = sa.DataShards + sa.ParityShards
 	// size of allocation for a blobber
 	var bSize = sa.bSize()
-	var list, errs = sa.validateEachBlobber(sc, blobbers, common.Timestamp(creationDate.Unix()),
-		balances)
+	var list, errs = sa.validateEachBlobber(blobbers, common.Timestamp(creationDate.Unix()))
 
 	if len(list) < size {
 		return nil, 0, errors.New("Not enough blobbers to honor the allocation: " + strings.Join(errs, ", "))
@@ -614,6 +723,46 @@ func getBlobbersByIDs(ids []string, balances chainstate.CommonStateContextI) []*
 	}
 
 	return filtered
+}
+
+func getStakePoolsByIDs(ids []string, balances chainstate.CommonStateContextI) (map[string]*stakePool, error) {
+	type spResp struct {
+		blobberId string
+		sp        *stakePool
+	}
+
+	stakePoolCh := make(chan spResp, len(ids))
+	errorChan := make(chan error, len(ids))
+	var wg sync.WaitGroup
+	for i, details := range ids {
+		wg.Add(1)
+		go func(index int, blobberId string) {
+			defer wg.Done()
+			sp, err := getStakePool(blobberId, balances)
+			if err != nil || sp == nil {
+				errorChan <- err
+			} else {
+				stakePoolCh <- spResp{
+					blobberId: blobberId,
+					sp:        sp,
+				}
+			}
+		}(i, details)
+	}
+	wg.Wait()
+	close(errorChan)
+	close(stakePoolCh)
+	for err := range errorChan {
+		if err != nil {
+			return nil, err
+		}
+	}
+	//ensure original ordering
+	stakePoolMap := make(map[string]*stakePool, len(ids))
+	for resp := range stakePoolCh {
+		stakePoolMap[resp.blobberId] = resp.sp
+	}
+	return stakePoolMap, nil
 }
 
 // getAllocationBlobbers loads blobbers of an allocation from store
@@ -968,21 +1117,6 @@ func (sc *StorageSmartContract) extendAllocation(
 		}
 	}
 
-	// is it about size increasing? if so, we should make sure the write
-	// pool has enough tokens
-	if diff > 0 {
-		if mldLeft, err := alloc.restMinLockDemand(); mldLeft > 0 {
-			if err != nil {
-				return common.NewErrorf("allocation_extending_failed",
-					"can't get min lock demand: %v", err)
-			}
-			if alloc.WritePool < mldLeft {
-				return common.NewError("allocation_extending_failed",
-					"not enough tokens in write pool to extend allocation")
-			}
-		}
-	}
-
 	// add more tokens to related challenge pool, or move some tokens back
 	var remainingDuration = alloc.Expiration - txn.CreationDate
 	err = sc.adjustChallengePool(alloc, originalRemainingDuration, remainingDuration, originalTerms, conf.TimeUnit, balances)
@@ -1191,13 +1325,17 @@ func (sc *StorageSmartContract) updateAllocationRequestInternal(
 	// otherwise, we use the same terms
 	if request.Size > 0 || request.Expiration > 0 {
 		err = sc.extendAllocation(t, conf, alloc, blobbers, &request, balances)
-	} else if request.Size != 0 || request.Expiration != 0 {
+	} else if request.Size < 0 || request.Expiration < 0 {
 		err = sc.reduceAllocation(t, conf, alloc, blobbers, &request, balances)
 	} else if len(request.AddBlobberId) > 0 {
 		err = sc.extendAllocation(t, conf, alloc, blobbers, &request, balances)
 	}
 	if err != nil {
 		return "", err
+	}
+
+	if err := alloc.checkFunding(conf.CancellationCharge); err != nil {
+		return "", common.NewError("allocation_updating_failed", err.Error())
 	}
 
 	if request.SetImmutable {
@@ -1559,10 +1697,6 @@ func (sc *StorageSmartContract) finishAllocation(
 			if err != nil {
 				return err
 			}
-			d.FinalReward, err = currency.AddCoin(d.FinalReward, delta)
-			if err != nil {
-				return err
-			}
 		}
 	}
 
@@ -1605,10 +1739,6 @@ func (sc *StorageSmartContract) finishAllocation(
 			d.Spent, err = currency.AddCoin(d.Spent, reward)
 			if err != nil {
 				return fmt.Errorf("blobber alloc spent: %v", err)
-			}
-			d.FinalReward, err = currency.AddCoin(d.FinalReward, reward)
-			if err != nil {
-				return fmt.Errorf("blobber alloc final reward: %v", err)
 			}
 			passPayments, err = currency.AddCoin(passPayments, reward)
 			if err != nil {
@@ -1667,6 +1797,33 @@ func (sc *StorageSmartContract) finishAllocation(
 		if err != nil {
 			return common.NewError("fini_alloc_failed",
 				"moving challenge pool rest back to write pool: "+err.Error())
+		}
+	}
+
+	conf, err := sc.getConfig(balances, true)
+	if err != nil {
+		return common.NewErrorf("allocation_creation_failed",
+			"can't get config: %v", err)
+	}
+
+	cancellationCharge, err := alloc.cancellationCharge(conf.CancellationCharge)
+	if err != nil {
+		return common.NewErrorf("allocation_creation_failed", err.Error())
+	}
+	if alloc.WritePool < cancellationCharge {
+		cancellationCharge = alloc.WritePool
+		logging.Logger.Error("insufficient funds, %v, for cancellation charge, %v. distributing the remaining write pool.")
+	}
+	reward, _, err := currency.DistributeCoin(cancellationCharge, int64(len(alloc.BlobberAllocs)))
+	if err != nil {
+		return common.NewErrorf("allocation_creation_failed", err.Error())
+	}
+
+	for i, ba := range alloc.BlobberAllocs {
+		err = sps[i].DistributeRewards(reward, ba.BlobberID, spenum.Blobber, balances)
+		if err != nil {
+			return common.NewError("fini_alloc_failed",
+				"paying cancellation charge to stake pool of "+ba.BlobberID+": "+err.Error())
 		}
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_rest_tests.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_rest_tests.go
@@ -156,19 +156,26 @@ func BenchmarkRestTests(
 				Endpoint: srh.getAllocations,
 			},
 			{
-				FuncName: "allocation_min_lock",
+				FuncName: "allocation-min-lock",
 				Params: map[string]string{
 					"allocation_data": func() string {
+						var blobbers []string
+						for i := 0; i < viper.GetInt(bk.NumBlobbersPerAllocation); i++ {
+							blobbers = append(blobbers, getMockBlobberId(i))
+						}
+						creationTimeRaw := viper.GetInt64(bk.MptCreationTime)
+						creationTime := common.Now()
+						if creationTimeRaw != 0 {
+							creationTime = common.Timestamp(creationTimeRaw)
+						}
 						nar, _ := (&newAllocationRequest{
-							DataShards:      viper.GetInt(bk.NumBlobbersPerAllocation) / 2,
-							ParityShards:    viper.GetInt(bk.NumBlobbersPerAllocation) / 2,
-							Size:            100 * viper.GetInt64(bk.StorageMinAllocSize),
-							Expiration:      2 * common.Timestamp(viper.GetDuration(bk.StorageMinAllocDuration).Seconds()),
-							Owner:           data.Clients[0],
-							OwnerPublicKey:  data.PublicKeys[0],
-							Blobbers:        []string{},
-							ReadPriceRange:  PriceRange{0, maxReadPrice},
-							WritePriceRange: PriceRange{0, maxWritePrice},
+							DataShards:      len(blobbers) / 2,
+							ParityShards:    len(blobbers) / 2,
+							Size:            10 * viper.GetInt64(bk.StorageMinAllocSize),
+							Expiration:      5*common.Timestamp(viper.GetDuration(bk.StorageMinAllocDuration).Seconds()) + creationTime,
+							Blobbers:        blobbers,
+							ReadPriceRange:  PriceRange{0, currency.Coin(viper.GetInt64(bk.StorageMaxReadPrice) * 1e10)},
+							WritePriceRange: PriceRange{0, currency.Coin(viper.GetInt64(bk.StorageMaxWritePrice) * 1e10)},
 						}).encode()
 						return string(nar)
 					}(),
@@ -311,7 +318,7 @@ func BenchmarkRestTests(
 				Endpoint: srh.getCollectedReward,
 			},
 			{
-				FuncName: "alloc_blobbers",
+				FuncName: "alloc-blobbers",
 				Params: map[string]string{
 					"allocation_data": func() string {
 						//now := common.Timestamp(time.Now().Unix())
@@ -320,9 +327,6 @@ func BenchmarkRestTests(
 							ParityShards:    viper.GetInt(bk.NumBlobbersPerAllocation) / 2,
 							Size:            100 * viper.GetInt64(bk.StorageMinAllocSize),
 							Expiration:      2 * common.Timestamp(viper.GetDuration(bk.StorageMinAllocDuration).Seconds()),
-							Owner:           data.Clients[0],
-							OwnerPublicKey:  data.PublicKeys[0],
-							Blobbers:        []string{},
 							ReadPriceRange:  PriceRange{0, maxReadPrice},
 							WritePriceRange: PriceRange{0, maxWritePrice},
 						}).encode()
@@ -349,7 +353,7 @@ func BenchmarkRestTests(
 				Endpoint: srh.getBlobberIdsByUrls,
 			},
 			{
-				FuncName: "free_alloc_blobbers",
+				FuncName: "free-alloc-blobbers",
 				Params: map[string]string{
 					"free_allocation_data": func() string {
 						var request = struct {

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
@@ -718,7 +718,7 @@ func getMockBlobberTerms() Terms {
 		ReadPrice:        currency.Coin(0.1 * 1e10),
 		WritePrice:       currency.Coin(0.1 * 1e10),
 		MinLockDemand:    0.0007,
-		MaxOfferDuration: time.Hour*50 + viper.GetDuration(sc.StorageMinOfferDuration),
+		MaxOfferDuration: time.Hour * 744,
 	}
 }
 
@@ -798,6 +798,7 @@ func SetMockConfig(
 	conf.MinBlobberCapacity = viper.GetInt64(sc.StorageMinBlobberCapacity)
 	conf.ValidatorReward = 0.025
 	conf.BlobberSlash = 0.1
+	conf.CancellationCharge = 0.2
 	conf.MaxReadPrice = 100e10  // 100 tokens per GB max allowed (by 64 KB)
 	conf.MaxWritePrice = 100e10 // 100 tokens per GB max allowed
 	conf.MinWritePrice = 0

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
@@ -198,7 +198,6 @@ func BenchmarkTests(
 				}(),
 			},
 			input: func() []byte {
-
 				bytes, _ := (&newAllocationRequest{
 					DataShards:      len(blobbers) / 2,
 					ParityShards:    len(blobbers) / 2,
@@ -744,6 +743,7 @@ func BenchmarkTests(
 
 					"max_total_free_allocation":      "10000",
 					"max_individual_free_allocation": "100",
+					"cancellation_charge":            "0.2",
 
 					"free_allocation_settings.data_shards":           "10",
 					"free_allocation_settings.parity_shards":         "5",

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -699,6 +699,11 @@ func (sc *StorageSmartContract) commitBlobberConnection(
 			"moving tokens: %v", err)
 	}
 
+	if err := alloc.checkFunding(conf.CancellationCharge); err != nil {
+		return "", common.NewErrorf("commit_connection_failed",
+			"insufficient funds: %v", err)
+	}
+
 	// the first time the allocation is added  to the blobber, created related resources
 	if blobAlloc.Stats.UsedSize == 0 {
 		err = removeAllocationFromBlobber(sc, blobAlloc, alloc.ID, balances)

--- a/code/go/0chain.net/smartcontract/storagesc/config.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config.go
@@ -138,6 +138,7 @@ type Config struct {
 	MinWritePrice currency.Coin `json:"min_write_price"`
 
 	// allocation cancellation
+	CancellationCharge float64 `json:"cancellation_charge"`
 
 	// FailedChallengesToCancel is number of failed challenges of an allocation
 	// to be able to cancel an allocation.
@@ -196,6 +197,10 @@ func (sc *Config) validate() (err error) {
 	if sc.BlobberSlash < 0.0 || 1.0 < sc.BlobberSlash {
 		return fmt.Errorf("blobber_slash not in [0; 1] range: %v",
 			sc.BlobberSlash)
+	}
+	if sc.CancellationCharge < 0.0 || 1.0 < sc.CancellationCharge {
+		return fmt.Errorf("cancellation_charge not in [0; 1] range: %v",
+			sc.CancellationCharge)
 	}
 	if sc.MaxBlobbersPerAllocation <= 0 {
 		return fmt.Errorf("invalid max_blobber_per_allocation <= 0: %v",
@@ -391,6 +396,7 @@ func getConfiguredConfig() (conf *Config, err error) {
 	conf.MinBlobberCapacity = scc.GetInt64(pfx + "min_blobber_capacity")
 	conf.ValidatorReward = scc.GetFloat64(pfx + "validator_reward")
 	conf.BlobberSlash = scc.GetFloat64(pfx + "blobber_slash")
+	conf.CancellationCharge = scc.GetFloat64(pfx + "cancellation_charge")
 	conf.MaxBlobbersPerAllocation = scc.GetInt(pfx + "max_blobbers_per_allocation")
 	conf.MaxReadPrice, err = currency.ParseZCN(scc.GetFloat64(pfx + "max_read_price"))
 	if err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/config_gen.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config_gen.go
@@ -9,9 +9,9 @@ import (
 // MarshalMsg implements msgp.Marshaler
 func (z *Config) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 34
+	// map header, size 35
 	// string "TimeUnit"
-	o = append(o, 0xde, 0x0, 0x22, 0xa8, 0x54, 0x69, 0x6d, 0x65, 0x55, 0x6e, 0x69, 0x74)
+	o = append(o, 0xde, 0x0, 0x23, 0xa8, 0x54, 0x69, 0x6d, 0x65, 0x55, 0x6e, 0x69, 0x74)
 	o = msgp.AppendDuration(o, z.TimeUnit)
 	// string "MaxMint"
 	o = append(o, 0xa7, 0x4d, 0x61, 0x78, 0x4d, 0x69, 0x6e, 0x74)
@@ -117,6 +117,9 @@ func (z *Config) MarshalMsg(b []byte) (o []byte, err error) {
 		err = msgp.WrapError(err, "MinWritePrice")
 		return
 	}
+	// string "CancellationCharge"
+	o = append(o, 0xb2, 0x43, 0x61, 0x6e, 0x63, 0x65, 0x6c, 0x6c, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x43, 0x68, 0x61, 0x72, 0x67, 0x65)
+	o = msgp.AppendFloat64(o, z.CancellationCharge)
 	// string "FailedChallengesToCancel"
 	o = append(o, 0xb8, 0x46, 0x61, 0x69, 0x6c, 0x65, 0x64, 0x43, 0x68, 0x61, 0x6c, 0x6c, 0x65, 0x6e, 0x67, 0x65, 0x73, 0x54, 0x6f, 0x43, 0x61, 0x6e, 0x63, 0x65, 0x6c)
 	o = msgp.AppendInt(o, z.FailedChallengesToCancel)
@@ -437,6 +440,12 @@ func (z *Config) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "MinWritePrice")
 				return
 			}
+		case "CancellationCharge":
+			z.CancellationCharge, bts, err = msgp.ReadFloat64Bytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "CancellationCharge")
+				return
+			}
 		case "FailedChallengesToCancel":
 			z.FailedChallengesToCancel, bts, err = msgp.ReadIntBytes(bts)
 			if err != nil {
@@ -606,7 +615,7 @@ func (z *Config) Msgsize() (s int) {
 	} else {
 		s += 1 + 8 + z.StakePool.MinLock.Msgsize() + 14 + msgp.DurationSize
 	}
-	s += 16 + msgp.Float64Size + 13 + msgp.Float64Size + 25 + msgp.IntSize + 13 + z.MaxReadPrice.Msgsize() + 14 + z.MaxWritePrice.Msgsize() + 14 + z.MinWritePrice.Msgsize() + 25 + msgp.IntSize + 32 + msgp.IntSize + 23 + z.MaxTotalFreeAllocation.Msgsize() + 28 + z.MaxIndividualFreeAllocation.Msgsize() + 23 + z.FreeAllocationSettings.Msgsize() + 17 + msgp.BoolSize + 27 + msgp.IntSize + 23 + msgp.IntSize + 24 + msgp.Float64Size + 9 + z.MinStake.Msgsize() + 9 + z.MaxStake.Msgsize() + 13 + msgp.IntSize + 10 + msgp.Float64Size + 12
+	s += 16 + msgp.Float64Size + 13 + msgp.Float64Size + 25 + msgp.IntSize + 13 + z.MaxReadPrice.Msgsize() + 14 + z.MaxWritePrice.Msgsize() + 14 + z.MinWritePrice.Msgsize() + 19 + msgp.Float64Size + 25 + msgp.IntSize + 32 + msgp.IntSize + 23 + z.MaxTotalFreeAllocation.Msgsize() + 28 + z.MaxIndividualFreeAllocation.Msgsize() + 23 + z.FreeAllocationSettings.Msgsize() + 17 + msgp.BoolSize + 27 + msgp.IntSize + 23 + msgp.IntSize + 24 + msgp.Float64Size + 9 + z.MinStake.Msgsize() + 9 + z.MaxStake.Msgsize() + 13 + msgp.IntSize + 10 + msgp.Float64Size + 12
 	if z.BlockReward == nil {
 		s += msgp.NilSize
 	} else {

--- a/code/go/0chain.net/smartcontract/storagesc/config_settigns.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config_settigns.go
@@ -46,6 +46,7 @@ const (
 
 	MaxTotalFreeAllocation
 	MaxIndividualFreeAllocation
+	CancellationCharge
 
 	FreeAllocationDataShards
 	FreeAllocationParityShards
@@ -139,6 +140,7 @@ var (
 
 		"max_total_free_allocation",
 		"max_individual_free_allocation",
+		"cancellation_charge",
 
 		"free_allocation_settings.data_shards",
 		"free_allocation_settings.parity_shards",
@@ -236,6 +238,7 @@ var (
 
 		"max_total_free_allocation":      {MaxTotalFreeAllocation, smartcontract.CurrencyCoin},
 		"max_individual_free_allocation": {MaxIndividualFreeAllocation, smartcontract.CurrencyCoin},
+		"cancellation_charge":            {CancellationCharge, smartcontract.Float64},
 
 		"free_allocation_settings.data_shards":           {FreeAllocationDataShards, smartcontract.Int},
 		"free_allocation_settings.parity_shards":         {FreeAllocationParityShards, smartcontract.Int},
@@ -434,6 +437,8 @@ func (conf *Config) setFloat64(key string, change float64) error {
 		conf.FreeAllocationSettings.ReadPoolFraction = change
 	case ValidatorReward:
 		conf.ValidatorReward = change
+	case CancellationCharge:
+		conf.CancellationCharge = change
 	case BlobberSlash:
 		conf.BlobberSlash = change
 	case ChallengeGenerationRate:
@@ -648,6 +653,8 @@ func (conf *Config) get(key Setting) interface{} {
 		return conf.MaxTotalFreeAllocation
 	case MaxIndividualFreeAllocation:
 		return conf.MaxIndividualFreeAllocation
+	case CancellationCharge:
+		return conf.CancellationCharge
 	case FreeAllocationDataShards:
 		return conf.FreeAllocationSettings.DataShards
 	case FreeAllocationParityShards:

--- a/code/go/0chain.net/smartcontract/storagesc/config_settings_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config_settings_test.go
@@ -136,6 +136,7 @@ func TestUpdateSettings(t *testing.T) {
 
 					"max_total_free_allocation":      "10000",
 					"max_individual_free_allocation": "100",
+					"cancellation_charge":            "0.2",
 
 					"free_allocation_settings.data_shards":           "10",
 					"free_allocation_settings.parity_shards":         "5",
@@ -338,6 +339,7 @@ func TestCommitSettingChanges(t *testing.T) {
 
 					"max_total_free_allocation":      "10000",
 					"max_individual_free_allocation": "100",
+					"cancellation_charge":            "0.2",
 
 					"free_allocation_settings.data_shards":           "10",
 					"free_allocation_settings.parity_shards":         "5",
@@ -425,6 +427,8 @@ func getConfField(conf Config, field string) interface{} {
 		return conf.MaxTotalFreeAllocation
 	case MaxIndividualFreeAllocation:
 		return conf.MaxIndividualFreeAllocation
+	case CancellationCharge:
+		return conf.CancellationCharge
 
 	case FreeAllocationDataShards:
 		return conf.FreeAllocationSettings.DataShards

--- a/code/go/0chain.net/smartcontract/storagesc/curator.go
+++ b/code/go/0chain.net/smartcontract/storagesc/curator.go
@@ -124,7 +124,7 @@ func (sc *StorageSmartContract) addCurator(
 	return "", nil
 }
 
-func (sa StorageAllocation) isCurator(id string) bool {
+func (sa *StorageAllocation) isCurator(id string) bool {
 	for _, curator := range sa.Curators {
 		if curator == id {
 			return true

--- a/code/go/0chain.net/smartcontract/storagesc/free_allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/free_allocation_test.go
@@ -1,7 +1,6 @@
 package storagesc
 
 import (
-	"0chain.net/smartcontract/stakepool/spenum"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -9,6 +8,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"0chain.net/smartcontract/stakepool/spenum"
 
 	"0chain.net/chaincore/currency"
 
@@ -593,6 +594,7 @@ func TestUpdateFreeStorageRequest(t *testing.T) {
 		MaxTotalFreeAllocation:     mockMaxAnnualFreeAllocation,
 		FreeAllocationSettings:     mockFreeAllocationSettings,
 		MaxBlobbersPerAllocation:   40,
+		TimeUnit:                   mockTimeUnit,
 	}
 	var now = common.Timestamp(29000000)
 
@@ -722,12 +724,6 @@ func TestUpdateFreeStorageRequest(t *testing.T) {
 				RedeemedTimestamps: append(p.assigner.RedeemedTimestamps, p.marker.Timestamp),
 			},
 		).Return("", nil).Once()
-
-		//balances.On("AddMint", &state.Mint{
-		//	Minter:     ADDRESS,
-		//	ToClientID: ADDRESS,
-		//	Amount:     zcnToBalance(p.marker.FreeTokens),
-		//}).Return(nil).Once()
 
 		balances.On(
 			"EmitEvent",

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -1,7 +1,6 @@
 package storagesc
 
 import (
-	"0chain.net/smartcontract/stakepool/spenum"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,13 +8,16 @@ import (
 	"strings"
 	"time"
 
+	"0chain.net/smartcontract/stakepool/spenum"
+	"github.com/0chain/common/core/logging"
+	"github.com/0chain/gosdk/core/util"
+
 	"0chain.net/chaincore/state"
 	"0chain.net/chaincore/transaction"
 
 	"0chain.net/chaincore/currency"
 	"0chain.net/chaincore/threshold/bls"
 
-	"github.com/0chain/common/core/logging"
 	"go.uber.org/zap"
 
 	"0chain.net/chaincore/config"
@@ -27,7 +29,6 @@ import (
 	"0chain.net/core/common"
 	"0chain.net/core/datastore"
 	"0chain.net/core/encryption"
-	"github.com/0chain/common/core/util"
 )
 
 const confMaxChallengeCompletionTime = "smart_contracts.storagesc.max_challenge_completion_time"
@@ -456,10 +457,6 @@ type BlobberAllocation struct {
 	Returned currency.Coin `json:"returned"`
 	// ChallengeReward of the blobber.
 	ChallengeReward currency.Coin `json:"challenge_reward"`
-	// FinalReward is number of tokens moved to the blobber on finalization.
-	// It can be greater than zero, if user didn't spent the min lock demand
-	// during the allocation.
-	FinalReward currency.Coin `json:"final_reward"`
 
 	// ChallengePoolIntegralValue represents integral price * size * dt for this
 	// blobber. Since, a user can upload and delete file, and a challenge
@@ -636,7 +633,7 @@ type StorageAllocation struct {
 	// ID is unique allocation ID that is equal to hash of transaction with
 	// which the allocation has created.
 	ID string `json:"id"`
-	// Tx keeps hash with which the allocation has created or updated.
+	// Tx keeps hash with which the allocation has created or updated. todo do we need this field?
 	Tx string `json:"tx"`
 
 	DataShards        int                     `json:"data_shards"`
@@ -778,7 +775,7 @@ func (sa *StorageAllocation) moveToChallengePool(
 		return errors.New("invalid challenge pool")
 	}
 	if value > sa.WritePool {
-		return fmt.Errorf("insufficent funds %v in write pool to pay %v", sa.WritePool, value)
+		return fmt.Errorf("insufficient funds %v in write pool to pay %v", sa.WritePool, value)
 	}
 
 	if balance, err := currency.AddCoin(cp.Balance, value); err != nil {
@@ -791,6 +788,7 @@ func (sa *StorageAllocation) moveToChallengePool(
 	} else {
 		sa.WritePool = writePool
 	}
+
 	return nil
 }
 
@@ -822,7 +820,7 @@ func (sa *StorageAllocation) moveFromChallengePool(
 
 func (sa *StorageAllocation) validateAllocationBlobber(
 	blobber *StorageNode,
-	sp *stakePool,
+	total, offers currency.Coin,
 	now common.Timestamp,
 ) error {
 	bSize := sa.bSize()
@@ -845,7 +843,7 @@ func (sa *StorageAllocation) validateAllocationBlobber(
 	}
 	// filter by blobber's capacity left
 	if blobber.Capacity-blobber.Allocated < bSize {
-		return fmt.Errorf("blobber %s free capacity %v insufficent, wanted %v",
+		return fmt.Errorf("blobber %s free capacity %v insufficient, wanted %v",
 			blobber.ID, blobber.Capacity-blobber.Allocated, bSize)
 	}
 
@@ -853,21 +851,62 @@ func (sa *StorageAllocation) validateAllocationBlobber(
 		return fmt.Errorf("blobber %s failed health check", blobber.ID)
 	}
 
-	unallocCapacity, err := sp.unallocatedCapacity(blobber.Terms.WritePrice)
+	unallocCapacity, err := unallocatedCapacity(blobber.Terms.WritePrice, total, offers)
 	if err != nil {
 		return fmt.Errorf("failed to get unallocated capacity: %v", err)
 	}
 
 	if blobber.Terms.WritePrice > 0 && unallocCapacity < bSize {
-		return fmt.Errorf("blobber %v staked capacity %v is insufficent, wanted %v",
+		return fmt.Errorf("blobber %v staked capacity %v is insufficient, wanted %v",
 			blobber.ID, unallocCapacity, bSize)
 	}
 
 	return nil
 }
 
+func (sa *StorageAllocation) cost() (currency.Coin, error) {
+	var cost currency.Coin
+	for _, ba := range sa.BlobberAllocs {
+		c, err := currency.MultFloat64(ba.Terms.WritePrice, sizeInGB(ba.Size))
+		if err != nil {
+			return 0, err
+		}
+		cost += c
+	}
+	return cost, nil
+}
+
+func (sa *StorageAllocation) cancellationCharge(cancellationFraction float64) (currency.Coin, error) {
+	cost, err := sa.cost()
+	if err != nil {
+		return 0, err
+	}
+	return currency.MultFloat64(cost, cancellationFraction)
+}
+
+func (sa *StorageAllocation) checkFunding(cancellationFraction float64) error {
+	cancellationCharge, err := sa.cancellationCharge(cancellationFraction)
+	if err != nil {
+		return err
+	}
+	mld, err := sa.restMinLockDemand()
+	if err != nil {
+		return err
+	}
+	if sa.WritePool < cancellationCharge+mld {
+		return fmt.Errorf("not enough tokens to honor the cancellation charge plus min lock demand"+" (%d < %d + %d)",
+			sa.WritePool, cancellationCharge, mld)
+	}
+
+	return nil
+}
+
 func (sa *StorageAllocation) bSize() int64 {
-	return int64(math.Ceil(float64(sa.Size) / float64(sa.DataShards)))
+	return bSize(sa.Size, sa.DataShards)
+}
+
+func bSize(size int64, dataShards int) int64 {
+	return int64(math.Ceil(float64(size) / float64(dataShards)))
 }
 
 func (sa *StorageAllocation) removeBlobber(
@@ -968,7 +1007,11 @@ func (sa *StorageAllocation) changeBlobbers(
 	if sp, err = ssc.getStakePool(spenum.Blobber, addedBlobber.ID, balances); err != nil {
 		return nil, fmt.Errorf("can't get blobber's stake pool: %v", err)
 	}
-	if err := sa.validateAllocationBlobber(addedBlobber, sp, now); err != nil {
+	staked, err := sp.stake()
+	if err != nil {
+		return nil, err
+	}
+	if err := sa.validateAllocationBlobber(addedBlobber, staked, sp.TotalOffers, now); err != nil {
 		return nil, err
 	}
 
@@ -1062,38 +1105,6 @@ func (sa *StorageAllocation) restMinLockDemand() (rest currency.Coin, err error)
 	return
 }
 
-func (sa *StorageAllocation) validate(now time.Time,
-	conf *Config) (err error) {
-
-	if !sa.ReadPriceRange.isValid() {
-		return errors.New("invalid read_price range")
-	}
-	if !sa.WritePriceRange.isValid() {
-		return errors.New("invalid write_price range")
-	}
-	if sa.Size < conf.MinAllocSize {
-		return errors.New("insufficient allocation size")
-	}
-	dur := common.ToTime(sa.Expiration).Sub(now)
-	if dur < conf.MinAllocDuration {
-		return errors.New("insufficient allocation duration")
-	}
-
-	if sa.DataShards <= 0 {
-		return errors.New("invalid number of data shards")
-	}
-
-	if sa.OwnerPublicKey == "" {
-		return errors.New("missing owner public key")
-	}
-
-	if sa.Owner == "" {
-		return errors.New("missing owner id")
-	}
-
-	return // nil
-}
-
 type filterBlobberFunc func(blobber *StorageNode) (kick bool)
 
 func (sa *StorageAllocation) filterBlobbers(list []*StorageNode,
@@ -1137,22 +1148,22 @@ List:
 }
 
 // validateEachBlobber (this is a copy paste version of filterBlobbers with minute modification for verifications)
-func (sa *StorageAllocation) validateEachBlobber(ssc *StorageSmartContract, blobbers []*blobberWithPool,
-	creationDate common.Timestamp, balances cstate.StateContextI) (
-	[]*blobberWithPool, []string) {
-
+func (sa *StorageAllocation) validateEachBlobber(
+	blobbers []*storageNodeResponse,
+	creationDate common.Timestamp,
+) ([]*StorageNode, []string) {
 	var (
 		errors   = make([]string, 0, len(blobbers))
-		filtered = make([]*blobberWithPool, 0, len(blobbers))
+		filtered = make([]*StorageNode, 0, len(blobbers))
 	)
 	for _, b := range blobbers {
-		err := sa.validateAllocationBlobber(b.StorageNode, b.Pool, creationDate)
+		err := sa.validateAllocationBlobber(b.StorageNode, b.TotalStake, b.TotalOffers, creationDate)
 		if err != nil {
 			logging.Logger.Debug("error validating blobber", zap.String("id", b.ID), zap.Error(err))
 			errors = append(errors, err.Error())
 			continue
 		}
-		filtered = append(filtered, b)
+		filtered = append(filtered, b.StorageNode)
 	}
 	return filtered, errors
 }

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -10,7 +10,7 @@ import (
 
 	"0chain.net/smartcontract/stakepool/spenum"
 	"github.com/0chain/common/core/logging"
-	"github.com/0chain/gosdk/core/util"
+	"github.com/0chain/common/core/util"
 
 	"0chain.net/chaincore/state"
 	"0chain.net/chaincore/transaction"

--- a/code/go/0chain.net/smartcontract/storagesc/models_gen.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models_gen.go
@@ -140,9 +140,9 @@ func (z *Allocations) Msgsize() (s int) {
 // MarshalMsg implements msgp.Marshaler
 func (z *BlobberAllocation) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 16
+	// map header, size 15
 	// string "BlobberID"
-	o = append(o, 0xde, 0x0, 0x10, 0xa9, 0x42, 0x6c, 0x6f, 0x62, 0x62, 0x65, 0x72, 0x49, 0x44)
+	o = append(o, 0x8f, 0xa9, 0x42, 0x6c, 0x6f, 0x62, 0x62, 0x65, 0x72, 0x49, 0x44)
 	o = msgp.AppendString(o, z.BlobberID)
 	// string "AllocationID"
 	o = append(o, 0xac, 0x41, 0x6c, 0x6c, 0x6f, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x49, 0x44)
@@ -222,13 +222,6 @@ func (z *BlobberAllocation) MarshalMsg(b []byte) (o []byte, err error) {
 	o, err = z.ChallengeReward.MarshalMsg(o)
 	if err != nil {
 		err = msgp.WrapError(err, "ChallengeReward")
-		return
-	}
-	// string "FinalReward"
-	o = append(o, 0xab, 0x46, 0x69, 0x6e, 0x61, 0x6c, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64)
-	o, err = z.FinalReward.MarshalMsg(o)
-	if err != nil {
-		err = msgp.WrapError(err, "FinalReward")
 		return
 	}
 	// string "ChallengePoolIntegralValue"
@@ -370,12 +363,6 @@ func (z *BlobberAllocation) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "ChallengeReward")
 				return
 			}
-		case "FinalReward":
-			bts, err = z.FinalReward.UnmarshalMsg(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "FinalReward")
-				return
-			}
 		case "ChallengePoolIntegralValue":
 			bts, err = z.ChallengePoolIntegralValue.UnmarshalMsg(bts)
 			if err != nil {
@@ -413,7 +400,7 @@ func (z *BlobberAllocation) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *BlobberAllocation) Msgsize() (s int) {
-	s = 3 + 10 + msgp.StringPrefixSize + len(z.BlobberID) + 13 + msgp.StringPrefixSize + len(z.AllocationID) + 5 + msgp.Int64Size + 15 + msgp.StringPrefixSize + len(z.AllocationRoot) + 16
+	s = 1 + 10 + msgp.StringPrefixSize + len(z.BlobberID) + 13 + msgp.StringPrefixSize + len(z.AllocationID) + 5 + msgp.Int64Size + 15 + msgp.StringPrefixSize + len(z.AllocationRoot) + 16
 	if z.LastWriteMarker == nil {
 		s += msgp.NilSize
 	} else {
@@ -425,7 +412,7 @@ func (z *BlobberAllocation) Msgsize() (s int) {
 	} else {
 		s += z.Stats.Msgsize()
 	}
-	s += 6 + z.Terms.Msgsize() + 14 + z.MinLockDemand.Msgsize() + 6 + z.Spent.Msgsize() + 8 + z.Penalty.Msgsize() + 11 + z.ReadReward.Msgsize() + 9 + z.Returned.Msgsize() + 16 + z.ChallengeReward.Msgsize() + 12 + z.FinalReward.Msgsize() + 27 + z.ChallengePoolIntegralValue.Msgsize() + 31
+	s += 6 + z.Terms.Msgsize() + 14 + z.MinLockDemand.Msgsize() + 6 + z.Spent.Msgsize() + 8 + z.Penalty.Msgsize() + 11 + z.ReadReward.Msgsize() + 9 + z.Returned.Msgsize() + 16 + z.ChallengeReward.Msgsize() + 27 + z.ChallengePoolIntegralValue.Msgsize() + 31
 	if z.BlobberAllocationsPartitionLoc == nil {
 		s += msgp.NilSize
 	} else {

--- a/code/go/0chain.net/smartcontract/storagesc/models_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStorageAllocation_validate(t *testing.T) {
+func TestNewAllocationRequest_validate(t *testing.T) {
 
 	const (
 		errMsg1 = "invalid read_price range"
@@ -23,43 +23,34 @@ func TestStorageAllocation_validate(t *testing.T) {
 	)
 
 	var (
-		now   = time.Unix(150, 0)
-		alloc StorageAllocation
-		conf  Config
+		now  = time.Unix(150, 0)
+		nar  newAllocationRequest
+		conf Config
 	)
 
 	conf.MinAllocSize = 10 * 1024
 	conf.MinAllocDuration = 48 * time.Hour
+	nar.DataShards = 1
+	nar.Blobbers = []string{"1", "2"}
 
-	alloc.ReadPriceRange = PriceRange{Min: 20, Max: 10}
-	requireErrMsg(t, alloc.validate(now, &conf), errMsg1)
+	nar.ReadPriceRange = PriceRange{Min: 20, Max: 10}
+	requireErrMsg(t, nar.validate(now, &conf), errMsg1)
 
-	alloc.ReadPriceRange = PriceRange{Min: 10, Max: 20}
-	alloc.WritePriceRange = PriceRange{Min: 20, Max: 10}
-	requireErrMsg(t, alloc.validate(now, &conf), errMsg2)
+	nar.ReadPriceRange = PriceRange{Min: 10, Max: 20}
+	nar.WritePriceRange = PriceRange{Min: 20, Max: 10}
+	requireErrMsg(t, nar.validate(now, &conf), errMsg2)
 
-	alloc.WritePriceRange = PriceRange{Min: 10, Max: 20}
-	alloc.Size = 5 * 1024
-	requireErrMsg(t, alloc.validate(now, &conf), errMsg3)
+	nar.WritePriceRange = PriceRange{Min: 10, Max: 20}
+	nar.Size = 5 * 1024
+	requireErrMsg(t, nar.validate(now, &conf), errMsg3)
 
-	alloc.Size = 10 * 1024
-	alloc.Expiration = 170
-	requireErrMsg(t, alloc.validate(now, &conf), errMsg4)
+	nar.Size = 10 * 1024
+	nar.Expiration = 170
+	requireErrMsg(t, nar.validate(now, &conf), errMsg4)
 
-	alloc.Expiration = 150 + toSeconds(48*time.Hour)
-	alloc.DataShards = 0
-	requireErrMsg(t, alloc.validate(now, &conf), errMsg5)
-
-	alloc.DataShards = 1
-	alloc.OwnerPublicKey = ""
-	requireErrMsg(t, alloc.validate(now, &conf), errMsg6)
-
-	alloc.OwnerPublicKey = "pk_hex"
-	alloc.Owner = ""
-	requireErrMsg(t, alloc.validate(now, &conf), errMsg7)
-
-	alloc.Owner = "client_hex"
-	assert.NoError(t, alloc.validate(now, &conf))
+	nar.Expiration = 150 + toSeconds(48*time.Hour)
+	nar.DataShards = 0
+	requireErrMsg(t, nar.validate(now, &conf), errMsg5)
 }
 
 func TestStorageAllocation_filterBlobbers(t *testing.T) {

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool.go
@@ -101,7 +101,7 @@ func (sp *stakePool) save(providerType spenum.Provider, providerID string,
 
 func (sp *stakePool) emitSaveEvent(providerType spenum.Provider, providerID string, balances chainstate.StateContextI) {
 	data := dbs.DbUpdates{
-		Id: providerID,
+		Id:      providerID,
 		Updates: map[string]interface{}{},
 	}
 	switch providerType {
@@ -125,7 +125,7 @@ func (sp *stakePool) cleanStake() (stake currency.Coin, err error) {
 	return staked - sp.TotalUnStake, nil
 }
 
-func (sp *stakePool) stakeByProvider(providerType spenum.Provider, providerID string, balances chainstate.StateContextI) error{
+func (sp *stakePool) stakeByProvider(providerType spenum.Provider, providerID string, balances chainstate.StateContextI) error {
 	staked, err := sp.stake()
 	if err != nil {
 		return err
@@ -148,10 +148,10 @@ func (sp *stakePool) stake() (stake currency.Coin, err error) {
 	return
 }
 
-func (sp *stakePool) emitStakeEvent(providerType spenum.Provider, providerID string,staked currency.Coin, balances chainstate.StateContextI)  {
+func (sp *stakePool) emitStakeEvent(providerType spenum.Provider, providerID string, staked currency.Coin, balances chainstate.StateContextI) {
 	logging.Logger.Info("emitting stake event")
 	data := dbs.DbUpdates{
-		Id: providerID,
+		Id:      providerID,
 		Updates: map[string]interface{}{},
 	}
 	switch providerType {
@@ -310,17 +310,7 @@ func (sp *stakePool) slash(
 	return
 }
 
-// unallocated capacity of related blobber, excluding delegate pools want to
-// unstake.
-func (sp *stakePool) unallocatedCapacity(writePrice currency.Coin) (free int64, err error) {
-
-	staked, err := sp.stake()
-	if err != nil {
-		return
-	}
-	var total, offers = staked, sp.TotalOffers
-	logging.Logger.Debug("clean_capacity", zap.Int64("total", int64(total)), zap.Int64("offers",
-		int64(offers)), zap.Int64("writePrice", int64(writePrice)))
+func unallocatedCapacity(writePrice, total, offers currency.Coin) (free int64, err error) {
 	if total <= offers {
 		// zero, since the offer stake (not updated) can be greater than the clean stake
 		return
@@ -447,8 +437,8 @@ func (ssc *StorageSmartContract) getOrCreateStakePool(
 
 type stakePoolRequest struct {
 	ProviderType spenum.Provider `json:"provider_type,omitempty"`
-	ProviderID   string       `json:"provider_id,omitempty"`
-	PoolID       string       `json:"pool_id,omitempty"`
+	ProviderID   string          `json:"provider_id,omitempty"`
+	PoolID       string          `json:"pool_id,omitempty"`
 }
 
 func (spr *stakePoolRequest) decode(p []byte) (err error) {

--- a/docker.local/config/sc.yaml
+++ b/docker.local/config/sc.yaml
@@ -110,6 +110,8 @@ smart_contracts:
     min_offer_duration: "10h"
     # min blobber capacity allowed by the SC
     min_blobber_capacity: 1024
+    # fraction of the allocation cost locked in cancellation charge
+    cancellation_charge: 0.2
     # users' read pool related configurations
     readpool:
       min_lock: 0.1 # tokens


### PR DESCRIPTION
Replaces https://github.com/0chain/0chain/pull/1614
## Fixes
* Add cancellation charge - paid whenever an allocation shuts down.
* The allocation write pool should start with the total allocation cost.
* Ensures there is always enough in the `write pool` to cover cancellation charge and min lock demand.
* Allocation min lock demand: Currently broken, changed to use common code with new allocation request.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
