### PR TITLE
Sharders should stop fetching absent blocks after blocks sync process is done

### DIFF
--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -107,7 +107,8 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 
 			endRound = lfbTk.Round + aheadN
 
-			if endRound <= cr {
+			if endRound <= cr || lfb.Round >= lfbTk.Round {
+				logging.Logger.Debug("process block, synced already, continue...")
 				continue
 			}
 
@@ -135,7 +136,6 @@ func (sc *Chain) BlockWorker(ctx context.Context) {
 			cr := sc.GetCurrentRound()
 			lfb := sc.GetLatestFinalizedBlock()
 			if b.Round > lfb.Round+aheadN {
-
 				// trigger sync process to pull the latest blocks when
 				// current round is > lfb.Round + aheadN to break the stuck if any.
 				if !syncing {


### PR DESCRIPTION
## Fixes

- resolve #1782 

## Changes

Avoid block fetching when block sync process is finished. Previously, it would do a blocks sync till a block could not be found every one minute, which is unnecessary and a waste of resources.  

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
