### PR TITLE
Fix slow chain

### DIFF
--- a/code/go/0chain.net/miner/protocol_receive.go
+++ b/code/go/0chain.net/miner/protocol_receive.go
@@ -244,10 +244,6 @@ func (mc *Chain) processVerifyBlock(ctx context.Context, b *block.Block) error {
 	}
 
 	vts := mr.GetVerificationTickets(b.Hash)
-	if len(vts) == 0 {
-		mc.AddToRoundVerification(ctx, mr, b)
-		return nil
-	}
 
 	// TODO: mc.MergeVerificationTickets does not verify block's own tickets, might be a problem!
 	mc.MergeVerificationTickets(b, vts)

--- a/code/go/0chain.net/miner/round.go
+++ b/code/go/0chain.net/miner/round.go
@@ -110,13 +110,11 @@ func (v *vrfSharesCache) getAll() []*round.VRFShare {
 	return vrfShares
 }
 
-// clean deletes shares that has round time out count <= the 'count' value
-func (v *vrfSharesCache) clean(count int) {
+// clean deletes shares of given keys
+func (v *vrfSharesCache) clean(keys map[string]struct{}) {
 	v.mutex.Lock()
-	for s, vrf := range v.vrfShares {
-		if vrf.GetRoundTimeoutCount() <= count {
-			delete(v.vrfShares, s)
-		}
+	for k := range keys {
+		delete(v.vrfShares, k)
 	}
 	v.mutex.Unlock()
 }
@@ -241,7 +239,7 @@ func (r *Round) Clear() {
 	r.CancelVerification()
 }
 
-//IsVRFComplete - is the VRF process complete?
+// IsVRFComplete - is the VRF process complete?
 func (r *Round) IsVRFComplete() bool {
 	return r.HasRandomSeed()
 }

--- a/code/go/0chain.net/miner/round_test.go
+++ b/code/go/0chain.net/miner/round_test.go
@@ -78,41 +78,47 @@ func TestVRFSharesCacheGetAll(t *testing.T) {
 
 func TestVRFSharesCacheClean(t *testing.T) {
 	tt := []struct {
-		name            string
-		sharesNum       int
-		cleanBelowCount int
-		leftNum         int
+		name      string
+		sharesNum int
+		remove    []int
+		leftNum   int
 	}{
 		{
-			name:            "clean 0",
-			sharesNum:       3,
-			cleanBelowCount: -1,
-			leftNum:         3,
+			name:      "clean 0",
+			sharesNum: 3,
+			//cleanBelowCount: -1,
+			remove:  []int{-1},
+			leftNum: 3,
 		},
 		{
-			name:            "clean 1",
-			sharesNum:       3,
-			cleanBelowCount: 0,
-			leftNum:         2,
+			name:      "clean 1",
+			sharesNum: 3,
+			remove:    []int{0},
+			leftNum:   2,
 		},
 		{
-			name:            "clean 2",
-			sharesNum:       3,
-			cleanBelowCount: 1,
-			leftNum:         1,
+			name:      "clean 2",
+			sharesNum: 3,
+			remove:    []int{0, 1},
+			leftNum:   1,
 		},
 		{
-			name:            "clean 3",
-			sharesNum:       3,
-			cleanBelowCount: 3,
-			leftNum:         0,
+			name:      "clean 3",
+			sharesNum: 3,
+			remove:    []int{0, 1, 2},
+			leftNum:   0,
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(fmt.Sprintf("%s %d_%d", tc.name, tc.sharesNum, tc.leftNum), func(t *testing.T) {
 			vrfc := setupVRFSharesCache(t, tc.sharesNum)
-			vrfc.clean(tc.cleanBelowCount)
+
+			rms := make(map[string]struct{}, len(tc.remove))
+			for _, i := range tc.remove {
+				rms[fmt.Sprintf("share%d", i)] = struct{}{}
+			}
+			vrfc.clean(rms)
 
 			require.Len(t, vrfc.getAll(), tc.leftNum)
 		})


### PR DESCRIPTION
## Fixes
- Fix chain moves slow on large network issue, it was slow because some of the VRF shares were removed mistakenly by the `VRF share cache.clean` function.

## Changes
- Remove VRF shares from cache for those successfully added ones only so that new added one would not be removed.

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
