### PR TITLE
Batch update fix gocql

### DIFF
--- a/code/go/0chain.net/chaincore/transaction/entity.go
+++ b/code/go/0chain.net/chaincore/transaction/entity.go
@@ -412,10 +412,7 @@ func (t *Transaction) GetSummary() *TransactionSummary {
 - applicable only when running in test mode and the transaction_data string contains debug keyword somewhere in it
 */
 func (t *Transaction) DebugTxn() bool {
-	if !config.Development() {
-		return false
-	}
-	return strings.Contains(t.TransactionData, "debug")
+	return true
 }
 
 /*ComputeOutputHash - compute the hash from the transaction output */

--- a/code/go/0chain.net/chaincore/transaction/entity.go
+++ b/code/go/0chain.net/chaincore/transaction/entity.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"0chain.net/chaincore/currency"
+	"k8s.io/client-go/kubernetes/typed/core/v1/fake"
 
 	"encoding/json"
 
@@ -412,7 +413,10 @@ func (t *Transaction) GetSummary() *TransactionSummary {
 - applicable only when running in test mode and the transaction_data string contains debug keyword somewhere in it
 */
 func (t *Transaction) DebugTxn() bool {
-	return true
+	if !config.Development() {
+		return false
+	}
+	return strings.Contains(t.TransactionData, "debug")
 }
 
 /*ComputeOutputHash - compute the hash from the transaction output */

--- a/code/go/0chain.net/chaincore/transaction/entity.go
+++ b/code/go/0chain.net/chaincore/transaction/entity.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"0chain.net/chaincore/currency"
-	"k8s.io/client-go/kubernetes/typed/core/v1/fake"
 
 	"encoding/json"
 

--- a/code/go/0chain.net/core/persistencestore/connection.go
+++ b/code/go/0chain.net/core/persistencestore/connection.go
@@ -70,6 +70,7 @@ func initSession(delay time.Duration, maxTries int) error {
 
 	cluster.ProtoVersion = 4
 	cluster.Keyspace = KeySpace
+	cluster.ConnectTimeout = time.Second * 10;
 	start0 := time.Now()
 	// We need to keep waiting till whatever time it takes for cassandra to come up and running that includes data operations which takes longer with growing data
 	for tries := 0; tries < maxTries; tries++ {


### PR DESCRIPTION
## Fixes
Panic in gocql cluster.

```
2022/09/14 21:31:12 gocql: control unable to register events: gocql: no response to connection startup within timeout
panic: finalize block save changes failed

goroutine 89274 [running]:
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc009ef3bc0, {0xc00c278300, 0x3, 0x3})
        /0chain/code/go/0chain.net/vendor/go.uber.org/zap/zapcore/entry.go:232 +0x68b
go.uber.org/zap.(*Logger).Panic(0xc000608e40, {0x18b1904, 0x22}, {0xc00c278300, 0x3, 0x3})
        /0chain/code/go/0chain.net/vendor/go.uber.org/zap/logger.go:230 +0x6c
0chain.net/chaincore/chain.(*Chain).finalizeBlock(0xc000204600, {0x19c3cd8, 0xc01c562360}, 0xc009df7860, {0x19c1050, 0x200cb80})
        /0chain/code/go/0chain.net/chaincore/chain/protocol_block.go:351 +0x17ab
0chain.net/chaincore/chain.(*Chain).finalizeBlockProcess(0xc000204600, {0x19c3cd8, 0xc01c562360}, 0xc009df7860, {0x19c1050, 0x200cb80})
        /0chain/code/go/0chain.net/chaincore/chain/worker.go:390 +0x2a9c
0chain.net/chaincore/chain.(*Chain).FinalizedBlockWorker.func1.1()
        /0chain/code/go/0chain.net/chaincore/chain/worker.go:263 +0xbe
created by 0chain.net/chaincore/chain.(*Chain).FinalizedBlockWorker.func1
        /0chain/code/go/0chain.net/chaincore/chain/worker.go:261 +0x23e
```
## Changes
- Add connectionTimeout to gocql cluster.

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
