### PR TITLE
Fix state hash mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ run-test:
 install-mockery:
 	@([ -d ./tmp/mockery ] || mkdir -p ./tmp/mockery) \
 	&& echo "[+]download mockery" \
-	&& ([ -f ./tmp/mockery/mockery.tar.gz ] || curl -L -o ./tmp/mockery/mockery.tar.gz https://github.com/vektra/mockery/releases/download/v2.12.2/mockery_2.12.2_$(detected_OS)_$(detected_ARCH).tar.gz) \
+	&& ([ -f ./tmp/mockery/mockery.tar.gz ] || curl -L -o ./tmp/mockery/mockery.tar.gz https://github.com/vektra/mockery/releases/download/v2.14.0/mockery_2.14.0_$(detected_OS)_$(detected_ARCH).tar.gz) \
 	&& echo "[+]install mockery" \
 	&& tar zxvfC ./tmp/mockery/mockery.tar.gz ./tmp/mockery \
 	&& cp ./tmp/mockery/mockery $(GOPATH)/bin/ \

--- a/code/go/0chain.net/chaincore/block/entity.go
+++ b/code/go/0chain.net/chaincore/block/entity.go
@@ -629,7 +629,7 @@ func (b *Block) GetReceiptsMerkleTree() *util.MerkleTree {
 	return &mt
 }
 
-//GetTransaction - get the transaction from the block
+// GetTransaction - get the transaction from the block
 func (b *Block) GetTransaction(hash string) *transaction.Transaction {
 	for _, txn := range b.Txns {
 		if txn.GetKey() == hash {
@@ -639,14 +639,14 @@ func (b *Block) GetTransaction(hash string) *transaction.Transaction {
 	return nil
 }
 
-//SetBlockNotarized - set the block as notarized
+// SetBlockNotarized - set the block as notarized
 func (b *Block) SetBlockNotarized() {
 	b.ticketsMutex.Lock()
 	defer b.ticketsMutex.Unlock()
 	b.isNotarized = true
 }
 
-//IsBlockNotarized - is block notarized?
+// IsBlockNotarized - is block notarized?
 func (b *Block) IsBlockNotarized() bool {
 	b.ticketsMutex.RLock()
 	defer b.ticketsMutex.RUnlock()
@@ -654,14 +654,14 @@ func (b *Block) IsBlockNotarized() bool {
 	return b.isNotarized
 }
 
-//SetBlockFinalised - set the block as finalised
+// SetBlockFinalised - set the block as finalised
 func (b *Block) SetBlockFinalised() {
 	b.ticketsMutex.Lock()
 	defer b.ticketsMutex.Unlock()
 	b.isFinalised = true
 }
 
-//IsBlockFinalised - is block notarized?
+// IsBlockFinalised - is block notarized?
 func (b *Block) IsBlockFinalised() bool {
 	b.ticketsMutex.RLock()
 	defer b.ticketsMutex.RUnlock()
@@ -926,7 +926,6 @@ func (b *Block) ComputeState(ctx context.Context, c Chainer) error {
 		})
 
 		events, err := c.UpdateState(ctx, b, bState, txn)
-		b.Events = append(b.Events, events...)
 		switch err {
 		case context.Canceled:
 			b.SetStateStatus(StateCancelled)
@@ -981,6 +980,7 @@ func (b *Block) ComputeState(ctx context.Context, c Chainer) error {
 				return common.NewError("state_update_error", err.Error())
 			}
 		}
+		b.Events = append(b.Events, events...)
 	}
 
 	if !bytes.Equal(b.ClientStateHash, bState.GetRoot()) {

--- a/code/go/0chain.net/chaincore/chain/handler.go
+++ b/code/go/0chain.net/chaincore/chain/handler.go
@@ -1,7 +1,6 @@
 package chain
 
 import (
-	"0chain.net/chaincore/state"
 	"bufio"
 	"context"
 	"encoding/json"
@@ -17,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"0chain.net/chaincore/state"
 
 	"0chain.net/chaincore/block"
 	"0chain.net/chaincore/config"
@@ -1622,16 +1623,16 @@ func (c *Chain) MinerStatsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func txnIterHandlerFunc(c *Chain, w http.ResponseWriter, s *state.State) func(context.Context, datastore.CollectionEntity) bool {
-	return func(ctx context.Context, ce datastore.CollectionEntity) bool {
+func txnIterHandlerFunc(c *Chain, w http.ResponseWriter, s *state.State) func(context.Context, datastore.CollectionEntity) (bool, error) {
+	return func(ctx context.Context, ce datastore.CollectionEntity) (bool, error) {
 		txn, ok := ce.(*transaction.Transaction)
 		if !ok {
 			logging.Logger.Error("generate block (invalid entity)", zap.Any("entity", ce))
-			return false
+			return false, nil
 		}
 
 		c.txnsInPoolTableRows(w, txn, s)
-		return true
+		return true, nil
 	}
 }
 

--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strings"
 	"time"
 
 	"0chain.net/chaincore/currency"
@@ -30,7 +29,7 @@ import (
 	"github.com/0chain/common/core/util"
 )
 
-//SmartContractExecutionTimer - a metric that tracks the time it takes to execute a smart contract txn
+// SmartContractExecutionTimer - a metric that tracks the time it takes to execute a smart contract txn
 var SmartContractExecutionTimer metrics.Timer
 
 func init() {
@@ -80,7 +79,7 @@ func (c *Chain) computeState(ctx context.Context, b *block.Block) error {
 	return b.ComputeState(ctx, c)
 }
 
-//SaveChanges - persist the state changes
+// SaveChanges - persist the state changes
 func (c *Chain) SaveChanges(ctx context.Context, b *block.Block) error {
 	if !b.IsStateComputed() {
 		err := errors.New("block state not computed")
@@ -109,19 +108,24 @@ func (c *Chain) rebaseState(lfb *block.Block) {
 	}
 }
 
-//ExecuteSmartContract - executes the smart contract for the transaction
+// ExecuteSmartContract - executes the smart contract for the transaction
 func (c *Chain) ExecuteSmartContract(
 	ctx context.Context,
 	t *transaction.Transaction,
 	scData *sci.SmartContractTransactionData,
 	balances bcstate.StateContextI) (string, error) {
 
-	var output string
-	var err error
-	ts := time.Now()
-	done := make(chan bool, 1)
+	type result struct {
+		output string
+		err    error
+	}
 
-	sct := time.NewTimer(c.SmartContractTimeout())
+	var (
+		ts      = time.Now()
+		sct     = time.NewTimer(c.SmartContractTimeout())
+		resultC = make(chan result, 1)
+	)
+
 	if node.Self.Type == node.NodeTypeSharder {
 		// give more times for sharders to compute state, as sharders are required to be run
 		// as full node, so each block should not be executed failed due to timeout
@@ -129,17 +133,22 @@ func (c *Chain) ExecuteSmartContract(
 	}
 
 	go func() {
-		output, err = smartcontract.ExecuteSmartContract(t, scData, balances)
-		done <- true
+		output, err := smartcontract.ExecuteSmartContract(t, scData, balances)
+		resultC <- result{output: output, err: err}
 	}()
 	select {
 	case <-ctx.Done():
 		return "", ctx.Err()
 	case <-sct.C:
 		return "", transaction.ErrSmartContractContext
-	case <-done:
+	case r := <-resultC:
 		SmartContractExecutionTimer.Update(time.Since(ts))
-		return output, err
+
+		if ierrs := balances.GetInvalidStateErrors(); len(ierrs) > 0 {
+			return "", ierrs[0]
+		}
+
+		return r.output, r.err
 	}
 }
 
@@ -178,6 +187,14 @@ func (c *Chain) EstimateTransactionCost(ctx context.Context,
 			return math.MaxInt32, err
 		}
 		cost, err := smartcontract.EstimateTransactionCost(txn, scData, sctx)
+		if ierrs := sctx.GetInvalidStateErrors(); len(ierrs) > 0 {
+			logging.Logger.Error("Internal error while estimate transaction cost",
+				zap.Errors("errors", ierrs),
+				zap.Int64("round", b.Round),
+				zap.String("block", b.Hash))
+			return math.MaxInt32, ierrs[0] // return the first one only
+		}
+
 		return cost, err
 
 	case transaction.TxnTypeSend:
@@ -220,13 +237,13 @@ func (c *Chain) NewStateContext(
 	)
 }
 
-func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.MerklePatriciaTrieI, txn *transaction.Transaction) (events []event.Event, err error) {
+func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.MerklePatriciaTrieI, txn *transaction.Transaction) ([]event.Event, error) {
 	// check if the block's ClientState has root value
-	_, err = bState.GetNodeDB().GetNode(bState.GetRoot())
+	_, err := bState.GetNodeDB().GetNode(bState.GetRoot())
 	if err != nil {
 		return nil, common.NewErrorf("update_state_failed",
-			"block state root is incorrect, block hash: %v, state hash: %v, root: %v, round: %d",
-			b.Hash, util.ToHex(b.ClientStateHash), util.ToHex(bState.GetRoot()), b.Round)
+			"block state root is incorrect, err: %v, block hash: %v, state hash: %v, root: %v, round: %d",
+			err, b.Hash, util.ToHex(b.ClientStateHash), util.ToHex(bState.GetRoot()), b.Round)
 	}
 
 	var (
@@ -234,37 +251,34 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		sctx        = c.NewStateContext(b, clientState, txn, nil)
 		startRoot   = sctx.GetState().GetRoot()
 	)
-	defer func() { events = sctx.GetEvents() }()
 
 	if err := c.validateNonce(sctx, txn.ClientID, txn.Nonce); err != nil {
 		return nil, err
 	}
 
-	//we should check that client has enough funds to pay for transaction before heavy computations are executed
+	// checks if the client has enough funds to pay for transaction before heavy computations are executed
 	if err = sctx.Validate(); err != nil {
-		return
+		return nil, err
 	}
 
 	switch txn.TransactionType {
-
 	case transaction.TxnTypeSmartContract:
-		var output string
+		var (
+			scData    sci.SmartContractTransactionData
+			dataBytes = []byte(txn.TransactionData)
+		)
 
-		var scData sci.SmartContractTransactionData
-		dataBytes := []byte(txn.TransactionData)
-		err = json.Unmarshal(dataBytes, &scData)
-		if err != nil {
+		if err := json.Unmarshal(dataBytes, &scData); err != nil {
 			logging.Logger.Error("Error while decoding the JSON from transaction",
 				zap.Any("input", txn.TransactionData), zap.Any("error", err))
 			return nil, err
 		}
 
 		t := time.Now()
-		output, err = c.ExecuteSmartContract(ctx, txn, &scData, sctx)
+		output, err := c.ExecuteSmartContract(ctx, txn, &scData, sctx)
 		switch err {
 		//internal errors
 		case context.DeadlineExceeded, transaction.ErrSmartContractContext, util.ErrNodeNotFound:
-			sctx.EmitError(err)
 			logging.Logger.Error("Error executing the SC, internal error",
 				zap.Error(err),
 				zap.String("scname", scData.FunctionName),
@@ -274,9 +288,8 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				zap.Duration("time_spent", time.Since(t)),
 				zap.Any("txn", txn))
 			//return original error, to handle upwards
-			return events, err
+			return nil, err
 		case context.Canceled:
-			sctx.EmitError(err)
 			logging.Logger.Debug("Error executing the SC, internal error",
 				zap.Error(err),
 				zap.String("scname", scData.FunctionName),
@@ -286,12 +299,10 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				zap.Duration("time_spent", time.Since(t)),
 				zap.Any("txn", txn))
 			//return original error, to handle upwards
-			return events, err
+			return nil, err
 		default:
 			if err != nil {
-				sctx.EmitError(err)
-
-				if strings.Contains(err.Error(), "node not found") {
+				if bcstate.ErrInvalidState(err) {
 					logging.Logger.Error("Error executing the SC, internal error",
 						zap.Error(err),
 						zap.String("scname", scData.FunctionName),
@@ -300,7 +311,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 						zap.String("prev block", b.PrevBlock.Hash),
 						zap.Duration("time_spent", time.Since(t)),
 						zap.Any("txn", txn))
-					return events, err
+					return nil, err
 				}
 
 				logging.Logger.Debug("Error executing the SC, chargeable error",
@@ -315,6 +326,8 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				//refresh client state context, so all changes made by broken smart contract are rejected, it will be used to add fee
 				clientState = CreateTxnMPT(bState) // begin transaction
 				sctx = c.NewStateContext(b, clientState, txn, nil)
+				// records chargeable error event
+				sctx.EmitError(err)
 
 				output = err.Error()
 				txn.Status = transaction.TxnError
@@ -333,11 +346,9 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 			zap.Duration("txn_exec_time", time.Since(t)),
 			zap.String("begin client state", util.ToHex(startRoot)),
 			zap.String("current_root", util.ToHex(sctx.GetState().GetRoot())))
-
 	case transaction.TxnTypeData:
-
 	case transaction.TxnTypeSend:
-		err = sctx.AddTransfer(state.NewTransfer(txn.ClientID, txn.ToClientID, txn.Value))
+		err := sctx.AddTransfer(state.NewTransfer(txn.ClientID, txn.ToClientID, txn.Value))
 		if err != nil {
 			logging.Logger.Error("Failed to add transfer",
 				zap.Any("txn type", txn.TransactionType),
@@ -345,7 +356,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				zap.Any("minersc_address", minersc.ADDRESS),
 				zap.Any("state_balance", txn.Fee),
 				zap.Any("current_root", sctx.GetState().GetRoot()))
-			return
+			return nil, err
 		}
 	default:
 		logging.Logger.Error("Invalid transaction type", zap.Int("txn type", txn.TransactionType))
@@ -353,22 +364,21 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 	}
 
 	if c.ChainConfig.IsFeeEnabled() {
-		err = sctx.AddTransfer(state.NewTransfer(txn.ClientID, minersc.ADDRESS,
-			txn.Fee))
+		err = sctx.AddTransfer(state.NewTransfer(txn.ClientID, minersc.ADDRESS, txn.Fee))
 		if err != nil {
 			logging.Logger.Error("Failed to add transfer",
 				zap.Any("txn type", txn.TransactionType),
 				zap.Any("transaction_ClientID", txn.ClientID),
 				zap.Any("minersc_address", minersc.ADDRESS),
 				zap.Any("state_balance", txn.Fee))
-			return
+			return nil, err
 		}
 	}
 
 	ue := make(map[string]*event.User)
 	for _, transfer := range sctx.GetTransfers() {
-		tEvents, er := c.transferAmount(sctx, transfer.ClientID, transfer.ToClientID, transfer.Amount)
-		if er != nil {
+		tEvents, err := c.transferAmount(sctx, transfer.ClientID, transfer.ToClientID, transfer.Amount)
+		if err != nil {
 			logging.Logger.Error("Failed to transfer amount",
 				zap.Any("txn type", txn.TransactionType),
 				zap.String("txn data", txn.TransactionData),
@@ -376,7 +386,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				zap.Any("to_ClientID", transfer.ToClientID),
 				zap.Any("amount", transfer.Amount),
 				zap.Error(err))
-			return
+			return nil, err
 		}
 		for _, e := range tEvents {
 			ue[e.UserID] = e
@@ -384,14 +394,14 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 	}
 
 	for _, signedTransfer := range sctx.GetSignedTransfers() {
-		tEvents, er := c.transferAmount(sctx, signedTransfer.ClientID,
+		tEvents, err := c.transferAmount(sctx, signedTransfer.ClientID,
 			signedTransfer.ToClientID, signedTransfer.Amount)
-		if er != nil {
+		if err != nil {
 			logging.Logger.Error("Failed to process signed transfer",
 				zap.Any("signedTransfer_ClientID", signedTransfer.ClientID),
 				zap.Any("signedTransfer_to_ClientID", signedTransfer.ToClientID),
 				zap.Any("signedTransfer_amount", signedTransfer.Amount))
-			return
+			return nil, err
 		}
 		for _, e := range tEvents {
 			ue[e.UserID] = e
@@ -399,12 +409,12 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 	}
 
 	for _, mint := range sctx.GetMints() {
-		u, er := c.mintAmount(sctx, mint.ToClientID, mint.Amount)
-		if er != nil {
+		u, err := c.mintAmount(sctx, mint.ToClientID, mint.Amount)
+		if err != nil {
 			logging.Logger.Error("mint error", zap.Any("error", err),
 				zap.Any("transaction", txn.Hash),
 				zap.String("to clientID", mint.ToClientID))
-			return
+			return nil, err
 		}
 		if u != nil {
 			ue[u.UserID] = u
@@ -416,8 +426,9 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		logging.Logger.Error("update nonce error", zap.Any("error", err),
 			zap.Any("transaction", txn.Hash),
 			zap.String("clientID", txn.ClientID))
-		return
+		return nil, err
 	}
+
 	if u != nil {
 		ue[u.UserID] = u
 	}
@@ -427,9 +438,10 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 			logging.Logger.Error("could not emit event", zap.Any("error", err),
 				zap.Any("transaction", txn.Hash),
 				zap.String("clientID", txn.ClientID))
-			return
+			return nil, err
 		}
 	}
+
 	// commit transaction
 	if err = bState.MergeMPTChanges(clientState); err != nil {
 		if state.DebugTxn() {
@@ -439,15 +451,8 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		}
 
 		logging.Logger.Error("error committing txn", zap.Any("error", err))
-		return
+		return nil, err
 	}
-
-	//logging.Logger.Debug("update state - root",
-	//	zap.String("block", b.Hash),
-	//	zap.String("txn", txn.Hash),
-	//	zap.String("prev_state_hash", util.ToHex(b.PrevBlock.ClientStateHash)),
-	//	zap.String("begin", util.ToHex(startRoot)),
-	//	zap.String("root", util.ToHex(clientState.GetRoot())))
 
 	if state.DebugTxn() {
 		// TODO: fix me, the b does not has the state changes
@@ -468,7 +473,8 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 	if txn.Status == 0 {
 		txn.Status = transaction.TxnSuccess
 	}
-	return
+
+	return sctx.GetEvents(), nil
 }
 
 /*
@@ -701,9 +707,11 @@ func (c *Chain) GetStateById(clientState util.MerklePatriciaTrieI, clientID stri
 	return s, nil
 }
 
-/*GetState - Get the state of a client w.r.t a block. Note, don't call this from within state computation logic
+/*
+GetState - Get the state of a client w.r.t a block. Note, don't call this from within state computation logic
 since block.GetStateValue uses a RLock on the StateMutex. This API is for someone reading the state from outside
-the protocol without already holding a lock on StateMutex */
+the protocol without already holding a lock on StateMutex
+*/
 func (c *Chain) GetState(b *block.Block, clientID string) (*state.State, error) {
 	c.stateMutex.RLock()
 	defer c.stateMutex.RUnlock()

--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -408,7 +408,7 @@ type errorIndex struct {
 	index int
 }
 
-type GetItemFunc func(id string, balance CommonStateContextI) (interface{}, error)
+type GetItemFunc[T any] func(id string, balance CommonStateContextI) (T, error)
 
 type rspIndex struct {
 	index int
@@ -418,7 +418,7 @@ type rspIndex struct {
 // GetItemsByIDs read items by ids from MPT concurrently and safely with consistent values
 // Note: the GetItemFunc should not return custom error that wraps the error returned from
 // StateContextI
-func GetItemsByIDs[T any](ids []string, getItem GetItemFunc, balances CommonStateContextI) ([]T, error) {
+func GetItemsByIDs[T any](ids []string, getItem GetItemFunc[T], balances CommonStateContextI) ([]T, error) {
 	var (
 		itemC     = make(chan rspIndex, len(ids))
 		stateErrC = make(chan error, len(ids))

--- a/code/go/0chain.net/chaincore/chain/state/state_context_test.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context_test.go
@@ -30,7 +30,7 @@ func TestGetItemsByIDs(t *testing.T) {
 
 	type args struct {
 		ids      []string
-		getItem  GetItemFunc
+		getItem  GetItemFunc[*testItem]
 		balances CommonStateContextI
 	}
 	tests := []struct {
@@ -43,7 +43,7 @@ func TestGetItemsByIDs(t *testing.T) {
 			name: "get one item",
 			args: args{
 				ids: []string{"t1"},
-				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+				getItem: func(id string, _ CommonStateContextI) (*testItem, error) {
 					return items["t1"], nil
 				},
 			},
@@ -58,7 +58,7 @@ func TestGetItemsByIDs(t *testing.T) {
 			name: "get 5 item",
 			args: args{
 				ids: []string{"t1", "t2", "t3", "t4", "t5"},
-				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+				getItem: func(id string, _ CommonStateContextI) (*testItem, error) {
 					return items[id], nil
 				},
 			},
@@ -89,7 +89,7 @@ func TestGetItemsByIDs(t *testing.T) {
 			name: "get node not found error",
 			args: args{
 				ids: []string{"t1", "t2", "t3", "t4", "t5"},
-				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+				getItem: func(id string, _ CommonStateContextI) (*testItem, error) {
 					if id == "t2" {
 						return nil, util.ErrNodeNotFound
 					}
@@ -102,7 +102,7 @@ func TestGetItemsByIDs(t *testing.T) {
 			name: "get node not found and value not present errors",
 			args: args{
 				ids: []string{"t1", "t2", "t3", "t4", "t5"},
-				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+				getItem: func(id string, _ CommonStateContextI) (*testItem, error) {
 					if id == "t2" {
 						return nil, util.ErrNodeNotFound
 					}
@@ -120,7 +120,7 @@ func TestGetItemsByIDs(t *testing.T) {
 			name: "get value not present error",
 			args: args{
 				ids: []string{"t1", "t2", "t3", "t4", "t5"},
-				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+				getItem: func(id string, _ CommonStateContextI) (*testItem, error) {
 					if id == "t1" {
 						return nil, util.ErrValueNotPresent
 					}
@@ -134,7 +134,7 @@ func TestGetItemsByIDs(t *testing.T) {
 			name: "get multiple value not present errors",
 			args: args{
 				ids: []string{"t1", "t2", "t3", "t4", "t5"},
-				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+				getItem: func(id string, _ CommonStateContextI) (*testItem, error) {
 					if id == "t1" {
 						return nil, util.ErrValueNotPresent
 					}

--- a/code/go/0chain.net/chaincore/chain/state/state_context_test.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context_test.go
@@ -1,0 +1,164 @@
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/0chain/common/core/logging"
+	"github.com/0chain/common/core/util"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	logging.InitLogging("development", "")
+}
+
+func TestGetItemsByIDs(t *testing.T) {
+	type testItem struct {
+		ID    string
+		Value string
+	}
+
+	items := make(map[string]*testItem, 10)
+	for i := 1; i <= 10; i++ {
+		id := fmt.Sprintf("t%d", i)
+		items[id] = &testItem{
+			ID:    id,
+			Value: fmt.Sprintf("v%d", i),
+		}
+	}
+
+	type args struct {
+		ids      []string
+		getItem  GetItemFunc
+		balances CommonStateContextI
+	}
+	tests := []struct {
+		name string
+		args args
+		want []*testItem
+		err  error
+	}{
+		{
+			name: "get one item",
+			args: args{
+				ids: []string{"t1"},
+				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+					return items["t1"], nil
+				},
+			},
+			want: []*testItem{
+				{
+					ID:    "t1",
+					Value: "v1",
+				},
+			},
+		},
+		{
+			name: "get 5 item",
+			args: args{
+				ids: []string{"t1", "t2", "t3", "t4", "t5"},
+				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+					return items[id], nil
+				},
+			},
+			want: []*testItem{
+				{
+					ID:    "t1",
+					Value: "v1",
+				},
+				{
+					ID:    "t2",
+					Value: "v2",
+				},
+				{
+					ID:    "t3",
+					Value: "v3",
+				},
+				{
+					ID:    "t4",
+					Value: "v4",
+				},
+				{
+					ID:    "t5",
+					Value: "v5",
+				},
+			},
+		},
+		{
+			name: "get node not found error",
+			args: args{
+				ids: []string{"t1", "t2", "t3", "t4", "t5"},
+				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+					if id == "t2" {
+						return nil, util.ErrNodeNotFound
+					}
+					return items[id], nil
+				},
+			},
+			err: util.ErrNodeNotFound,
+		},
+		{
+			name: "get node not found and value not present errors",
+			args: args{
+				ids: []string{"t1", "t2", "t3", "t4", "t5"},
+				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+					if id == "t2" {
+						return nil, util.ErrNodeNotFound
+					}
+
+					if id == "t1" {
+						return nil, util.ErrValueNotPresent
+					}
+
+					return items[id], nil
+				},
+			},
+			err: util.ErrNodeNotFound,
+		},
+		{
+			name: "get value not present error",
+			args: args{
+				ids: []string{"t1", "t2", "t3", "t4", "t5"},
+				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+					if id == "t1" {
+						return nil, util.ErrValueNotPresent
+					}
+
+					return items[id], nil
+				},
+			},
+			err: fmt.Errorf("could not get item %q: %v", "t1", util.ErrValueNotPresent),
+		},
+		{
+			name: "get multiple value not present errors",
+			args: args{
+				ids: []string{"t1", "t2", "t3", "t4", "t5"},
+				getItem: func(id string, _ CommonStateContextI) (interface{}, error) {
+					if id == "t1" {
+						return nil, util.ErrValueNotPresent
+					}
+
+					if id == "t5" {
+						return nil, util.ErrValueNotPresent
+					}
+
+					return items[id], nil
+				},
+			},
+			err: fmt.Errorf("could not get item %q: %v", "t1", util.ErrValueNotPresent),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GetItemsByIDs[*testItem](tc.args.ids, tc.args.getItem, tc.args.balances)
+			require.Equal(t, tc.err, err)
+			if err != nil {
+				return
+			}
+
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/code/go/0chain.net/chaincore/chain/state/state_context_test.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -148,11 +149,21 @@ func TestGetItemsByIDs(t *testing.T) {
 			},
 			err: fmt.Errorf("could not get item %q: %v", "t1", util.ErrValueNotPresent),
 		},
+		{
+			name: "return nil item without ErrValueNotPresent",
+			args: args{
+				ids: []string{"t1"},
+				getItem: func(id string, _ CommonStateContextI) (*testItem, error) {
+					return nil, nil
+				},
+			},
+			err: fmt.Errorf("could not get item %q: %v", "t1", errors.New("nil item returned without ErrValueNotPresent")),
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := GetItemsByIDs[*testItem](tc.args.ids, tc.args.getItem, tc.args.balances)
+			got, err := GetItemsByIDs[testItem](tc.args.ids, tc.args.getItem, tc.args.balances)
 			require.Equal(t, tc.err, err)
 			if err != nil {
 				return

--- a/code/go/0chain.net/chaincore/chain/state/state_context_test.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context_test.go
@@ -163,7 +163,7 @@ func TestGetItemsByIDs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := GetItemsByIDs[testItem](tc.args.ids, tc.args.getItem, tc.args.balances)
+			got, err := GetItemsByIDs(tc.args.ids, tc.args.getItem, tc.args.balances)
 			require.Equal(t, tc.err, err)
 			if err != nil {
 				return
@@ -172,4 +172,18 @@ func TestGetItemsByIDs(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestWrongGetItemFunc(t *testing.T) {
+	// NOTE: uncomment the following code to see compiler error
+
+	//type testItem struct {
+	//	ID    string
+	//	Value string
+	//}
+	//ids := []string{"t1"}
+	//_, err := GetItemsByIDs(ids, func(id string, _ CommonStateContextI) (testItem, error) {
+	//	return testItem{}, nil
+	//}, nil)
+	//require.NoError(t, err)
 }

--- a/code/go/0chain.net/chaincore/transaction/transaction_test.go
+++ b/code/go/0chain.net/chaincore/transaction/transaction_test.go
@@ -72,9 +72,9 @@ func BenchmarkTransactionRead(b *testing.B) {
 	txn := transactionEntityMetadata.Instance().(*Transaction)
 	txn.ChainID = config.GetMainChainID()
 	txnIDs := make([]datastore.Key, 0, memorystore.BATCH_SIZE)
-	getTxnsFunc := func(ctx context.Context, qe datastore.CollectionEntity) bool {
+	getTxnsFunc := func(ctx context.Context, qe datastore.CollectionEntity) (bool, error) {
 		txnIDs = append(txnIDs, qe.GetKey())
-		return len(txnIDs) != memorystore.BATCH_SIZE
+		return len(txnIDs) != memorystore.BATCH_SIZE, nil
 	}
 
 	transactionEntityMetadata.GetStore().IterateCollection(ctx, transactionEntityMetadata, txn.GetCollectionName(), getTxnsFunc)

--- a/code/go/0chain.net/core/datastore/collection.go
+++ b/code/go/0chain.net/core/datastore/collection.go
@@ -13,7 +13,7 @@ const (
 type (
 	// CollectionIteratorHandler describes the signature of
 	// the collection iterator handler function.
-	CollectionIteratorHandler func(ctx context.Context, ce CollectionEntity) bool
+	CollectionIteratorHandler func(ctx context.Context, ce CollectionEntity) (bool, error)
 
 	// Order describes ordering enum.
 	Order int8

--- a/code/go/0chain.net/core/memorystore/collection.go
+++ b/code/go/0chain.net/core/memorystore/collection.go
@@ -107,7 +107,11 @@ func (ms *Store) iterateCollection(ctx context.Context, entityMetadata datastore
 			} else {
 				ckeys[bucket[i].GetKey()] = e
 			}
-			proceed = handler(ctx, bucket[i].(datastore.CollectionEntity))
+			proceed, err = handler(ctx, bucket[i].(datastore.CollectionEntity))
+			if err != nil {
+				return err
+			}
+
 			if !proceed {
 				break
 			}

--- a/code/go/0chain.net/core/memorystore/collection_test.go
+++ b/code/go/0chain.net/core/memorystore/collection_test.go
@@ -52,16 +52,16 @@ func addTxnsToCollection(t *testing.T, txns ...*transaction.Transaction) {
 }
 
 func makeTestCollectionIterationHandler() datastore.CollectionIteratorHandler {
-	return func(ctx context.Context, ce datastore.CollectionEntity) bool {
+	return func(ctx context.Context, ce datastore.CollectionEntity) (bool, error) {
 		if ce.GetEntityMetadata().GetName() == "txn" {
 			ent := ce.(*transaction.Transaction)
 			if ent.Value > 5 {
 				ent.Value++
-				return true
+				return true, nil
 			}
-			return false
+			return false, nil
 		}
-		return false
+		return false, nil
 	}
 }
 

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -584,10 +584,12 @@ func (mc *Chain) updateFinalizedBlock(ctx context.Context, b *block.Block) {
 	tii := newTxnIterInfo(mc.BlockSize())
 	invalidTxns := tii.checkForInvalidTxns(b.Txns)
 
-	transaction.RemoveFromPool(ctx, txns)
+	cleanPoolCtx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	defer cancel()
+	transaction.RemoveFromPool(cleanPoolCtx, txns)
 
 	if len(invalidTxns) > 0 {
-		transaction.RemoveFromPool(ctx, invalidTxns)
+		transaction.RemoveFromPool(cleanPoolCtx, invalidTxns)
 	}
 }
 

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	cstate "0chain.net/chaincore/chain/state"
 	"github.com/rcrowley/go-metrics"
 	"go.uber.org/zap"
 
@@ -28,7 +29,7 @@ import (
 	"github.com/0chain/common/core/util"
 )
 
-//InsufficientTxns - to indicate an error when the transactions are not sufficient to make a block
+// InsufficientTxns - to indicate an error when the transactions are not sufficient to make a block
 const InsufficientTxns = "insufficient_txns"
 
 // ErrLFBClientStateNil is returned when client state of latest finalized block is nil
@@ -56,13 +57,13 @@ func init() {
 func (mc *Chain) processTxn(ctx context.Context, txn *transaction.Transaction, b *block.Block, bState util.MerklePatriciaTrieI, clients map[string]*client.Client) error {
 	clients[txn.ClientID] = nil
 	events, err := mc.UpdateState(ctx, b, bState, txn)
-	b.Events = append(b.Events, events...)
 	if err != nil {
 		logging.Logger.Error("processTxn", zap.String("txn", txn.Hash),
 			zap.String("txn_object", datastore.ToJSON(txn).String()),
 			zap.Error(err))
 		return err
 	}
+	b.Events = append(b.Events, events...)
 	b.Txns = append(b.Txns, txn)
 	b.AddTransaction(txn)
 	return nil
@@ -79,14 +80,18 @@ func (mc *Chain) createFeeTxn(b *block.Block) *transaction.Transaction {
 	return feeTxn
 }
 
-func (mc *Chain) getCurrentSelfNonce(minerId datastore.Key, bState util.MerklePatriciaTrieI) int64 {
+func (mc *Chain) getCurrentSelfNonce(minerId datastore.Key, bState util.MerklePatriciaTrieI) (int64, error) {
 	s, err := mc.GetStateById(bState, minerId)
 	if err != nil {
-		logging.Logger.Error("can't get nonce", zap.Error(err))
-		return 1
+		if err != util.ErrValueNotPresent {
+			logging.Logger.Error("can't get nonce", zap.Error(err))
+			return 0, err
+		}
+
+		return 1, nil
 	}
 	node.Self.SetNonce(s.Nonce)
-	return node.Self.GetNextNonce()
+	return node.Self.GetNextNonce(), nil
 }
 
 func (mc *Chain) storageScCommitSettingChangesTx(b *block.Block) *transaction.Transaction {
@@ -626,17 +631,20 @@ func getLatestBlockFromSharders(ctx context.Context) *block.Block {
 	return nil
 }
 
-//NotarizedBlockFetched - handler to process fetched notarized block
+// NotarizedBlockFetched - handler to process fetched notarized block
 func (mc *Chain) NotarizedBlockFetched(ctx context.Context, b *block.Block) {
 	// mc.SendNotarization(ctx, b)
 }
 
-type txnProcessorHandler func(context.Context, util.MerklePatriciaTrieI, *transaction.Transaction, *TxnIterInfo) bool
+// txnProcessorHandler process transaction and return bool and error to indicate
+// whether processed successfully, or error if any
+type txnProcessorHandler func(context.Context, util.MerklePatriciaTrieI, *transaction.Transaction, *TxnIterInfo) (bool, error)
 
 func txnProcessorHandlerFunc(mc *Chain, b *block.Block) txnProcessorHandler {
-	return func(ctx context.Context, bState util.MerklePatriciaTrieI, txn *transaction.Transaction, tii *TxnIterInfo) bool {
+	return func(ctx context.Context, bState util.MerklePatriciaTrieI,
+		txn *transaction.Transaction, tii *TxnIterInfo) (bool, error) {
 		if _, ok := tii.txnMap[txn.GetKey()]; ok {
-			return false
+			return false, nil
 		}
 		var debugTxn = txn.DebugTxn()
 
@@ -649,7 +657,7 @@ func txnProcessorHandlerFunc(mc *Chain, b *block.Block) txnProcessorHandler {
 					zap.String("txn", txn.Hash), zap.Int32("idx", tii.idx),
 					zap.Any("now", common.Now()), zap.Int64("nonce", txn.Nonce))
 			}
-			return false
+			return false, nil
 		case FutureTransaction:
 			list := tii.futureTxns[txn.ClientID]
 			list = append(list, txn)
@@ -661,7 +669,7 @@ func txnProcessorHandlerFunc(mc *Chain, b *block.Block) txnProcessorHandler {
 				return list[i].Nonce < list[j].Nonce
 			})
 			tii.futureTxns[txn.ClientID] = list
-			return false
+			return false, nil
 		case ErrNotTimeTolerant:
 			tii.invalidTxns = append(tii.invalidTxns, txn)
 			if debugTxn {
@@ -670,7 +678,11 @@ func txnProcessorHandlerFunc(mc *Chain, b *block.Block) txnProcessorHandler {
 					zap.String("txn", txn.Hash), zap.Int32("idx", tii.idx),
 					zap.Any("now", common.Now()))
 			}
-			return false
+			return false, nil
+		default:
+			if err != nil && cstate.ErrInvalidState(err) {
+				return false, err // return err to break the txns pool iteration
+			}
 		}
 
 		if debugTxn {
@@ -678,8 +690,8 @@ func txnProcessorHandlerFunc(mc *Chain, b *block.Block) txnProcessorHandler {
 				zap.String("txn", txn.Hash), zap.Int32("idx", tii.idx),
 				zap.String("txn_object", datastore.ToJSON(txn).String()))
 		}
+
 		events, err := mc.UpdateState(ctx, b, bState, txn)
-		b.Events = append(b.Events, events...)
 		if err != nil {
 			if debugTxn {
 				logging.Logger.Error("generate block (debug transaction) update state",
@@ -688,8 +700,13 @@ func txnProcessorHandlerFunc(mc *Chain, b *block.Block) txnProcessorHandler {
 					zap.Error(err))
 			}
 			tii.failedStateCount++
-			return false
+			if cstate.ErrInvalidState(err) {
+				return false, err // return err to break the txns pool iteration
+			}
+			return false, nil
 		}
+
+		b.Events = append(b.Events, events...)
 
 		// Setting the score lower so the next time blocks are generated
 		// these transactions don't show up at the top.
@@ -707,7 +724,7 @@ func txnProcessorHandlerFunc(mc *Chain, b *block.Block) txnProcessorHandler {
 		tii.idx++
 		tii.checkForCurrent(txn)
 
-		return true
+		return true, nil
 	}
 }
 
@@ -780,29 +797,32 @@ func newTxnIterInfo(blockSize int32) *TxnIterInfo {
 	}
 }
 
+// txns iterate handler, the function will return bool and error to indicate
+// whether the iteration should continue or not, or error if any to stop the iteration
 func txnIterHandlerFunc(mc *Chain,
 	b *block.Block,
 	lfb *block.Block,
 	bState util.MerklePatriciaTrieI,
 	txnProcessor txnProcessorHandler,
-	tii *TxnIterInfo) func(context.Context, datastore.CollectionEntity) bool {
-	return func(ctx context.Context, qe datastore.CollectionEntity) bool {
+	tii *TxnIterInfo) func(context.Context, datastore.CollectionEntity) (bool, error) {
+	return func(ctx context.Context, qe datastore.CollectionEntity) (bool, error) {
 		tii.count++
 		if ctx.Err() != nil {
-			return false
+			return false, ctx.Err()
 		}
 		if mc.GetCurrentRound() > b.Round {
 			tii.roundMismatch = true
-			return false
+			return false, nil
 		}
 		if tii.roundTimeoutCount != mc.GetRoundTimeoutCount() {
 			tii.roundTimeout = true
-			return false
+			return false, nil
 		}
 		txn, ok := qe.(*transaction.Transaction)
 		if !ok {
 			logging.Logger.Error("generate block (invalid entity)", zap.Any("entity", qe))
-			return true
+			// continue iteration to process next transaction
+			return true, nil
 		}
 
 		if lfb.ClientState == nil {
@@ -810,35 +830,52 @@ func txnIterHandlerFunc(mc *Chain,
 				zap.Int64("round", b.Round),
 				zap.String("hash", b.Hash),
 				zap.Error(ErrLFBClientStateNil))
-			return false
+			return false, nil
 		}
 
 		cost, err := mc.EstimateTransactionCost(ctx, lfb, lfb.ClientState, txn)
 		if err != nil {
 			logging.Logger.Debug("Bad transaction cost", zap.Error(err))
-			return true
+
+			// return error to break iteration due to the invalid state error
+			if cstate.ErrInvalidState(err) {
+				return false, err
+			}
+
+			// skipping and continue
+			return true, nil
 		}
 		if tii.cost+cost >= mc.ChainConfig.MaxBlockCost() {
 			logging.Logger.Debug("generate block (too big cost, skipping)")
-			return true
+			return true, nil
 		}
 
-		if txnProcessor(ctx, bState, txn, tii) {
-			tii.cost += cost
-			if tii.idx >= mc.ChainConfig.BlockSize() || tii.byteSize >= mc.MaxByteSize() {
-				logging.Logger.Debug("generate block (too big block size)",
-					zap.Bool("idx >= block size", tii.idx >= mc.ChainConfig.BlockSize()),
-					zap.Bool("byteSize >= mc.NMaxByteSize", tii.byteSize >= mc.ChainConfig.MaxByteSize()),
-					zap.Int32("idx", tii.idx),
-					zap.Int32("block size", mc.ChainConfig.BlockSize()),
-					zap.Int64("byte size", tii.byteSize),
-					zap.Int64("max byte size", mc.ChainConfig.MaxByteSize()),
-					zap.Int32("count", tii.count),
-					zap.Int("txns", len(b.Txns)))
-				return false
-			}
+		success, err := txnProcessor(ctx, bState, txn, tii)
+		if err != nil {
+			return false, err
 		}
-		return true
+
+		if !success {
+			// skipping and continue to check the next transaction
+			return true, nil
+		}
+
+		tii.cost += cost
+		if tii.idx >= mc.ChainConfig.BlockSize() || tii.byteSize >= mc.MaxByteSize() {
+			logging.Logger.Debug("generate block (too big block size)",
+				zap.Bool("idx >= block size", tii.idx >= mc.ChainConfig.BlockSize()),
+				zap.Bool("byteSize >= mc.NMaxByteSize", tii.byteSize >= mc.ChainConfig.MaxByteSize()),
+				zap.Int32("idx", tii.idx),
+				zap.Int32("block size", mc.ChainConfig.BlockSize()),
+				zap.Int64("byte size", tii.byteSize),
+				zap.Int64("max byte size", mc.ChainConfig.MaxByteSize()),
+				zap.Int32("count", tii.count),
+				zap.Int("txns", len(b.Txns)))
+			// break the iteration as the max block size reached
+			return false, nil
+		}
+
+		return true, nil
 	}
 }
 
@@ -945,6 +982,9 @@ func (mc *Chain) generateBlock(ctx context.Context, b *block.Block,
 		txn := iterInfo.currentTxns[i]
 		cost, err := mc.EstimateTransactionCost(ctx, lfb, lfb.ClientState, txn)
 		if err != nil {
+			// Note: optimistic block generation
+			// we would just skip the error so that the work on txns collection and state computation above
+			// would not be wasted. Therefore, we will pack the block anyway.
 			logging.Logger.Debug("Bad transaction cost", zap.Error(err))
 			break
 		}
@@ -952,7 +992,15 @@ func (mc *Chain) generateBlock(ctx context.Context, b *block.Block,
 			logging.Logger.Debug("generate block (too big cost, skipping)")
 			break
 		}
-		if txnProcessor(ctx, blockState, txn, iterInfo) {
+
+		success, err := txnProcessor(ctx, blockState, txn, iterInfo)
+		if err != nil {
+			// optimistic block generation. Same as EstimateTransactionCost above
+			logging.Logger.Debug("generate block - process failed and ignored", zap.Error(err))
+			break
+		}
+
+		if success {
 			rcount++
 			iterInfo.cost += cost
 			if iterInfo.idx == mc.BlockSize() || iterInfo.byteSize >= mc.MaxByteSize() {
@@ -980,7 +1028,14 @@ func (mc *Chain) generateBlock(ctx context.Context, b *block.Block,
 	}
 
 	for _, biTxn := range buildInTxns {
-		biTxn.Nonce = mc.getCurrentSelfNonce(b.MinerID, blockState)
+		biTxn.Nonce, err = mc.getCurrentSelfNonce(b.MinerID, blockState)
+		if err != nil {
+			logging.Logger.Error("generate block - could not get miner nonce",
+				zap.Error(err),
+				zap.String("miner", b.MinerID))
+			return fmt.Errorf("could not get miner nonce of %v: %v", b.MinerID, err)
+		}
+
 		_, err := biTxn.Sign(node.Self.GetSignatureScheme())
 		if err != nil {
 			panic(err)

--- a/code/go/0chain.net/smartcontract/minersc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/minersc/balances_test.go
@@ -107,6 +107,10 @@ func (tb *testBalances) GetClientBalance(clientID datastore.Key) (
 	return
 }
 
+func (tb *testBalances) GetInvalidStateErrors() []error {
+	return nil
+}
+
 func (tb *testBalances) GetTrieNode(key datastore.Key, v util.MPTSerializable) error {
 	if encryption.IsHash(key) {
 		return common.NewError("failed to get trie node",

--- a/code/go/0chain.net/smartcontract/minersc/fees2_test.go
+++ b/code/go/0chain.net/smartcontract/minersc/fees2_test.go
@@ -263,7 +263,7 @@ func testPayFees(t *testing.T, minerStakes []float64, sharderStakes [][]float64,
 		ToClientID: minerScId,
 	}
 	var ctx = &mockStateContext{
-		ctx: *cstate.NewStateContext(
+		StateContext: *cstate.NewStateContext(
 			nil,
 			&util.MerklePatriciaTrie{},
 			txn,

--- a/code/go/0chain.net/smartcontract/minersc/helper2_test.go
+++ b/code/go/0chain.net/smartcontract/minersc/helper2_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 type mockStateContext struct {
-	ctx                        cstate.StateContext
+	cstate.StateContext
 	block                      *block.Block
 	store                      map[datastore.Key]util.MPTSerializable
 	sharders                   []string
@@ -54,14 +54,6 @@ func (sc *mockStateContext) EmitError(error)                       {}
 func (sc *mockStateContext) GetEvents() []event.Event              { return nil }
 func (sc *mockStateContext) GetEventDB() *event.EventDb            { return nil }
 func (sc *mockStateContext) GetLatestFinalizedBlock() *block.Block { return nil }
-func (sc *mockStateContext) GetTransfers() []*state.Transfer {
-	return sc.ctx.GetTransfers()
-}
-
-func (sc *mockStateContext) GetMints() []*state.Mint {
-	return sc.ctx.GetMints()
-}
-
 func (sc *mockStateContext) GetLastestFinalizedMagicBlock() *block.Block {
 	return sc.LastestFinalizedMagicBlock
 }
@@ -90,15 +82,6 @@ func (sc *mockStateContext) GetTrieNode(key datastore.Key, v util.MPTSerializabl
 func (sc *mockStateContext) InsertTrieNode(key datastore.Key, node util.MPTSerializable) (datastore.Key, error) {
 	sc.store[key] = node
 	return key, nil
-}
-
-func (sc *mockStateContext) AddTransfer(t *state.Transfer) error {
-	return sc.ctx.AddTransfer(t)
-}
-
-func (sc *mockStateContext) AddMint(m *state.Mint) error {
-
-	return sc.ctx.AddMint(m)
 }
 
 func zcnToBalance(token float64) currency.Coin {
@@ -156,7 +139,6 @@ const (
 // logs and cli input parameters.
 // sc = sc.yaml
 // lockFlags input to ./zwallet lock
-//
 type formulae struct {
 	zChain           mock0ChainYaml
 	sc               mockScYaml

--- a/code/go/0chain.net/smartcontract/stakepool/balances_test.go
+++ b/code/go/0chain.net/smartcontract/stakepool/balances_test.go
@@ -176,6 +176,8 @@ func (tb *testBalances) AddTransfer(t *state.Transfer) error {
 	return nil
 }
 
+func (tb *testBalances) GetInvalidStateErrors() []error { return nil }
+
 type mptStore struct {
 	mpt  util.MerklePatriciaTrieI
 	mndb *util.MemoryNodeDB

--- a/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/alloation2_test.go
@@ -1,7 +1,6 @@
 package storagesc
 
 import (
-	"0chain.net/smartcontract/stakepool/spenum"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"0chain.net/smartcontract/stakepool/spenum"
 
 	"0chain.net/chaincore/currency"
 
@@ -502,7 +503,7 @@ func setupMocksFinishAllocation(
 		CreationDate: now,
 	}
 	var ctx = &mockStateContext{
-		ctx: *cstate.NewStateContext(
+		StateContext: *cstate.NewStateContext(
 			nil,
 			&util.MerklePatriciaTrie{},
 			txn,
@@ -743,7 +744,7 @@ func testNewAllocation(t *testing.T, request newAllocationRequest, blobbers Sort
 	}
 	defer eventDb.Close()
 	var ctx = &mockStateContext{
-		ctx: *cstate.NewStateContext(
+		StateContext: *cstate.NewStateContext(
 			nil,
 			&util.MerklePatriciaTrie{},
 			txn,

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"math/rand"
 	"strings"
-	"sync"
 	"time"
 
 	"0chain.net/chaincore/currency"
@@ -598,86 +597,39 @@ func (uar *updateAllocationRequest) getNewBlobbersSize(
 
 // get blobbers by IDs concurrently, return error if any of them could not be acquired.
 func getBlobbersByIDs(ids []string, balances chainstate.CommonStateContextI) ([]*StorageNode, error) {
-	type blobberResp struct {
-		index   int
-		blobber *StorageNode
-	}
-
-	blobberCh := make(chan blobberResp, len(ids))
-	stateErrC := make(chan error, len(ids))
-	var wg sync.WaitGroup
-	for i, details := range ids {
-		wg.Add(1)
-		go func(index int, blobberId string) {
-			defer wg.Done()
-			blobber, err := getBlobber(blobberId, balances)
-			if err != nil {
-				stateErrC <- fmt.Errorf("could not get blobber %s: %v", blobberId, err)
-				logging.Logger.Debug("could not get blobber", zap.String("blobberId", blobberId), zap.Error(err))
-				return
-			}
-
-			blobberCh <- blobberResp{
-				index:   index,
-				blobber: blobber,
-			}
-		}(i, details)
-	}
-	wg.Wait()
-	close(blobberCh)
-
-	// return if got state error
-	select {
-	case err := <-stateErrC:
-		return nil, err
-	default:
-	}
-
-	//ensure original ordering
-	blobbers := make([]*StorageNode, len(ids))
-	for resp := range blobberCh {
-		blobbers[resp.index] = resp.blobber
-	}
-
-	return blobbers, nil
+	return chainstate.GetItemsByIDs[*StorageNode](ids,
+		func(id string, balances chainstate.CommonStateContextI) (interface{}, error) {
+			return getBlobber(id, balances)
+		},
+		balances)
 }
 
 func getStakePoolsByIDs(ids []string, providerType spenum.Provider, balances chainstate.CommonStateContextI) (map[string]*stakePool, error) {
-	type spResp struct {
-		providerID string
-		sp         *stakePool
+	type stakePoolPID struct {
+		pid  string
+		pool *stakePool
 	}
 
-	poolC := make(chan spResp, len(ids))
-	errC := make(chan error, len(ids))
-	var wg sync.WaitGroup
-	for i, id := range ids {
-		wg.Add(1)
-		go func(i int, pid string) {
-			defer wg.Done()
-			sp, err := getStakePool(providerType, pid, balances)
+	stakePools, err := chainstate.GetItemsByIDs[*stakePoolPID](ids,
+		func(id string, balances chainstate.CommonStateContextI) (interface{}, error) {
+			sp, err := getStakePool(providerType, id, balances)
 			if err != nil {
-				errC <- err
-				return
+				return nil, err
 			}
-			poolC <- spResp{
-				providerID: pid,
-				sp:         sp,
-			}
-		}(i, id)
-	}
-	wg.Wait()
-	close(poolC)
 
-	select {
-	case err := <-errC:
+			return &stakePoolPID{
+				pid:  id,
+				pool: sp,
+			}, nil
+		},
+		balances)
+	if err != nil {
 		return nil, err
-	default:
 	}
-	//ensure original ordering
+
 	stakePoolMap := make(map[string]*stakePool, len(ids))
-	for resp := range poolC {
-		stakePoolMap[resp.providerID] = resp.sp
+	for _, sp := range stakePools {
+		stakePoolMap[sp.pid] = sp.pool
 	}
 
 	return stakePoolMap, nil
@@ -686,46 +638,16 @@ func getStakePoolsByIDs(ids []string, providerType spenum.Provider, balances cha
 // getAllocationBlobbers loads blobbers of an allocation from store
 func (sc *StorageSmartContract) getAllocationBlobbers(alloc *StorageAllocation,
 	balances chainstate.StateContextI) (blobbers []*StorageNode, err error) {
-
-	blobbers = make([]*StorageNode, len(alloc.BlobberAllocs))
-	type blobberResp struct {
-		index   int
-		blobber *StorageNode
+	ids := make([]string, 0, len(alloc.BlobberAllocs))
+	for _, ba := range alloc.BlobberAllocs {
+		ids = append(ids, ba.BlobberID)
 	}
 
-	blobberCh := make(chan blobberResp, len(alloc.BlobberAllocs))
-	errorCh := make(chan error, len(alloc.BlobberAllocs))
-	var wg sync.WaitGroup
-	for i, details := range alloc.BlobberAllocs {
-		wg.Add(1)
-		go func(index int, blobberId string) {
-			defer wg.Done()
-			var blobber *StorageNode
-			blobber, err = sc.getBlobber(blobberId, balances)
-			if err != nil {
-				errorCh <- fmt.Errorf("can't get blobber %q: %v", blobberId, err)
-				return
-			}
-			blobberCh <- blobberResp{
-				index:   index,
-				blobber: blobber,
-			}
-		}(i, details.BlobberID)
-	}
-	wg.Wait()
-	close(blobberCh)
-
-	select {
-	case err := <-errorCh:
-		return nil, err
-	default:
-	}
-
-	for resp := range blobberCh {
-		blobbers[resp.index] = resp.blobber
-	}
-
-	return
+	return chainstate.GetItemsByIDs[*StorageNode](ids,
+		func(id string, balances chainstate.CommonStateContextI) (interface{}, error) {
+			return sc.getBlobber(id, balances)
+		},
+		balances)
 }
 
 // closeAllocation making it expired; the allocation will be alive the

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -598,7 +598,7 @@ func (uar *updateAllocationRequest) getNewBlobbersSize(
 // get blobbers by IDs concurrently, return error if any of them could not be acquired.
 func getBlobbersByIDs(ids []string, balances chainstate.CommonStateContextI) ([]*StorageNode, error) {
 	return chainstate.GetItemsByIDs[*StorageNode](ids,
-		func(id string, balances chainstate.CommonStateContextI) (interface{}, error) {
+		func(id string, balances chainstate.CommonStateContextI) (*StorageNode, error) {
 			return getBlobber(id, balances)
 		},
 		balances)
@@ -611,7 +611,7 @@ func getStakePoolsByIDs(ids []string, providerType spenum.Provider, balances cha
 	}
 
 	stakePools, err := chainstate.GetItemsByIDs[*stakePoolPID](ids,
-		func(id string, balances chainstate.CommonStateContextI) (interface{}, error) {
+		func(id string, balances chainstate.CommonStateContextI) (*stakePoolPID, error) {
 			sp, err := getStakePool(providerType, id, balances)
 			if err != nil {
 				return nil, err
@@ -644,7 +644,7 @@ func (sc *StorageSmartContract) getAllocationBlobbers(alloc *StorageAllocation,
 	}
 
 	return chainstate.GetItemsByIDs[*StorageNode](ids,
-		func(id string, balances chainstate.CommonStateContextI) (interface{}, error) {
+		func(id string, balances chainstate.CommonStateContextI) (*StorageNode, error) {
 			return sc.getBlobber(id, balances)
 		},
 		balances)

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -597,7 +597,7 @@ func (uar *updateAllocationRequest) getNewBlobbersSize(
 
 // get blobbers by IDs concurrently, return error if any of them could not be acquired.
 func getBlobbersByIDs(ids []string, balances chainstate.CommonStateContextI) ([]*StorageNode, error) {
-	return chainstate.GetItemsByIDs[*StorageNode](ids,
+	return chainstate.GetItemsByIDs(ids,
 		func(id string, balances chainstate.CommonStateContextI) (*StorageNode, error) {
 			return getBlobber(id, balances)
 		},
@@ -610,7 +610,7 @@ func getStakePoolsByIDs(ids []string, providerType spenum.Provider, balances cha
 		pool *stakePool
 	}
 
-	stakePools, err := chainstate.GetItemsByIDs[*stakePoolPID](ids,
+	stakePools, err := chainstate.GetItemsByIDs(ids,
 		func(id string, balances chainstate.CommonStateContextI) (*stakePoolPID, error) {
 			sp, err := getStakePool(providerType, id, balances)
 			if err != nil {
@@ -643,7 +643,7 @@ func (sc *StorageSmartContract) getAllocationBlobbers(alloc *StorageAllocation,
 		ids = append(ids, ba.BlobberID)
 	}
 
-	return chainstate.GetItemsByIDs[*StorageNode](ids,
+	return chainstate.GetItemsByIDs(ids,
 		func(id string, balances chainstate.CommonStateContextI) (*StorageNode, error) {
 			return sc.getBlobber(id, balances)
 		},

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -1072,7 +1072,7 @@ func TestStorageSmartContract_newAllocationRequest(t *testing.T) {
 			"invalid character '}' looking for beginning of value"
 		errMsg6 = "allocation_creation_failed: " +
 			"invalid request: blobbers provided are not enough to honour the allocation"
-		errMsg7 = "allocation_creation_failed: " + "getting stake pools: value not present"
+		errMsg7 = "allocation_creation_failed: " + "getting stake pools: could not get item \"b1\": value not present"
 		errMsg8 = "allocation_creation_failed: " +
 			"no tokens to lock"
 		errMsg9 = "allocation_creation_failed: " +

--- a/code/go/0chain.net/smartcontract/storagesc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/balances_test.go
@@ -166,3 +166,5 @@ func (tb *testBalances) AddTransfer(t *state.Transfer) error {
 	tb.transfers = append(tb.transfers, t)
 	return nil
 }
+
+func (tb *testBalances) GetInvalidStateErrors() []error { return nil }

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -36,7 +36,7 @@ func getBlobber(
 
 func (_ *StorageSmartContract) getBlobber(
 	blobberID string,
-	balances cstate.StateContextI,
+	balances cstate.CommonStateContextI,
 ) (blobber *StorageNode, err error) {
 	return getBlobber(blobberID, balances)
 }

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -866,8 +866,14 @@ func (sc *StorageSmartContract) insertBlobber(t *transaction.Transaction,
 	balances cstate.StateContextI,
 ) (err error) {
 	savedBlobber, err := sc.getBlobber(blobber.ID, balances)
-	if err == nil {
+	switch err {
+	case nil:
+		// already exist, update it
 		return sc.updateBlobber(t, conf, blobber, savedBlobber, balances)
+	default:
+		if err != util.ErrValueNotPresent {
+			return err
+		}
 	}
 
 	has, err := sc.hasBlobberUrl(blobber.BaseURL, balances)

--- a/code/go/0chain.net/smartcontract/storagesc/blobber.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber.go
@@ -866,14 +866,13 @@ func (sc *StorageSmartContract) insertBlobber(t *transaction.Transaction,
 	balances cstate.StateContextI,
 ) (err error) {
 	savedBlobber, err := sc.getBlobber(blobber.ID, balances)
-	switch err {
-	case nil:
+	if err == nil {
 		// already exist, update it
 		return sc.updateBlobber(t, conf, blobber, savedBlobber, balances)
-	default:
-		if err != util.ErrValueNotPresent {
-			return err
-		}
+	}
+
+	if err != util.ErrValueNotPresent {
+		return err
 	}
 
 	has, err := sc.hasBlobberUrl(blobber.BaseURL, balances)

--- a/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
@@ -1,6 +1,12 @@
 package storagesc
 
 import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
 	"0chain.net/chaincore/block"
 	cstate "0chain.net/chaincore/chain/state"
 	"0chain.net/chaincore/currency"
@@ -12,13 +18,8 @@ import (
 	"0chain.net/core/encryption"
 	"0chain.net/smartcontract/stakepool"
 	"0chain.net/smartcontract/stakepool/spenum"
-	"encoding/json"
 	"github.com/0chain/common/core/util"
 	"github.com/stretchr/testify/require"
-	"strconv"
-	"strings"
-	"testing"
-	"time"
 )
 
 const (
@@ -234,7 +235,7 @@ func testCommitBlobberRead(
 		CreationDate: creationDate,
 	}
 	var ctx = &mockStateContext{
-		ctx: *cstate.NewStateContext(
+		StateContext: *cstate.NewStateContext(
 			&block.Block{},
 			&util.MerklePatriciaTrie{},
 			txn,

--- a/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
@@ -1,13 +1,14 @@
 package storagesc
 
 import (
-	"0chain.net/smartcontract/stakepool/spenum"
 	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"0chain.net/smartcontract/stakepool/spenum"
 
 	"0chain.net/chaincore/currency"
 
@@ -559,7 +560,7 @@ func setupChallengeMocks(
 		CreationDate: now,
 	}
 	var ctx = &mockStateContext{
-		ctx: *cstate.NewStateContext(
+		StateContext: *cstate.NewStateContext(
 			nil,
 			&util.MerklePatriciaTrie{},
 			txn,

--- a/code/go/0chain.net/smartcontract/storagesc/helper2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/helper2_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 type mockStateContext struct {
-	ctx           cstate.StateContext
+	cstate.StateContext
 	clientBalance currency.Coin
 	store         map[datastore.Key]util.MPTSerializable
 }
@@ -62,24 +62,12 @@ func (sc *mockStateContext) GetClientBalance(_ datastore.Key) (currency.Coin, er
 	return sc.clientBalance, nil
 }
 
-func (sc *mockStateContext) GetTransfers() []*state.Transfer {
-	return sc.ctx.GetTransfers()
-}
-
-func (sc *mockStateContext) GetMints() []*state.Mint {
-	return sc.ctx.GetMints()
-}
-
 func (sc *mockStateContext) GetLastestFinalizedMagicBlock() *block.Block {
 	return nil
 }
 
 func (sc *mockStateContext) GetBlockSharders(_ *block.Block) []string {
 	return nil
-}
-
-func (sc *mockStateContext) GetBlock() *block.Block {
-	return sc.ctx.GetBlock()
 }
 
 func (sc *mockStateContext) SetStateContext(_ *state.State) error { return nil }
@@ -101,14 +89,6 @@ func (sc *mockStateContext) GetTrieNode(key datastore.Key, v util.MPTSerializabl
 func (sc *mockStateContext) InsertTrieNode(key datastore.Key, node util.MPTSerializable) (datastore.Key, error) {
 	sc.store[key] = node
 	return key, nil
-}
-
-func (sc *mockStateContext) AddTransfer(t *state.Transfer) error {
-	return sc.ctx.AddTransfer(t)
-}
-
-func (sc *mockStateContext) AddMint(m *state.Mint) error {
-	return sc.ctx.AddMint(m)
 }
 
 func zcnToInt64(token float64) int64 {

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool_test.go
@@ -125,7 +125,7 @@ func testStakePoolLock(t *testing.T, value, clientBalance currency.Coin, delegat
 		CreationDate: creationDate,
 	}
 	var ctx = &mockStateContext{
-		ctx: *cstate.NewStateContext(
+		StateContext: *cstate.NewStateContext(
 			nil,
 			&util.MerklePatriciaTrie{},
 			txn,

--- a/code/go/0chain.net/smartcontract/vestingsc/balances_test.go
+++ b/code/go/0chain.net/smartcontract/vestingsc/balances_test.go
@@ -122,3 +122,5 @@ func (tb *testBalances) AddTransfer(t *state.Transfer) error {
 	tb.transfers = append(tb.transfers, t)
 	return nil
 }
+
+func (tb *testBalances) GetInvalidStateErrors() []error { return nil }


### PR DESCRIPTION
## Fixes
- #1723 
- #1688

## Changes

- Fix concurrently MPT access caused state hash mismatch error
- Implemented common way to get items from MPT concurrently
- Store invalid state error 'node not found' in StateContext, it will be saved whenever it happens when read/write/delete node from MPT. Check the invalid state error first to ensure invalid state error would not be ignored, which would lead to state hash mismatch error.


## Need to be mentioned in CHANGELOG.md?
No

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):

