### PR TITLE
Need to confirm it is needed. Order event processing by round

### DIFF
--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -377,7 +377,7 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 	c.SetLatestOwnFinalizedBlockRound(fb.Round)
 	c.SetLatestFinalizedBlock(fb)
 
-	if len(fb.Events) > 0 && c.GetEventDb() != nil {
+	if c.GetEventDb() != nil {
 		wg.Run("finalize block - add events", fb.Round, func() {
 			if err := c.GetEventDb().ProcessEvents(ctx, fb.Events, fb.Round, fb.Hash, len(fb.Txns)); err != nil {
 				logging.Logger.Error("finalize block - add events failed",

--- a/code/go/0chain.net/smartcontract/dbs/event/event_sorter.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/event_sorter.go
@@ -1,0 +1,79 @@
+package event
+
+import (
+	"github.com/0chain/common/core/logging"
+	"go.uber.org/zap"
+	"golang.org/x/net/context"
+)
+
+func (edb *EventDb) eventBlockController(_ context.Context) {
+	var (
+		currentRound   = int64(1)
+		partialBlocks  = make(map[int64]*blockEvents)
+		completeBlocks = make(map[int64]*blockEvents)
+	)
+	logging.Logger.Info("piers eventBlockController start")
+	for {
+		es := <-edb.blockEventChannel
+		logging.Logger.Info("piers eventBlockController just caught block",
+			zap.Int64("round", es.round))
+		block, foundPartial := partialBlocks[es.round]
+		//_, foundComplete := completeBlocks[es.round]
+		//logging.Logger.Info("piers eventBlockController",
+		//	zap.Int64("round", es.round),
+		//	zap.Bool("found partial", foundPartial),
+		//	zap.Bool("found complete", foundComplete),
+		//	zap.Int("len partial", len(partialBlocks)),
+		//	zap.Int("len complete", len(completeBlocks)),
+		//)
+
+		if es.round < currentRound {
+			logging.Logger.Error("piers events for previous round",
+				zap.Any("current round", currentRound),
+				zap.Any("out of order events", es),
+				zap.Int64("es round", es.round),
+				zap.Int64("current round", currentRound),
+			)
+			continue
+		}
+
+		if !foundPartial {
+			partialBlocks[es.round] = &es
+			//logging.Logger.Info("piers eventBlockController",
+			//	zap.Bool("foundPartial", foundPartial))
+			continue
+		}
+
+		block.events = append(block.events, es.events...)
+		delete(partialBlocks, es.round)
+
+		if es.round > currentRound {
+			completeBlocks[es.round] = block
+			//logging.Logger.Info("piers eventBlockController",
+			//	zap.Int64("es round", es.round),
+			//	zap.Int64("current round", currentRound))
+			continue
+		}
+
+		// We receive exactly two packets of events for each block
+		//select {
+		//case edb.blockEventChannel <- *block:
+		//}
+		//logging.Logger.Info("piers eventBlockController about to send",
+		//	zap.Int64("round", block.round))
+		edb.eventsChannel <- *block
+		//logging.Logger.Info("piers eventBlockController just sent",
+		//	zap.Int64("round", block.round))
+
+		currentRound++
+		//logging.Logger.Info("piers eventBlockController", zap.Int64("new round", currentRound))
+		for b, found := completeBlocks[currentRound]; found; currentRound++ {
+			logging.Logger.Info("piers eventBlockController in loop",
+				zap.Int64("current round", currentRound),
+				zap.Bool("found", found))
+			edb.eventsChannel <- *b
+			delete(completeBlocks, currentRound)
+		}
+		//logging.Logger.Info("piers eventBlockController end", zap.Int64("current round", currentRound))
+	}
+}

--- a/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
@@ -17,10 +17,12 @@ func NewEventDb(config config.DbAccess) (*EventDb, error) {
 		return nil, err
 	}
 	eventDb := &EventDb{
-		Store:         db,
-		eventsChannel: make(chan blockEvents, 1),
+		Store:             db,
+		eventsChannel:     make(chan blockEvents, 1),
+		blockEventChannel: make(chan blockEvents),
 	}
 	go eventDb.addEventsWorker(common.GetRootContext())
+	go eventDb.eventBlockController(common.GetRootContext())
 
 	if err := eventDb.AutoMigrate(); err != nil {
 		return nil, err
@@ -30,7 +32,8 @@ func NewEventDb(config config.DbAccess) (*EventDb, error) {
 
 type EventDb struct {
 	dbs.Store
-	eventsChannel chan blockEvents
+	eventsChannel     chan blockEvents
+	blockEventChannel chan blockEvents
 }
 
 type blockEvents struct {

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -91,9 +91,9 @@ func (edb *EventDb) ProcessEvents(ctx context.Context, events []Event, round int
 		blockSize: blockSize,
 		doneC:     make(chan struct{}, 1),
 	}
-
+	//logging.Logger.Info("piers ProcessEvents", zap.Int64("round", event.round))
 	select {
-	case edb.eventsChannel <- event:
+	case edb.blockEventChannel <- event:
 	case <-ctx.Done():
 		logging.Logger.Warn("process events - context done",
 			zap.Error(ctx.Err()),
@@ -206,6 +206,9 @@ func mergeEvents(round int64, block string, events []Event) ([]Event, error) {
 func (edb *EventDb) addEventsWorker(ctx context.Context) {
 	for {
 		es := <-edb.eventsChannel
+		logging.Logger.Info("piers addEventsWorker",
+			zap.Int64("round", es.round),
+		)
 		edb.addEvents(ctx, es)
 		tse := time.Now()
 		tags := make([]int, 0, len(es.events))


### PR DESCRIPTION
## Fixes
Prevents events from being processed out of order. It assumes that we always receive events in two packets.

It is not clear whether we need this. While events are processed out of order, they do it regularly:
```
n
n-4
n+1
n-3
n+2
n-2
n+3
n-1
n+4
n
```
So is it possible that we don't have to worry about conflicts ?

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
