### PR TITLE
take miners list as argument to verifyMinerState

### DIFF
--- a/code/go/0chain.net/smartcontract/minersc/miner.go
+++ b/code/go/0chain.net/smartcontract/minersc/miner.go
@@ -58,7 +58,7 @@ func (msc *MinerSmartContract) AddMiner(t *transaction.Transaction,
 			"failed to get miner list: %v", err)
 	}
 
-	msc.verifyMinerState(balances,
+	msc.verifyMinerState(allMiners, balances,
 		"add_miner: checking all miners list in the beginning")
 
 	if newMiner.Settings.DelegateWallet == "" {
@@ -130,7 +130,7 @@ func (msc *MinerSmartContract) AddMiner(t *transaction.Transaction,
 			return "", common.NewError("add_miner", err.Error())
 		}
 
-		msc.verifyMinerState(balances, "add_miner: Checking all miners list afterInsert")
+		msc.verifyMinerState(allMiners, balances, "add_miner: Checking all miners list afterInsert")
 
 		update = true
 	}
@@ -313,15 +313,8 @@ func (msc *MinerSmartContract) UpdateMinerSettings(t *transaction.Transaction,
 
 //------------- local functions ---------------------
 // TODO: remove this or return error and do real checking
-func (msc *MinerSmartContract) verifyMinerState(balances cstate.StateContextI,
+func (msc *MinerSmartContract) verifyMinerState(allMinersList *MinerNodes, balances cstate.StateContextI,
 	msg string) {
-
-	allMinersList, err := getMinersList(balances)
-	if err != nil {
-		logging.Logger.Info(msg + " (verifyMinerState) getMinersList_failed - " +
-			"Failed to retrieve existing miners list: " + err.Error())
-		return
-	}
 	if allMinersList == nil || len(allMinersList.Nodes) == 0 {
 		logging.Logger.Info(msg + " allminerslist is empty")
 		return

--- a/code/go/0chain.net/smartcontract/minersc/sharder.go
+++ b/code/go/0chain.net/smartcontract/minersc/sharder.go
@@ -158,7 +158,14 @@ func (msc *MinerSmartContract) AddSharder(
 		return "", common.NewErrorf("add_sharder", "saving all sharders list: %v", err)
 	}
 
-	msc.verifyMinerState(balances, "checking all sharders list after insert")
+	allMiners, err := getMinersList(balances)
+	if err != nil {
+		logging.Logger.Error("add_miner: Error in getting list from the DB",
+			zap.Error(err))
+		return "", common.NewErrorf("add_miner",
+			"failed to get miner list: %v", err)
+	}
+	msc.verifyMinerState(allMiners, balances, "checking all sharders list after insert")
 
 	return string(newSharder.Encode()), nil
 }
@@ -348,7 +355,15 @@ func (msc *MinerSmartContract) sharderKeep(_ *transaction.Transaction,
 	if err := updateShardersKeepList(balances, sharderKeepList); err != nil {
 		return "", err
 	}
-	msc.verifyMinerState(balances, "Checking allsharderslist afterInsert")
+	allMiners, err := getMinersList(balances)
+	if err != nil {
+		logging.Logger.Error("add_miner: Error in getting list from the DB",
+			zap.Error(err))
+		return "", common.NewErrorf("add_miner",
+			"failed to get miner list: %v", err)
+	}
+
+	msc.verifyMinerState(allMiners, balances, "Checking allsharderslist afterInsert")
 	buff := newSharder.Encode()
 	return string(buff), nil
 }


### PR DESCRIPTION
## Fixes
https://github.com/0chain/0chain/issues/1511

## Changes
get minerlist once and pass then to `verifyMinerState` function there by avoiding calling `getMinersList` everytime 

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
