### PR TITLE
add option to `/getblobbers` get active blobbers

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -15,7 +15,7 @@ import (
 	"github.com/guregu/null"
 )
 
-const ActiveBlobbersTimeLimit = 60 * 60 // 1 hour
+const ActiveBlobbersTimeLimit = 5 * time.Minute // 5 Minutes
 
 type Blobber struct {
 	gorm.Model
@@ -133,7 +133,7 @@ func (edb *EventDb) GetActiveBlobbers(limit common2.Pagination) ([]Blobber, erro
 	result := edb.Store.Get().
 		Preload("Rewards").
 		Model(&Blobber{}).Offset(limit.Offset).
-		Where("last_health_check > ?", common.ToTime(now).Add(-time.Hour).Unix()).Limit(limit.Limit).Order(clause.OrderByColumn{
+		Where("last_health_check > ?", common.ToTime(now).Add(-ActiveBlobbersTimeLimit).Unix()).Limit(limit.Limit).Order(clause.OrderByColumn{
 		Column: clause.Column{Name: "capacity"},
 		Desc:   limit.IsDescending,
 	}).Find(&blobbers)

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -15,6 +15,8 @@ import (
 	"github.com/guregu/null"
 )
 
+const ActiveBlobbersTimeLimit = 60 * 60 // 1 hour
+
 type Blobber struct {
 	gorm.Model
 	BlobberID string `json:"id" gorm:"uniqueIndex"`
@@ -122,6 +124,19 @@ func (edb *EventDb) GetBlobbers(limit common2.Pagination) ([]Blobber, error) {
 		Desc:   limit.IsDescending,
 	}).Find(&blobbers)
 
+	return blobbers, result.Error
+}
+
+func (edb *EventDb) GetActiveBlobbers(limit common2.Pagination) ([]Blobber, error) {
+	now := common.Now()
+	var blobbers []Blobber
+	result := edb.Store.Get().
+		Preload("Rewards").
+		Model(&Blobber{}).Offset(limit.Offset).
+		Where("last_health_check > ?", common.ToTime(now).Add(-time.Hour).Unix()).Limit(limit.Limit).Order(clause.OrderByColumn{
+		Column: clause.Column{Name: "capacity"},
+		Desc:   limit.IsDescending,
+	}).Find(&blobbers)
 	return blobbers, result.Error
 }
 

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -2277,13 +2277,21 @@ func (srh *StorageRestHandler) getBlobbers(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	values := r.URL.Query()
+	active := values.Get("active")
 	edb := srh.GetQueryStateContext().GetEventDB()
 	if edb == nil {
 		common.Respond(w, r, nil, common.NewErrInternal("no db connection"))
 		return
 	}
 
-	blobbers, err := edb.GetBlobbers(limit)
+	var blobbers []event.Blobber
+	if active == "true" {
+		blobbers, err = edb.GetActiveBlobbers(limit)
+	} else {
+		blobbers, err = edb.GetBlobbers(limit)
+	}
+
 	if err != nil {
 		err := common.NewErrInternal("cannot get blobber list" + err.Error())
 		common.Respond(w, r, nil, err)


### PR DESCRIPTION
## Fixes
In gosdk, Currently to the get active blobbers, we will have to call `/getBlobbers` and read the `LastHealthCheck. Sime times we might have to do pagination and go till the end of the results to get the active blobbers. 

https://github.com/0chain/gosdk/blob/7a0a5c27fdaf4c4d4ea1155dc629dcd5393bd07b/zboxcore/sdk/sdk.go#L627

So performing when the request is made is a quick way to get active blobbers list.

so to `/getblobbers` adding an extra query parameter to signify if active blobbers are required or not

## Changes

option to get blobbers in that are active in last 5 mins

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
