### PR TITLE
Allow txns to go to pool when get 'node not found' error

### DIFF
--- a/code/go/0chain.net/chaincore/chain/handler.go
+++ b/code/go/0chain.net/chaincore/chain/handler.go
@@ -1371,7 +1371,9 @@ func PutTransaction(ctx context.Context, entity datastore.Entity) (interface{}, 
 
 	s, err := sc.GetStateById(sc.GetLatestFinalizedBlock().ClientState, txn.ClientID)
 	if !isValid(err) {
-		return nil, err
+		// put txn to pool if the miner has 'node not found', we should not ignore the txn because
+		// of the 'error' of the miner itself.
+		return transaction.PutTransaction(ctx, txn)
 	}
 	nonce := int64(0)
 	if s != nil {


### PR DESCRIPTION
## Fixes
- Miners should not ignore the txns for their own 'fault' (invalid state) when checking nonce. Which could lead to txns losing issue if all miner generators are in the 'invalid' state.

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
