### PR TITLE
Fix msgp checking error

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,11 +14,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.18'
-      
-      - name: git init and remote add
-        run: |
-          git init
-          git remote add 0chain https://github.com/0chain/0chain.git
 
       - name: Check msgp changes
         run: ./docker.local/bin/check.msgp.sh
@@ -46,11 +41,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.18'
-
-      - name: git init and remote add
-        run: |
-          git init
-          git remote add 0chain https://github.com/0chain/0chain.git
 
       - name: Check msgp changes
         run: ./docker.local/bin/check.msgp.sh

--- a/docker.local/bin/check.msgp.sh
+++ b/docker.local/bin/check.msgp.sh
@@ -12,9 +12,7 @@ pushd "${DIR}/../../code/go/0chain.net" >/dev/null
 
 go generate -run=msgp ./... >/dev/null
 
-changes=$(git diff | wc -l | tr -d ' ')
-
-if [[ $changes != 0 ]]; then echo 'Changes detected on running go generate: msgp'; exit 2; fi
-
-
 popd >/dev/null
+
+changes=$(git diff | wc -l | tr -d ' ')
+if [[ $changes != 0 ]]; then echo 'Changes detected on running go generate: msgp'; exit 2; fi


### PR DESCRIPTION
## Fixes 
- #1687 

## Changes
We should not run git init to initialize the repo in the actions. It's already initialized, but somehow the git version we are using might not able to detect file changes in sub dirs. So we should change the `msgp.check.sh script instead`. I've tested this by manually change the `_gen.go` file and it worked well.

## Need to be mentioned in CHANGELOG.md?
No

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
No