### PR TITLE
Fix sharder token locking issue

### DIFF
--- a/code/go/0chain.net/smartcontract/minersc/delegate_pools.go
+++ b/code/go/0chain.net/smartcontract/minersc/delegate_pools.go
@@ -55,7 +55,7 @@ func (msc *MinerSmartContract) addToDelegatePool(t *transaction.Transaction,
 			"stake is greater than max allowed: %d > %d", t.Value, mn.Settings.MaxStake)
 	}
 
-	if err := mn.LockPool(t, spenum.Miner, mn.ID, spenum.Pending, balances); err != nil {
+	if err := mn.LockPool(t, spenum.Provider(mn.NodeType), mn.ID, spenum.Pending, balances); err != nil {
 		return "", common.NewErrorf("delegate_pool_add",
 			"digging delegate pool: %v", err)
 	}

--- a/code/go/0chain.net/smartcontract/minersc/models.go
+++ b/code/go/0chain.net/smartcontract/minersc/models.go
@@ -1015,7 +1015,19 @@ func getNodesList(balances cstate.CommonStateContextI, key datastore.Key) (*Mine
 		return nil, err
 	}
 
-	return nodesList, nil
+	ids := make([]string, 0, len(nodesList.Nodes))
+	for _, sh := range nodesList.Nodes {
+		ids = append(ids, sh.ID)
+	}
+
+	// TODO: replace AllShardersKey data in MPT with keys only or use partitions to
+	// avoid sync issue
+	ss, err := cstate.GetItemsByIDs(ids, getMinerNode, balances)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MinerNodes{ss}, nil
 }
 
 // quick fix: localhost check + duplicate check


### PR DESCRIPTION
## Fixes

- Lock token to provider with correct provider type, previously it was always miner.
- Update `getNodesList` to only use keys from `AllMinersKeys` and `AllShardersKeys`, then load items by ids concurrently from MPT to avoid sync issue. Because of the nodes were not synced, even we locked token to sharder, and added the pool id to the sharder's delegate pool, it would be overwritten to nil later when update rewards to sharders delegates in payFee txn. This is kind of a workaround fix, and we will need to refactor to only store node keys in `AllMinersKeys` and `AllShardersKeys`, or replace the nodes list with partitions.  

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
No