### PR TITLE
Add script to configure network for ubuntu wsl hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Run powershell as administrator
 ```powershell
 ./windows_network.sh
 ```
+#### Ubuntu/WSL2
+Run the following script
+```bash
+./wsl_ubuntu_network_iptables.sh
+```
 ### Directory Setup for Miners and Sharders
 
 In the git/0chain run the following command

--- a/wsl_ubuntu_network_iptables.sh
+++ b/wsl_ubuntu_network_iptables.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+NETWORK="198.18.0.0/15"
+
+if [ "$(command -v iptables)" ]; then
+    sudo iptables -t nat -I OUTPUT --dst "$NETWORK" -p tcp -j REDIRECT
+    echo "$(tput setaf 2)""[SUCCESS]""$(tput sgr0)" "NAT entries updated successfully for network $NETWORK. Run iptables -t nat -L OUTPUT to make sure it exists"
+    exit 0
+fi
+
+echo "$(tput setaf 1)""[FAILURE]""$(tput sgr0)" "\"iptables\" should be installed first to run this script."
+exit 1


### PR DESCRIPTION
## Fixes
- `zbox` and `zwallet` commands cannot resolve addresses when run on Ubuntu/WSL hosts that use docker to host run the network.

## Changes
- Added script to configure network in Ubuntu/WSL.
- Refered to it in README
## Need to be mentioned in CHANGELOG.md?
No idea.

## Tests
Tasks to complete before merging PR:
- [x]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [x]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
