### PR TITLE
Minersc reward settings

### DIFF
--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -382,10 +382,18 @@ func (sc *StateContext) GetSignatureScheme() encryption.SignatureScheme {
 }
 
 func (sc *StateContext) GetTrieNode(key datastore.Key, v util.MPTSerializable) error {
+	GlobalNodeKey := "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d9" + encryption.Hash("global_node")
+	if key == GlobalNodeKey {
+		fmt.Println(key)
+	}
 	return sc.getNodeValue(key, v)
 }
 
 func (sc *StateContext) InsertTrieNode(key datastore.Key, node util.MPTSerializable) (datastore.Key, error) {
+	GlobalNodeKey := "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d9" + encryption.Hash("global_node")
+	if key == GlobalNodeKey {
+		fmt.Println(key)
+	}
 	return sc.setNodeValue(key, node)
 }
 

--- a/code/go/0chain.net/chaincore/chain/state/state_context.go
+++ b/code/go/0chain.net/chaincore/chain/state/state_context.go
@@ -382,18 +382,10 @@ func (sc *StateContext) GetSignatureScheme() encryption.SignatureScheme {
 }
 
 func (sc *StateContext) GetTrieNode(key datastore.Key, v util.MPTSerializable) error {
-	GlobalNodeKey := "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d9" + encryption.Hash("global_node")
-	if key == GlobalNodeKey {
-		fmt.Println(key)
-	}
 	return sc.getNodeValue(key, v)
 }
 
 func (sc *StateContext) InsertTrieNode(key datastore.Key, node util.MPTSerializable) (datastore.Key, error) {
-	GlobalNodeKey := "6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d9" + encryption.Hash("global_node")
-	if key == GlobalNodeKey {
-		fmt.Println(key)
-	}
 	return sc.setNodeValue(key, node)
 }
 

--- a/code/go/0chain.net/miner/testdata/config/sc.yaml
+++ b/code/go/0chain.net/miner/testdata/config/sc.yaml
@@ -55,7 +55,7 @@ smart_contracts:
     # gives 10% for miner and rest for block sharders
     share_ratio: 0.8 # [0; 1)
     # reward for a block
-    block_reward: 0.21 # tokens
+    block_reward: 0.2129 # tokens
     # max service charge can be set by a generator
     max_charge: 0.5 # %
     # epoch is number of rounds before rewards and interest are decreased
@@ -68,6 +68,12 @@ smart_contracts:
     max_mint: 1500000.0 # tokens
     # if view change is false then reward round frequency is used to send rewards and interests
     reward_round_frequency: 250
+    # miner delegates to get paid each round when paying fees and rewards
+    num_miner_delegates_rewarded: 10
+    # sharders rewarded each round
+    num_sharders_rewarded: 5
+    # sharder delegates to get paid each round when paying fees and rewards
+    num_sharder_delegates_rewarded: 1
     cooldown_period: 100
     cost:
       add_miner: 100

--- a/code/go/0chain.net/miner/testdata/config/sc.yaml
+++ b/code/go/0chain.net/miner/testdata/config/sc.yaml
@@ -55,7 +55,7 @@ smart_contracts:
     # gives 10% for miner and rest for block sharders
     share_ratio: 0.8 # [0; 1)
     # reward for a block
-    block_reward: 0.2129 # tokens
+    block_reward: 0.21 # tokens
     # max service charge can be set by a generator
     max_charge: 0.5 # %
     # epoch is number of rounds before rewards and interest are decreased

--- a/code/go/0chain.net/smartcontract/benchmark/bench_data.go
+++ b/code/go/0chain.net/smartcontract/benchmark/bench_data.go
@@ -8,6 +8,8 @@ type BenchDataMpt struct {
 	Clients     []string         `json:"clients"`
 	PublicKeys  []string         `json:"publicKeys"`
 	PrivateKeys []string         `json:"privateKeys"`
+	Miners      []string         `json:"miners"`
 	Sharders    []string         `json:"sharders"`
+	SharderKeys []string         `json:"sharderKeys"`
 	Now         common.Timestamp `json:"now"`
 }

--- a/code/go/0chain.net/smartcontract/benchmark/bench_data_gen.go
+++ b/code/go/0chain.net/smartcontract/benchmark/bench_data_gen.go
@@ -9,9 +9,9 @@ import (
 // MarshalMsg implements msgp.Marshaler
 func (z *BenchDataMpt) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 5
+	// map header, size 7
 	// string "Clients"
-	o = append(o, 0x85, 0xa7, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x73)
+	o = append(o, 0x87, 0xa7, 0x43, 0x6c, 0x69, 0x65, 0x6e, 0x74, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Clients)))
 	for za0001 := range z.Clients {
 		o = msgp.AppendString(o, z.Clients[za0001])
@@ -28,11 +28,23 @@ func (z *BenchDataMpt) MarshalMsg(b []byte) (o []byte, err error) {
 	for za0003 := range z.PrivateKeys {
 		o = msgp.AppendString(o, z.PrivateKeys[za0003])
 	}
+	// string "Miners"
+	o = append(o, 0xa6, 0x4d, 0x69, 0x6e, 0x65, 0x72, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.Miners)))
+	for za0004 := range z.Miners {
+		o = msgp.AppendString(o, z.Miners[za0004])
+	}
 	// string "Sharders"
 	o = append(o, 0xa8, 0x53, 0x68, 0x61, 0x72, 0x64, 0x65, 0x72, 0x73)
 	o = msgp.AppendArrayHeader(o, uint32(len(z.Sharders)))
-	for za0004 := range z.Sharders {
-		o = msgp.AppendString(o, z.Sharders[za0004])
+	for za0005 := range z.Sharders {
+		o = msgp.AppendString(o, z.Sharders[za0005])
+	}
+	// string "SharderKeys"
+	o = append(o, 0xab, 0x53, 0x68, 0x61, 0x72, 0x64, 0x65, 0x72, 0x4b, 0x65, 0x79, 0x73)
+	o = msgp.AppendArrayHeader(o, uint32(len(z.SharderKeys)))
+	for za0006 := range z.SharderKeys {
+		o = msgp.AppendString(o, z.SharderKeys[za0006])
 	}
 	// string "Now"
 	o = append(o, 0xa3, 0x4e, 0x6f, 0x77)
@@ -119,22 +131,60 @@ func (z *BenchDataMpt) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					return
 				}
 			}
-		case "Sharders":
+		case "Miners":
 			var zb0005 uint32
 			zb0005, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Miners")
+				return
+			}
+			if cap(z.Miners) >= int(zb0005) {
+				z.Miners = (z.Miners)[:zb0005]
+			} else {
+				z.Miners = make([]string, zb0005)
+			}
+			for za0004 := range z.Miners {
+				z.Miners[za0004], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Miners", za0004)
+					return
+				}
+			}
+		case "Sharders":
+			var zb0006 uint32
+			zb0006, bts, err = msgp.ReadArrayHeaderBytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "Sharders")
 				return
 			}
-			if cap(z.Sharders) >= int(zb0005) {
-				z.Sharders = (z.Sharders)[:zb0005]
+			if cap(z.Sharders) >= int(zb0006) {
+				z.Sharders = (z.Sharders)[:zb0006]
 			} else {
-				z.Sharders = make([]string, zb0005)
+				z.Sharders = make([]string, zb0006)
 			}
-			for za0004 := range z.Sharders {
-				z.Sharders[za0004], bts, err = msgp.ReadStringBytes(bts)
+			for za0005 := range z.Sharders {
+				z.Sharders[za0005], bts, err = msgp.ReadStringBytes(bts)
 				if err != nil {
-					err = msgp.WrapError(err, "Sharders", za0004)
+					err = msgp.WrapError(err, "Sharders", za0005)
+					return
+				}
+			}
+		case "SharderKeys":
+			var zb0007 uint32
+			zb0007, bts, err = msgp.ReadArrayHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "SharderKeys")
+				return
+			}
+			if cap(z.SharderKeys) >= int(zb0007) {
+				z.SharderKeys = (z.SharderKeys)[:zb0007]
+			} else {
+				z.SharderKeys = make([]string, zb0007)
+			}
+			for za0006 := range z.SharderKeys {
+				z.SharderKeys[za0006], bts, err = msgp.ReadStringBytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "SharderKeys", za0006)
 					return
 				}
 			}
@@ -170,9 +220,17 @@ func (z *BenchDataMpt) Msgsize() (s int) {
 	for za0003 := range z.PrivateKeys {
 		s += msgp.StringPrefixSize + len(z.PrivateKeys[za0003])
 	}
+	s += 7 + msgp.ArrayHeaderSize
+	for za0004 := range z.Miners {
+		s += msgp.StringPrefixSize + len(z.Miners[za0004])
+	}
 	s += 9 + msgp.ArrayHeaderSize
-	for za0004 := range z.Sharders {
-		s += msgp.StringPrefixSize + len(z.Sharders[za0004])
+	for za0005 := range z.Sharders {
+		s += msgp.StringPrefixSize + len(z.Sharders[za0005])
+	}
+	s += 12 + msgp.ArrayHeaderSize
+	for za0006 := range z.SharderKeys {
+		s += msgp.StringPrefixSize + len(z.SharderKeys[za0006])
 	}
 	s += 4 + z.Now.Msgsize()
 	return

--- a/code/go/0chain.net/smartcontract/benchmark/benchmark.go
+++ b/code/go/0chain.net/smartcontract/benchmark/benchmark.go
@@ -361,7 +361,9 @@ var MockBenchData = BenchData{
 		Clients:     make([]string, 100),
 		PublicKeys:  make([]string, 100),
 		PrivateKeys: make([]string, 100),
+		Miners:      make([]string, 100),
 		Sharders:    make([]string, 100),
+		SharderKeys: make([]string, 100),
 		Now:         common.Now(),
 	},
 }

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
@@ -74,7 +74,9 @@ func getBalances(
 	bk.CreationDate = common.Timestamp(viper.GetInt64(benchmark.MptCreationTime))
 	bk.MinerID = minersc.GetMockNodeId(0, spenum.Miner)
 	node.Self.Underlying().SetKey(minersc.GetMockNodeId(0, spenum.Miner))
-	magicBlock := &block.MagicBlock{}
+	magicBlock := &block.MagicBlock{
+		Sharders: new(node.Pool),
+	}
 	signatureScheme := &encryption.BLS0ChainScheme{}
 	return mpt, cstate.NewStateContext(
 		bk,

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
@@ -252,6 +252,14 @@ func setUpMpt(
 	go func() {
 		defer wg.Done()
 		timer := time.Now()
+		minersc.AddMockGlobalNode(balances)
+		log.Println("added minersc global node\t", time.Since(timer))
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		timer := time.Now()
 		miners = minersc.AddMockNodes(clients, spenum.Miner, eventDb, balances)
 		log.Println("added miners\t", time.Since(timer))
 	}()

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
@@ -72,10 +72,22 @@ func getBalances(
 	}
 	bk.Round = 2
 	bk.CreationDate = common.Timestamp(viper.GetInt64(benchmark.MptCreationTime))
-	bk.MinerID = minersc.GetMockNodeId(0, spenum.Miner)
-	node.Self.Underlying().SetKey(minersc.GetMockNodeId(0, spenum.Miner))
+	bk.MinerID = data.Miners[0]
+	node.Self.Underlying().SetKey(data.Miners[0])
 	magicBlock := &block.MagicBlock{
-		Sharders: new(node.Pool),
+		Sharders: node.NewPool(node.NodeTypeSharder),
+	}
+	for i := range data.Sharders {
+		var n = node.Provider()
+		if err := n.SetID(data.Sharders[i]); err != nil {
+			log.Fatal(err)
+		}
+		n.PublicKey = data.SharderKeys[i]
+		n.Type = node.NodeTypeSharder
+		n.SetSignatureSchemeType(encryption.SignatureSchemeBls0chain)
+		if err := magicBlock.Sharders.AddNode(n); err != nil {
+			log.Fatal(err)
+		}
 	}
 	signatureScheme := &encryption.BLS0ChainScheme{}
 	return mpt, cstate.NewStateContext(
@@ -221,8 +233,8 @@ func setUpMpt(
 
 	var wg sync.WaitGroup
 	var (
-		blobbers         []*storagesc.StorageNode
-		miners, sharders []string
+		blobbers                      []*storagesc.StorageNode
+		miners, sharders, sharderKeys []string
 	)
 
 	wg.Add(1)
@@ -262,7 +274,7 @@ func setUpMpt(
 	go func() {
 		defer wg.Done()
 		timer := time.Now()
-		miners = minersc.AddMockNodes(clients, spenum.Miner, eventDb, balances)
+		miners, _ = minersc.AddMockNodes(clients, spenum.Miner, eventDb, balances, getMockIdKeyPair)
 		log.Println("added miners\t", time.Since(timer))
 	}()
 
@@ -270,7 +282,7 @@ func setUpMpt(
 	go func() {
 		defer wg.Done()
 		timer := time.Now()
-		sharders = minersc.AddMockNodes(clients, spenum.Sharder, eventDb, balances)
+		sharders, sharderKeys = minersc.AddMockNodes(clients, spenum.Sharder, eventDb, balances, getMockIdKeyPair)
 		log.Println("added sharders\t", time.Since(timer))
 	}()
 
@@ -356,7 +368,7 @@ func setUpMpt(
 	go func() {
 		defer wg.Done()
 		timer := time.Now()
-		minersc.SetUpNodes(miners, sharders)
+		minersc.SetUpNodes(miners, sharders, sharderKeys)
 		log.Println("registering miners and sharders\t", time.Since(timer))
 	}()
 
@@ -460,7 +472,9 @@ func setUpMpt(
 		benchData.Clients = clients
 		benchData.PublicKeys = publicKeys
 		benchData.PrivateKeys = privateKeys
+		benchData.Miners = miners
 		benchData.Sharders = sharders
+		benchData.SharderKeys = sharderKeys
 		benchData.Now = common.Now()
 
 		if _, err := balances.InsertTrieNode(BenchDataKey, &benchData); err != nil {
@@ -479,6 +493,19 @@ func setUpMpt(
 	log.Println("mpt generation took:", time.Since(mptGenTime))
 
 	return pMpt, balances.GetState().GetRoot(), benchData
+}
+
+func getMockIdKeyPair() (string, string, error) {
+	blsScheme := BLS0ChainScheme{}
+	if err := blsScheme.GenerateKeys(); err != nil {
+		return "", "", err
+	}
+	pk := blsScheme.GetPublicKey()
+	b, err := hex.DecodeString(pk)
+	if err != nil {
+		return "", "", err
+	}
+	return encryption.Hash(b), pk, nil
 }
 
 func openEventsDb() *event.EventDb {

--- a/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
+++ b/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
@@ -69,7 +69,7 @@ smart_contracts:
     interest_rate: 0.0 # [0; 1)
     reward_rate: 1.0 # [0; 1)
     share_ratio: 0.8 # [0; 1)
-    block_reward: 0.2123 # tokens
+    block_reward: 0.21 # tokens
     max_charge: 0.5 # %
     epoch: 15000000 # rounds
     reward_decline_rate: 0.1 # [0; 1), 0.1 = 10%

--- a/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
+++ b/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
@@ -3,8 +3,8 @@ simulation:
   num_active_clients: 210
   num_miners: 100
   num_active_miners: 100
-  nun_sharders: 5
-  nun_active_sharders: 5
+  nun_sharders: 20
+  nun_active_sharders: 20
   num_allocations: 300
   num_blobbers: 100
   num_validators: 10

--- a/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
+++ b/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
@@ -69,12 +69,15 @@ smart_contracts:
     interest_rate: 0.0 # [0; 1)
     reward_rate: 1.0 # [0; 1)
     share_ratio: 0.8 # [0; 1)
-    block_reward: 0.21 # tokens
+    block_reward: 0.2123 # tokens
     max_charge: 0.5 # %
     epoch: 15000000 # rounds
     reward_decline_rate: 0.1 # [0; 1), 0.1 = 10%
     interest_decline_rate: 0.1 # [0; 1), 0.1 = 10%
     max_mint: 1500000.0 # tokens
+    num_miner_delegates_rewarded: 10
+    num_sharders_rewarded: 5
+    num_sharder_delegates_rewarded: 1
     cost:
       add_miner: 100
       add_sharder: 100

--- a/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
+++ b/code/go/0chain.net/smartcontract/benchmark/main/config/benchmark.yaml
@@ -3,8 +3,8 @@ simulation:
   num_active_clients: 210
   num_miners: 100
   num_active_miners: 100
-  nun_sharders: 20
-  nun_active_sharders: 20
+  nun_sharders: 5
+  nun_active_sharders: 5
   num_allocations: 300
   num_blobbers: 100
   num_validators: 10

--- a/code/go/0chain.net/smartcontract/minersc/benchmark_rest_tests.go
+++ b/code/go/0chain.net/smartcontract/minersc/benchmark_rest_tests.go
@@ -88,14 +88,14 @@ func BenchmarkRestTests(
 			{
 				FuncName: "nodeStat",
 				Params: map[string]string{
-					"id": GetMockNodeId(0, spenum.Miner),
+					"id": data.Miners[0],
 				},
 				Endpoint: mrh.getNodeStat,
 			},
 			{
 				FuncName: "nodePoolStat",
 				Params: map[string]string{
-					"id":      GetMockNodeId(0, spenum.Miner),
+					"id":      data.Miners[0],
 					"pool_id": getMinerDelegatePoolId(0, 0, spenum.Miner),
 				},
 				Endpoint: mrh.getNodePoolStat,

--- a/code/go/0chain.net/smartcontract/minersc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/minersc/benchmark_setup.go
@@ -36,16 +36,17 @@ func AddMockNodes(
 	nodeType spenum.Provider,
 	eventDb *event.EventDb,
 	balances cstate.StateContextI,
-) []string {
+	getIdAndPublicKey func() (string, string, error),
+) ([]string, []string) {
 	var (
-		err          error
-		nodes        []string
-		allNodes     MinerNodes
-		nodeMap      = make(map[string]*SimpleNode)
-		numNodes     int
-		numActive    int
-		numDelegates int
-		key          string
+		err                error
+		nodes, publickKeys []string
+		allNodes           MinerNodes
+		nodeMap            = make(map[string]*SimpleNode)
+		numNodes           int
+		numActive          int
+		numDelegates       int
+		key                string
 	)
 
 	if nodeType == spenum.Miner {
@@ -62,16 +63,18 @@ func AddMockNodes(
 
 	for i := 0; i < numNodes; i++ {
 		newNode := NewMinerNode()
-		newNode.ID = GetMockNodeId(i, nodeType)
+		newNode.ID, newNode.PublicKey, err = getIdAndPublicKey()
+		if err != nil {
+			log.Fatal(err)
+		}
 		newNode.LastHealthCheck = common.Timestamp(viper.GetInt64(benchmark.MptCreationTime))
-		newNode.PublicKey = "mockPublicKey"
 		newNode.Settings.ServiceChargeRatio = viper.GetFloat64(benchmark.MinerMaxCharge)
 		newNode.Settings.MaxNumDelegates = viper.GetInt(benchmark.MinerMaxDelegates)
 		newNode.Settings.MinStake = currency.Coin(viper.GetInt64(benchmark.MinerMinStake))
 		newNode.Settings.MaxStake = currency.Coin(viper.GetFloat64(benchmark.MinerMaxStake) * 1e10)
 		newNode.NodeType = NodeTypeMiner
 		newNode.Settings.DelegateWallet = clients[0]
-
+		publickKeys = append(publickKeys, newNode.PublicKey)
 		for j := 0; j < numDelegates; j++ {
 			dId := (i + j) % numNodes
 			pool := stakepool.DelegatePool{
@@ -87,7 +90,7 @@ func AddMockNodes(
 				newNode.Pools[getMinerDelegatePoolId(i, dId, nodeType)] = &pool
 			}
 		}
-		_, err := balances.InsertTrieNode(newNode.GetKey(), newNode)
+		_, err = balances.InsertTrieNode(newNode.GetKey(), newNode)
 		if err != nil {
 			panic(err)
 		}
@@ -156,7 +159,7 @@ func AddMockNodes(
 	if err != nil {
 		panic(err)
 	}
-	return nodes
+	return nodes, publickKeys
 }
 
 func AddNodeDelegates(
@@ -189,7 +192,7 @@ func AddUserNodesForNode(
 }
 
 func SetUpNodes(
-	miners, sharders []string,
+	miners, sharders, sharderKeys []string,
 ) {
 	activeMiners := viper.GetInt(benchmark.NumActiveMiners)
 	for i, miner := range miners {
@@ -215,7 +218,7 @@ func SetUpNodes(
 		nextSharder.TimersByURI = make(map[string]metrics.Timer, 10)
 		nextSharder.SizeByURI = make(map[string]metrics.Histogram, 10)
 		nextSharder.ID = sharder
-		nextSharder.PublicKey = "mockPublicKey"
+		nextSharder.PublicKey = sharderKeys[i]
 		nextSharder.Type = node.NodeTypeMiner
 		if i < activeSharders {
 			nextSharder.Status = node.NodeStatusActive
@@ -227,7 +230,7 @@ func SetUpNodes(
 }
 
 func AddMagicBlock(
-	miners, sharders []string,
+	_, _ []string,
 	balances cstate.StateContextI,
 ) {
 	var magicBlock block.MagicBlock
@@ -253,8 +256,4 @@ func AddPhaseNode(balances cstate.StateContextI) {
 func getMinerDelegatePoolId(miner, delegate int, nodeType spenum.Provider) string {
 	return encryption.Hash("delegate pool" +
 		strconv.Itoa(miner) + strconv.Itoa(delegate) + strconv.Itoa(int(nodeType)))
-}
-
-func GetMockNodeId(index int, nodeType spenum.Provider) string {
-	return encryption.Hash("mock" + nodeType.String() + strconv.Itoa(index))
 }

--- a/code/go/0chain.net/smartcontract/minersc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/minersc/benchmark_setup.go
@@ -29,7 +29,6 @@ func AddMockGlobalNode(balances cstate.StateContextI) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 }
 
 func AddMockNodes(

--- a/code/go/0chain.net/smartcontract/minersc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/minersc/benchmark_setup.go
@@ -3,6 +3,8 @@ package minersc
 import (
 	"strconv"
 
+	"0chain.net/smartcontract/benchmark/main/cmd/log"
+
 	"0chain.net/chaincore/currency"
 
 	"0chain.net/smartcontract/dbs/event"
@@ -19,6 +21,16 @@ import (
 	"github.com/rcrowley/go-metrics"
 	"github.com/spf13/viper"
 )
+
+func AddMockGlobalNode(balances cstate.StateContextI) {
+	var gn GlobalNode
+	gn.readConfig()
+	_, err := balances.InsertTrieNode(GlobalNodeKey, &gn)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+}
 
 func AddMockNodes(
 	clients []string,

--- a/code/go/0chain.net/smartcontract/minersc/benchmark_tests.go
+++ b/code/go/0chain.net/smartcontract/minersc/benchmark_tests.go
@@ -146,7 +146,7 @@ func BenchmarkTests(
 			name:     "miner.update_globals",
 			endpoint: msc.minerHealthCheck,
 			txn: &transaction.Transaction{
-				ClientID:     GetMockNodeId(0, spenum.Miner),
+				ClientID:     data.Miners[0],
 				CreationDate: creationTime,
 			},
 			input: nil,
@@ -155,7 +155,7 @@ func BenchmarkTests(
 			name:     "miner.miner_health_check",
 			endpoint: msc.minerHealthCheck,
 			txn: &transaction.Transaction{
-				ClientID:     GetMockNodeId(0, spenum.Miner),
+				ClientID:     data.Miners[0],
 				CreationDate: creationTime,
 			},
 			input: nil,
@@ -164,7 +164,7 @@ func BenchmarkTests(
 			name:     "miner.sharder_health_check",
 			endpoint: msc.sharderHealthCheck,
 			txn: &transaction.Transaction{
-				ClientID:     GetMockNodeId(0, spenum.Sharder),
+				ClientID:     data.Miners[0],
 				CreationDate: creationTime,
 			},
 			input: nil,
@@ -173,7 +173,7 @@ func BenchmarkTests(
 			name:     "miner.payFees",
 			endpoint: msc.payFees,
 			txn: &transaction.Transaction{
-				ClientID:     GetMockNodeId(0, spenum.Miner),
+				ClientID:     data.Miners[0],
 				ToClientID:   ADDRESS,
 				CreationDate: creationTime,
 			},
@@ -183,14 +183,14 @@ func BenchmarkTests(
 			name:     "miner.contributeMpk",
 			endpoint: msc.contributeMpk,
 			txn: &transaction.Transaction{
-				ClientID:     GetMockNodeId(0, spenum.Miner),
+				ClientID:     data.Miners[0],
 				ToClientID:   ADDRESS,
 				CreationDate: creationTime,
 			},
 			input: func() []byte {
 				var mpks []string
 				for i := 0; i < viper.GetInt(bk.InternalT); i++ {
-					mpks = append(mpks, GetMockNodeId(i, spenum.Miner))
+					mpks = append(mpks, data.Miners[i])
 				}
 				return (&block.MPK{
 					Mpk: mpks,
@@ -201,13 +201,13 @@ func BenchmarkTests(
 			name:     "miner.shareSignsOrShares",
 			endpoint: msc.shareSignsOrShares,
 			txn: &transaction.Transaction{
-				ClientID:     GetMockNodeId(0, spenum.Miner),
+				ClientID:     data.Miners[0],
 				CreationDate: creationTime,
 			},
 			input: func() []byte {
 				var sos = make(map[string]*bls.DKGKeyShare)
 				for i := 0; i < viper.GetInt(bk.InternalT); i++ {
-					sos[GetMockNodeId(i, spenum.Miner)] = nil
+					sos[data.Miners[i]] = nil
 				}
 				return (&block.ShareOrSigns{
 					ShareOrSigns: sos,
@@ -304,7 +304,7 @@ func BenchmarkTests(
 			},
 			input: (&MinerNode{
 				SimpleNode: &SimpleNode{
-					ID: GetMockNodeId(0, spenum.Miner),
+					ID: data.Miners[0],
 				},
 				StakePool: &stakepool.StakePool{
 					Pools: make(map[string]*stakepool.DelegatePool),
@@ -326,7 +326,7 @@ func BenchmarkTests(
 			},
 			input: (&MinerNode{
 				SimpleNode: &SimpleNode{
-					ID: GetMockNodeId(0, spenum.Sharder),
+					ID: data.Miners[0],
 				},
 				StakePool: &stakepool.StakePool{
 					Pools: make(map[string]*stakepool.DelegatePool),
@@ -351,7 +351,7 @@ func BenchmarkTests(
 				CreationDate: creationTime,
 			},
 			input: (&deletePool{
-				MinerID: GetMockNodeId(0, spenum.Miner),
+				MinerID: data.Miners[0],
 			}).Encode(),
 		},
 		{
@@ -362,7 +362,7 @@ func BenchmarkTests(
 				CreationDate: creationTime,
 			},
 			input: (&deletePool{
-				MinerID: GetMockNodeId(0, spenum.Miner),
+				MinerID: data.Miners[0],
 			}).Encode(),
 		},
 		{
@@ -371,7 +371,7 @@ func BenchmarkTests(
 			txn:      &transaction.Transaction{CreationDate: creationTime},
 			input: (&MinerNode{
 				SimpleNode: &SimpleNode{
-					ID:        GetMockNodeId(0, spenum.Sharder),
+					ID:        data.Sharders[0],
 					PublicKey: "my public key",
 				},
 			}).Encode(),
@@ -382,7 +382,7 @@ func BenchmarkTests(
 			txn:      &transaction.Transaction{},
 			input: (&MinerNode{
 				SimpleNode: &SimpleNode{
-					ID:        GetMockNodeId(1, spenum.Miner),
+					ID:        data.Miners[1],
 					PublicKey: "my public key",
 				},
 			}).Encode(),
@@ -393,7 +393,7 @@ func BenchmarkTests(
 			txn:      &transaction.Transaction{},
 			input: (&MinerNode{
 				SimpleNode: &SimpleNode{
-					ID:        GetMockNodeId(1, spenum.Sharder),
+					ID:        data.Sharders[0],
 					PublicKey: "my public key",
 				},
 			}).Encode(),
@@ -409,7 +409,7 @@ func BenchmarkTests(
 				bytes, _ := json.Marshal(&stakepool.CollectRewardRequest{
 					//PoolId:       miner00,
 					ProviderType: spenum.Miner,
-					ProviderId:   GetMockNodeId(0, spenum.Miner),
+					ProviderId:   data.Miners[0],
 				})
 				return bytes
 			}(),

--- a/code/go/0chain.net/smartcontract/minersc/fees.go
+++ b/code/go/0chain.net/smartcontract/minersc/fees.go
@@ -369,7 +369,7 @@ func (msc *MinerSmartContract) payFees(t *transaction.Transaction,
 
 	// pay random N miners
 	if err := mn.StakePool.DistributeRewardsRandN(
-		moveValue, mn.ID, spenum.Miner, b.GetRoundRandomSeed(), 10, "fee", balances,
+		moveValue, mn.ID, spenum.Miner, b.GetRoundRandomSeed(), gn.NumMinerDelegatesRewarded, "fee", balances,
 	); err != nil {
 		return "", err
 	}
@@ -384,8 +384,10 @@ func (msc *MinerSmartContract) payFees(t *transaction.Transaction,
 
 	if len(sharders.Nodes) > 0 {
 		mbSharders := getRegisterShardersInMagicBlock(balances, sharders)
-		if err := msc.payShardersAndDelegates(mbSharders, sharderFees, sharderRewards,
-			5, b.GetRoundRandomSeed(), balances); err != nil {
+		if err := msc.payShardersAndDelegates(
+			gn, mbSharders, sharderFees, sharderRewards,
+			gn.NumShardersRewarded, b.GetRoundRandomSeed(), balances,
+		); err != nil {
 			return "", err
 		}
 	}
@@ -482,8 +484,13 @@ func (msc *MinerSmartContract) sumFee(b *block.Block,
 
 // pay fees and mint sharders
 func (msc *MinerSmartContract) payShardersAndDelegates(
-	sharders []*MinerNode, fee, mint currency.Coin, randN int, seed int64,
-	balances cstate.StateContextI) error {
+	gn *GlobalNode,
+	sharders []*MinerNode,
+	fee, mint currency.Coin,
+	randN int,
+	seed int64,
+	balances cstate.StateContextI,
+) error {
 	sn := len(sharders)
 	if sn <= 0 {
 		return errors.New("no sharders to pay")
@@ -538,7 +545,7 @@ func (msc *MinerSmartContract) payShardersAndDelegates(
 			return err
 		}
 		if err = sh.StakePool.DistributeRewardsRandN(
-			moveValue, sh.ID, spenum.Sharder, seed, 1, "pay sharders", balances,
+			moveValue, sh.ID, spenum.Sharder, seed, gn.NumSharderDelegatesRewarded, "pay sharders", balances,
 		); err != nil {
 			return common.NewErrorf("pay_fees/pay_sharders",
 				"distributing rewards: %v", err)

--- a/code/go/0chain.net/smartcontract/minersc/fees.go
+++ b/code/go/0chain.net/smartcontract/minersc/fees.go
@@ -369,7 +369,13 @@ func (msc *MinerSmartContract) payFees(t *transaction.Transaction,
 
 	// pay random N miners
 	if err := mn.StakePool.DistributeRewardsRandN(
-		moveValue, mn.ID, spenum.Miner, b.GetRoundRandomSeed(), gn.NumMinerDelegatesRewarded, "fee", balances,
+		moveValue,
+		mn.ID,
+		spenum.Miner,
+		b.GetRoundRandomSeed(),
+		gn.NumMinerDelegatesRewarded,
+		"fee",
+		balances,
 	); err != nil {
 		return "", err
 	}

--- a/code/go/0chain.net/smartcontract/minersc/fees2_test.go
+++ b/code/go/0chain.net/smartcontract/minersc/fees2_test.go
@@ -242,14 +242,17 @@ func testPayFees(t *testing.T, minerStakes []float64, sharderStakes [][]float64,
 
 	var globalNode = &GlobalNode{
 		//ViewChange:           runtime.nextViewChange,
-		LastRound:            runtime.lastRound,
-		RewardRate:           scYaml.rewardRate,
-		BlockReward:          zcnToBalance(scYaml.blockReward),
-		Epoch:                scYaml.epoch,
-		ShareRatio:           scYaml.shareRatio,
-		MaxMint:              zcnToBalance(scYaml.maxMint),
-		Minted:               runtime.minted,
-		RewardRoundFrequency: scYaml.rewardRoundPeriod,
+		LastRound:                   runtime.lastRound,
+		RewardRate:                  scYaml.rewardRate,
+		BlockReward:                 zcnToBalance(scYaml.blockReward),
+		Epoch:                       scYaml.epoch,
+		ShareRatio:                  scYaml.shareRatio,
+		MaxMint:                     zcnToBalance(scYaml.maxMint),
+		Minted:                      runtime.minted,
+		RewardRoundFrequency:        scYaml.rewardRoundPeriod,
+		NumShardersRewarded:         5,
+		NumSharderDelegatesRewarded: 1,
+		NumMinerDelegatesRewarded:   10,
 	}
 	var msc = &MinerSmartContract{
 		SmartContract: &sci.SmartContract{

--- a/code/go/0chain.net/smartcontract/minersc/helper_test.go
+++ b/code/go/0chain.net/smartcontract/minersc/helper_test.go
@@ -221,8 +221,11 @@ func setConfig(t *testing.T, balances cstate.StateContextI) (
 	gn.MaxS = 30
 	gn.MinS = 1
 	gn.MaxDelegates = 10 // for tests
-	gn.TPercent = 0.51   // %
-	gn.KPercent = 0.75   // %
+	gn.NumMinerDelegatesRewarded = 10
+	gn.NumShardersRewarded = 5
+	gn.NumSharderDelegatesRewarded = 1
+	gn.TPercent = 0.51 // %
+	gn.KPercent = 0.75 // %
 	gn.LastRound = 0
 	gn.MaxStake = currency.Coin(100.0e10)
 	gn.MinStake = currency.Coin(0.01e10)

--- a/code/go/0chain.net/smartcontract/minersc/models.go
+++ b/code/go/0chain.net/smartcontract/minersc/models.go
@@ -236,7 +236,12 @@ type GlobalNode struct {
 	RewardDeclineRate float64 `json:"reward_decline_rate"`
 	// MaxMint is minting boundary for SC.
 	MaxMint currency.Coin `json:"max_mint"`
-
+	// miner delegates to get paid each round when paying fees and rewards
+	NumMinerDelegatesRewarded int `json:"num_miner_delegates_rewarded"`
+	// sharders rewarded each round
+	NumShardersRewarded int `json:"num_sharders_rewarded"`
+	// sharder delegates to get paid each round when paying fees and rewards
+	NumSharderDelegatesRewarded int `json:"num_sharder_delegates_rewarded"`
 	// PrevMagicBlock keeps previous magic block to make Miner SC more stable.
 	// In case latestFinalizedMagicBlock of a miner works incorrect. We are
 	// using this previous MB or latestFinalizedMagicBlock for genesis block.
@@ -273,6 +278,9 @@ func (gn *GlobalNode) readConfig() (err error) {
 	gn.RewardRoundFrequency = config.SmartContractConfig.GetInt64(pfx + SettingName[RewardRoundFrequency])
 	gn.RewardRate = config.SmartContractConfig.GetFloat64(pfx + SettingName[RewardRate])
 	gn.ShareRatio = config.SmartContractConfig.GetFloat64(pfx + SettingName[ShareRatio])
+	gn.NumMinerDelegatesRewarded = config.SmartContractConfig.GetInt(pfx + SettingName[NumMinerDelegatesRewarded])
+	gn.NumShardersRewarded = config.SmartContractConfig.GetInt(pfx + SettingName[NumShardersRewarded])
+	gn.NumSharderDelegatesRewarded = config.SmartContractConfig.GetInt(pfx + SettingName[NumSharderDelegatesRewarded])
 	gn.BlockReward, err = currency.ParseZCN(config.SmartContractConfig.GetFloat64(pfx + SettingName[BlockReward]))
 	if err != nil {
 		return
@@ -309,6 +317,18 @@ func (gn *GlobalNode) validate() error {
 
 	if gn.MaxDelegates <= 0 {
 		return fmt.Errorf("max_delegates is too small: %d", gn.MaxDelegates)
+	}
+	if gn.NumSharderDelegatesRewarded < 0 {
+		return fmt.Errorf("%s cannot be negative: %d",
+			NumSharderDelegatesRewarded.String(), gn.NumSharderDelegatesRewarded)
+	}
+	if gn.NumMinerDelegatesRewarded < 0 {
+		return fmt.Errorf("%s cannot be negative: %d",
+			NumMinerDelegatesRewarded.String(), gn.NumMinerDelegatesRewarded)
+	}
+	if gn.NumShardersRewarded < 0 {
+		return fmt.Errorf("%s cannot be negative: %d",
+			NumShardersRewarded.String(), gn.NumShardersRewarded)
 	}
 	return nil
 }
@@ -368,6 +388,12 @@ func (gn *GlobalNode) Get(key Setting) (interface{}, error) {
 		return gn.RewardRoundFrequency, nil
 	case RewardRate:
 		return gn.RewardRate, nil
+	case NumMinerDelegatesRewarded:
+		return gn.NumMinerDelegatesRewarded, nil
+	case NumShardersRewarded:
+		return gn.NumShardersRewarded, nil
+	case NumSharderDelegatesRewarded:
+		return gn.NumSharderDelegatesRewarded, nil
 	case ShareRatio:
 		return gn.ShareRatio, nil
 	case BlockReward:

--- a/code/go/0chain.net/smartcontract/minersc/models_gen.go
+++ b/code/go/0chain.net/smartcontract/minersc/models_gen.go
@@ -308,9 +308,9 @@ func (z *DKGMinerNodes) Msgsize() (s int) {
 // MarshalMsg implements msgp.Marshaler
 func (z *GlobalNode) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 25
+	// map header, size 28
 	// string "ViewChange"
-	o = append(o, 0xde, 0x0, 0x19, 0xaa, 0x56, 0x69, 0x65, 0x77, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65)
+	o = append(o, 0xde, 0x0, 0x1c, 0xaa, 0x56, 0x69, 0x65, 0x77, 0x43, 0x68, 0x61, 0x6e, 0x67, 0x65)
 	o = msgp.AppendInt64(o, z.ViewChange)
 	// string "MaxN"
 	o = append(o, 0xa4, 0x4d, 0x61, 0x78, 0x4e)
@@ -382,6 +382,15 @@ func (z *GlobalNode) MarshalMsg(b []byte) (o []byte, err error) {
 		err = msgp.WrapError(err, "MaxMint")
 		return
 	}
+	// string "NumMinerDelegatesRewarded"
+	o = append(o, 0xb9, 0x4e, 0x75, 0x6d, 0x4d, 0x69, 0x6e, 0x65, 0x72, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x73, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x65, 0x64)
+	o = msgp.AppendInt(o, z.NumMinerDelegatesRewarded)
+	// string "NumShardersRewarded"
+	o = append(o, 0xb3, 0x4e, 0x75, 0x6d, 0x53, 0x68, 0x61, 0x72, 0x64, 0x65, 0x72, 0x73, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x65, 0x64)
+	o = msgp.AppendInt(o, z.NumShardersRewarded)
+	// string "NumSharderDelegatesRewarded"
+	o = append(o, 0xbb, 0x4e, 0x75, 0x6d, 0x53, 0x68, 0x61, 0x72, 0x64, 0x65, 0x72, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x73, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x65, 0x64)
+	o = msgp.AppendInt(o, z.NumSharderDelegatesRewarded)
 	// string "PrevMagicBlock"
 	o = append(o, 0xae, 0x50, 0x72, 0x65, 0x76, 0x4d, 0x61, 0x67, 0x69, 0x63, 0x42, 0x6c, 0x6f, 0x63, 0x6b)
 	if z.PrevMagicBlock == nil {
@@ -557,6 +566,24 @@ func (z *GlobalNode) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				err = msgp.WrapError(err, "MaxMint")
 				return
 			}
+		case "NumMinerDelegatesRewarded":
+			z.NumMinerDelegatesRewarded, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NumMinerDelegatesRewarded")
+				return
+			}
+		case "NumShardersRewarded":
+			z.NumShardersRewarded, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NumShardersRewarded")
+				return
+			}
+		case "NumSharderDelegatesRewarded":
+			z.NumSharderDelegatesRewarded, bts, err = msgp.ReadIntBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "NumSharderDelegatesRewarded")
+				return
+			}
 		case "PrevMagicBlock":
 			if msgp.IsNil(bts) {
 				bts, err = msgp.ReadNilBytes(bts)
@@ -642,7 +669,7 @@ func (z *GlobalNode) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *GlobalNode) Msgsize() (s int) {
-	s = 3 + 11 + msgp.Int64Size + 5 + msgp.IntSize + 5 + msgp.IntSize + 5 + msgp.IntSize + 5 + msgp.IntSize + 13 + msgp.IntSize + 9 + msgp.Float64Size + 9 + msgp.Float64Size + 9 + msgp.Float64Size + 10 + msgp.Int64Size + 9 + z.MaxStake.Msgsize() + 9 + z.MinStake.Msgsize() + 11 + msgp.Float64Size + 11 + msgp.Float64Size + 12 + z.BlockReward.Msgsize() + 10 + msgp.Float64Size + 6 + msgp.Int64Size + 18 + msgp.Float64Size + 8 + z.MaxMint.Msgsize() + 15
+	s = 3 + 11 + msgp.Int64Size + 5 + msgp.IntSize + 5 + msgp.IntSize + 5 + msgp.IntSize + 5 + msgp.IntSize + 13 + msgp.IntSize + 9 + msgp.Float64Size + 9 + msgp.Float64Size + 9 + msgp.Float64Size + 10 + msgp.Int64Size + 9 + z.MaxStake.Msgsize() + 9 + z.MinStake.Msgsize() + 11 + msgp.Float64Size + 11 + msgp.Float64Size + 12 + z.BlockReward.Msgsize() + 10 + msgp.Float64Size + 6 + msgp.Int64Size + 18 + msgp.Float64Size + 8 + z.MaxMint.Msgsize() + 26 + msgp.IntSize + 20 + msgp.IntSize + 28 + msgp.IntSize + 15
 	if z.PrevMagicBlock == nil {
 		s += msgp.NilSize
 	} else {

--- a/code/go/0chain.net/smartcontract/minersc/settings.go
+++ b/code/go/0chain.net/smartcontract/minersc/settings.go
@@ -153,7 +153,7 @@ func initSettings() {
 		Epoch.String():                       {Epoch, smartcontract.Int64},
 		RewardDeclineRate.String():           {RewardDeclineRate, smartcontract.Float64},
 		NumMinerDelegatesRewarded.String():   {NumMinerDelegatesRewarded, smartcontract.Int},
-		NumShardersRewarded.String():         {NumSharderDelegatesRewarded, smartcontract.Int},
+		NumShardersRewarded.String():         {NumShardersRewarded, smartcontract.Int},
 		NumSharderDelegatesRewarded.String(): {NumSharderDelegatesRewarded, smartcontract.Int},
 		MaxMint.String():                     {MaxMint, smartcontract.CurrencyCoin},
 		OwnerId.String():                     {OwnerId, smartcontract.Key},

--- a/code/go/0chain.net/smartcontract/minersc/settings.go
+++ b/code/go/0chain.net/smartcontract/minersc/settings.go
@@ -39,6 +39,9 @@ const (
 	MaxCharge
 	Epoch
 	RewardDeclineRate
+	NumMinerDelegatesRewarded
+	NumShardersRewarded
+	NumSharderDelegatesRewarded
 	MaxMint
 	OwnerId
 	CooldownPeriod
@@ -101,6 +104,9 @@ func initSettingName() {
 	SettingName[MaxCharge] = "max_charge"
 	SettingName[Epoch] = "epoch"
 	SettingName[RewardDeclineRate] = "reward_decline_rate"
+	SettingName[NumMinerDelegatesRewarded] = "num_miner_delegates_rewarded"
+	SettingName[NumShardersRewarded] = "num_sharders_rewarded"
+	SettingName[NumSharderDelegatesRewarded] = "num_sharder_delegates_rewarded"
 	SettingName[MaxMint] = "max_mint"
 	SettingName[OwnerId] = "owner_id"
 	SettingName[CooldownPeriod] = "cooldown_period"
@@ -129,44 +135,47 @@ func initSettings() {
 		Setting    Setting
 		ConfigType smartcontract.ConfigType
 	}{
-		MinStake.String():                   {MinStake, smartcontract.CurrencyCoin},
-		MaxStake.String():                   {MaxStake, smartcontract.CurrencyCoin},
-		MaxN.String():                       {MaxN, smartcontract.Int},
-		MinN.String():                       {MinN, smartcontract.Int},
-		TPercent.String():                   {TPercent, smartcontract.Float64},
-		KPercent.String():                   {KPercent, smartcontract.Float64},
-		XPercent.String():                   {XPercent, smartcontract.Float64},
-		MaxS.String():                       {MaxS, smartcontract.Int},
-		MinS.String():                       {MinS, smartcontract.Int},
-		MaxDelegates.String():               {MaxDelegates, smartcontract.Int},
-		RewardRoundFrequency.String():       {RewardRoundFrequency, smartcontract.Int64},
-		RewardRate.String():                 {RewardRate, smartcontract.Float64},
-		ShareRatio.String():                 {ShareRatio, smartcontract.Float64},
-		BlockReward.String():                {BlockReward, smartcontract.CurrencyCoin},
-		MaxCharge.String():                  {MaxCharge, smartcontract.Float64},
-		Epoch.String():                      {Epoch, smartcontract.Int64},
-		RewardDeclineRate.String():          {RewardDeclineRate, smartcontract.Float64},
-		MaxMint.String():                    {MaxMint, smartcontract.CurrencyCoin},
-		OwnerId.String():                    {OwnerId, smartcontract.Key},
-		CooldownPeriod.String():             {CooldownPeriod, smartcontract.Int64},
-		CostAddMiner.String():               {CostAddMiner, smartcontract.Cost},
-		CostAddSharder.String():             {CostAddSharder, smartcontract.Cost},
-		CostDeleteMiner.String():            {CostDeleteMiner, smartcontract.Cost},
-		CostMinerHealthCheck.String():       {CostMinerHealthCheck, smartcontract.Cost},
-		CostSharderHealthCheck.String():     {CostSharderHealthCheck, smartcontract.Cost},
-		CostContributeMpk.String():          {CostContributeMpk, smartcontract.Cost},
-		CostShareSignsOrShares.String():     {CostShareSignsOrShares, smartcontract.Cost},
-		CostWait.String():                   {CostWait, smartcontract.Cost},
-		CostUpdateGlobals.String():          {CostUpdateGlobals, smartcontract.Cost},
-		CostUpdateSettings.String():         {CostUpdateSettings, smartcontract.Cost},
-		CostUpdateMinerSettings.String():    {CostUpdateMinerSettings, smartcontract.Cost},
-		CostUpdateSharderSettings.String():  {CostUpdateSharderSettings, smartcontract.Cost},
-		CostPayFees.String():                {CostPayFees, smartcontract.Cost},
-		CostFeesPaid.String():               {CostFeesPaid, smartcontract.Cost},
-		CostMintedTokens.String():           {CostMintedTokens, smartcontract.Cost},
-		CostAddToDelegatePool.String():      {CostAddToDelegatePool, smartcontract.Cost},
-		CostDeleteFromDelegatePool.String(): {CostDeleteFromDelegatePool, smartcontract.Cost},
-		CostSharderKeep.String():            {CostSharderKeep, smartcontract.Cost},
+		MinStake.String():                    {MinStake, smartcontract.CurrencyCoin},
+		MaxStake.String():                    {MaxStake, smartcontract.CurrencyCoin},
+		MaxN.String():                        {MaxN, smartcontract.Int},
+		MinN.String():                        {MinN, smartcontract.Int},
+		TPercent.String():                    {TPercent, smartcontract.Float64},
+		KPercent.String():                    {KPercent, smartcontract.Float64},
+		XPercent.String():                    {XPercent, smartcontract.Float64},
+		MaxS.String():                        {MaxS, smartcontract.Int},
+		MinS.String():                        {MinS, smartcontract.Int},
+		MaxDelegates.String():                {MaxDelegates, smartcontract.Int},
+		RewardRoundFrequency.String():        {RewardRoundFrequency, smartcontract.Int64},
+		RewardRate.String():                  {RewardRate, smartcontract.Float64},
+		ShareRatio.String():                  {ShareRatio, smartcontract.Float64},
+		BlockReward.String():                 {BlockReward, smartcontract.CurrencyCoin},
+		MaxCharge.String():                   {MaxCharge, smartcontract.Float64},
+		Epoch.String():                       {Epoch, smartcontract.Int64},
+		RewardDeclineRate.String():           {RewardDeclineRate, smartcontract.Float64},
+		NumMinerDelegatesRewarded.String():   {NumMinerDelegatesRewarded, smartcontract.Int},
+		NumShardersRewarded.String():         {NumSharderDelegatesRewarded, smartcontract.Int},
+		NumSharderDelegatesRewarded.String(): {NumSharderDelegatesRewarded, smartcontract.Int},
+		MaxMint.String():                     {MaxMint, smartcontract.CurrencyCoin},
+		OwnerId.String():                     {OwnerId, smartcontract.Key},
+		CooldownPeriod.String():              {CooldownPeriod, smartcontract.Int64},
+		CostAddMiner.String():                {CostAddMiner, smartcontract.Cost},
+		CostAddSharder.String():              {CostAddSharder, smartcontract.Cost},
+		CostDeleteMiner.String():             {CostDeleteMiner, smartcontract.Cost},
+		CostMinerHealthCheck.String():        {CostMinerHealthCheck, smartcontract.Cost},
+		CostSharderHealthCheck.String():      {CostSharderHealthCheck, smartcontract.Cost},
+		CostContributeMpk.String():           {CostContributeMpk, smartcontract.Cost},
+		CostShareSignsOrShares.String():      {CostShareSignsOrShares, smartcontract.Cost},
+		CostWait.String():                    {CostWait, smartcontract.Cost},
+		CostUpdateGlobals.String():           {CostUpdateGlobals, smartcontract.Cost},
+		CostUpdateSettings.String():          {CostUpdateSettings, smartcontract.Cost},
+		CostUpdateMinerSettings.String():     {CostUpdateMinerSettings, smartcontract.Cost},
+		CostUpdateSharderSettings.String():   {CostUpdateSharderSettings, smartcontract.Cost},
+		CostPayFees.String():                 {CostPayFees, smartcontract.Cost},
+		CostFeesPaid.String():                {CostFeesPaid, smartcontract.Cost},
+		CostMintedTokens.String():            {CostMintedTokens, smartcontract.Cost},
+		CostAddToDelegatePool.String():       {CostAddToDelegatePool, smartcontract.Cost},
+		CostDeleteFromDelegatePool.String():  {CostDeleteFromDelegatePool, smartcontract.Cost},
+		CostSharderKeep.String():             {CostSharderKeep, smartcontract.Cost},
 	}
 }
 
@@ -182,6 +191,12 @@ func (gn *GlobalNode) setInt(key string, change int) error {
 		gn.MinS = change
 	case MaxDelegates:
 		gn.MaxDelegates = change
+	case NumMinerDelegatesRewarded:
+		gn.NumMinerDelegatesRewarded = change
+	case NumShardersRewarded:
+		gn.NumShardersRewarded = change
+	case NumSharderDelegatesRewarded:
+		gn.NumSharderDelegatesRewarded = change
 	default:
 		return fmt.Errorf("key: %v not implemented as int", key)
 	}

--- a/docker.local/config/benchmark.yaml
+++ b/docker.local/config/benchmark.yaml
@@ -71,7 +71,7 @@ smart_contracts:
     interest_rate: 0.0 # [0; 1)
     reward_rate: 1.0 # [0; 1)
     share_ratio: 0.8 # [0; 1)
-    block_reward: 0.2121 # tokens
+    block_reward: 0.21 # tokens
     max_charge: 0.5 # %
     epoch: 15000000 # rounds
     reward_decline_rate: 0.1 # [0; 1), 0.1 = 10%

--- a/docker.local/config/benchmark.yaml
+++ b/docker.local/config/benchmark.yaml
@@ -71,12 +71,17 @@ smart_contracts:
     interest_rate: 0.0 # [0; 1)
     reward_rate: 1.0 # [0; 1)
     share_ratio: 0.8 # [0; 1)
-    block_reward: 0.21 # tokens
+    block_reward: 0.2121 # tokens
     max_charge: 0.5 # %
     epoch: 15000000 # rounds
     reward_decline_rate: 0.1 # [0; 1), 0.1 = 10%
     interest_decline_rate: 0.1 # [0; 1), 0.1 = 10%
     max_mint: 1500000.0 # tokens
+    num_miner_delegates_rewarded: 10
+    # sharders rewarded each round
+    num_sharders_rewarded: 5
+    # sharder delegates to get paid each round when paying fees and rewards
+    num_sharder_delegates_rewarded: 1
 
   storagesc:
     owner_id: 1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802

--- a/docker.local/config/loadtest_benchmark.yaml
+++ b/docker.local/config/loadtest_benchmark.yaml
@@ -71,12 +71,17 @@ smart_contracts:
     interest_rate: 0.0 # [0; 1)
     reward_rate: 1.0 # [0; 1)
     share_ratio: 0.8 # [0; 1)
-    block_reward: 0.21 # tokens
+    block_reward: 0.2117 # tokens
     max_charge: 0.5 # %
     epoch: 15000000 # rounds
     reward_decline_rate: 0.1 # [0; 1), 0.1 = 10%
     interest_decline_rate: 0.1 # [0; 1), 0.1 = 10%
     max_mint: 1500000.0 # tokens
+    num_miner_delegates_rewarded: 10
+    # sharders rewarded each round
+    num_sharders_rewarded: 5
+    # sharder delegates to get paid each round when paying fees and rewards
+    num_sharder_delegates_rewarded: 1
 
   storagesc:
     owner_id: 1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802

--- a/docker.local/config/loadtest_benchmark.yaml
+++ b/docker.local/config/loadtest_benchmark.yaml
@@ -71,7 +71,7 @@ smart_contracts:
     interest_rate: 0.0 # [0; 1)
     reward_rate: 1.0 # [0; 1)
     share_ratio: 0.8 # [0; 1)
-    block_reward: 0.2117 # tokens
+    block_reward: 0.21 # tokens
     max_charge: 0.5 # %
     epoch: 15000000 # rounds
     reward_decline_rate: 0.1 # [0; 1), 0.1 = 10%

--- a/docker.local/config/sc.yaml
+++ b/docker.local/config/sc.yaml
@@ -55,7 +55,7 @@ smart_contracts:
     # gives 10% for miner and rest for block sharders
     share_ratio: 0.8 # [0; 1)
     # reward for a block
-    block_reward: 0.213 # tokens
+    block_reward: 0.21 # tokens
     # max service charge can be set by a generator
     max_charge: 0.5 # %
     # epoch is number of rounds before rewards and interest are decreased

--- a/docker.local/config/sc.yaml
+++ b/docker.local/config/sc.yaml
@@ -55,7 +55,7 @@ smart_contracts:
     # gives 10% for miner and rest for block sharders
     share_ratio: 0.8 # [0; 1)
     # reward for a block
-    block_reward: 0.21 # tokens
+    block_reward: 0.213 # tokens
     # max service charge can be set by a generator
     max_charge: 0.5 # %
     # epoch is number of rounds before rewards and interest are decreased
@@ -68,6 +68,12 @@ smart_contracts:
     max_mint: 1500000.0 # tokens
     # if view change is false then reward round frequency is used to send rewards and interests
     reward_round_frequency: 250
+    # miner delegates to get paid each round when paying fees and rewards
+    num_miner_delegates_rewarded: 10
+    # sharders rewarded each round
+    num_sharders_rewarded: 5
+    # sharder delegates to get paid each round when paying fees and rewards
+    num_sharder_delegates_rewarded: 1
     cooldown_period: 100
     cost:
       add_miner: 100

--- a/quickstart/1s_2m_4b/config/1s_2m_4b/0Chain/docker.local/config/sc.yaml
+++ b/quickstart/1s_2m_4b/config/1s_2m_4b/0Chain/docker.local/config/sc.yaml
@@ -43,7 +43,7 @@ smart_contracts:
     # gives 10% for miner and rest for block sharders
     share_ratio: 0.8 # [0; 1)
     # reward for a block
-    block_reward: 0.21 # tokens
+    block_reward: 0.2131 # tokens
     # max service charge can be set by a generator
     max_charge: 0.5 # %
     # epoch is number of rounds before rewards and interest are decreased
@@ -56,6 +56,11 @@ smart_contracts:
     max_mint: 4000000.0 # tokens
     # if view change is false then reward round frequency is used to send rewards and interests
     reward_round_frequency: 250
+    num_miner_delegates_rewarded: 10
+    # sharders rewarded each round
+    num_sharders_rewarded: 5
+    # sharder delegates to get paid each round when paying fees and rewards
+    num_sharder_delegates_rewarded: 1
 
   storagesc:
     owner_id: 1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802

--- a/quickstart/1s_2m_4b/config/1s_2m_4b/0Chain/docker.local/config/sc.yaml
+++ b/quickstart/1s_2m_4b/config/1s_2m_4b/0Chain/docker.local/config/sc.yaml
@@ -43,7 +43,7 @@ smart_contracts:
     # gives 10% for miner and rest for block sharders
     share_ratio: 0.8 # [0; 1)
     # reward for a block
-    block_reward: 0.2131 # tokens
+    block_reward: 0.21 # tokens
     # max service charge can be set by a generator
     max_charge: 0.5 # %
     # epoch is number of rounds before rewards and interest are decreased

--- a/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/config/sc.yaml
+++ b/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/config/sc.yaml
@@ -43,7 +43,7 @@ smart_contracts:
     # gives 10% for miner and rest for block sharders
     share_ratio: 0.8 # [0; 1)
     # reward for a block
-    block_reward: 0.21 # tokens
+    block_reward: 0.2111 # tokens
     # max service charge can be set by a generator
     max_charge: 0.5 # %
     # epoch is number of rounds before rewards and interest are decreased
@@ -56,6 +56,11 @@ smart_contracts:
     max_mint: 4000000.0 # tokens
     # if view change is false then reward round frequency is used to send rewards and interests
     reward_round_frequency: 250
+    num_miner_delegates_rewarded: 10
+    # sharders rewarded each round
+    num_sharders_rewarded: 5
+    # sharder delegates to get paid each round when paying fees and rewards
+    num_sharder_delegates_rewarded: 1
 
   storagesc:
     owner_id: 1746b06bb09f55ee01b33b5e2e055d6cc7a900cb57c0a3a5eaabb8a0e7745802

--- a/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/config/sc.yaml
+++ b/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/config/sc.yaml
@@ -43,7 +43,7 @@ smart_contracts:
     # gives 10% for miner and rest for block sharders
     share_ratio: 0.8 # [0; 1)
     # reward for a block
-    block_reward: 0.2111 # tokens
+    block_reward: 0.21 # tokens
     # max service charge can be set by a generator
     max_charge: 0.5 # %
     # epoch is number of rounds before rewards and interest are decreased


### PR DESCRIPTION
## Fixes
Fix panics in benchmark due to GlobalNode not being initiated.
Fix `payFees` not working. Link together node id and private key.
## Changes
Add new minersc settings `num_miner_delegates_rewarded`,  `num_sharders_rewarded` and `num_sharder_delegates_rewarded`.
## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
