### PR TITLE
Fix panic on provider.String()

### DIFF
--- a/code/go/0chain.net/smartcontract/stakepool/spenum/enums.go
+++ b/code/go/0chain.net/smartcontract/stakepool/spenum/enums.go
@@ -15,6 +15,10 @@ const (
 var providerString = []string{"unknown", "miner", "sharder", "blobber", "validator", "authorizer"}
 
 func (p Provider) String() string {
+	if p < 0 || int(p) >= len(providerString) {
+		return "unknown"
+	}
+
 	return providerString[p]
 }
 


### PR DESCRIPTION
## Fixes

```
panic: runtime error: index out of range [12] with length 6

goroutine 46986061 [running]:
0chain.net/smartcontract/stakepool/spenum.Provider.String(0xc)
        /0chain/code/go/0chain.net/smartcontract/stakepool/spenum/enums.go:18 +0x5b
0chain.net/smartcontract/storagesc.stakePoolKey(0xc, {0xc00b10a640, 0x40})
        /0chain/code/go/0chain.net/smartcontract/storagesc/stakepool.go:70 +0x33
0chain.net/smartcontract/storagesc.getStakePool(0xc, {0xc00b10a640, 0x40}, {0x18f59e0, 0xc00d7e95f0})
        /0chain/code/go/0chain.net/smartcontract/storagesc/stakepool.go:357 +0x65
```

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
