### PR TITLE
reset magic block in each conductor test

### DIFF
--- a/code/go/0chain.net/conductor/conductor/main.go
+++ b/code/go/0chain.net/conductor/conductor/main.go
@@ -905,7 +905,7 @@ func (r *Runner) Run() (err error, success bool) {
 
 	cases:
 		for i, testCase := range r.conf.TestsOfSet(&set) {
-			r.SetMagicBlock("")
+			_ = r.SetMagicBlock("")
 			r.conf.CleanupEnv()
 			var report reportTestCase
 			report.name = testCase.Name

--- a/code/go/0chain.net/conductor/conductor/main.go
+++ b/code/go/0chain.net/conductor/conductor/main.go
@@ -905,6 +905,7 @@ func (r *Runner) Run() (err error, success bool) {
 
 	cases:
 		for i, testCase := range r.conf.TestsOfSet(&set) {
+			r.SetMagicBlock("")
 			r.conf.CleanupEnv()
 			var report reportTestCase
 			report.name = testCase.Name

--- a/docker.local/config/conductor.miners.yaml
+++ b/docker.local/config/conductor.miners.yaml
@@ -75,6 +75,7 @@ tests:
           must_fail: true
   - name: "Lock notarization and spam next round VRF"
     flow:
+      - magic_block_config: config/b0magicBlock_4_miners_2_sharders.json
       - set_monitor: "sharder-1"
       - cleanup_bc: {}
       - start: ["sharder-1"]


### PR DESCRIPTION
## Fixes

* Using the `magic_block_config` directive was influencing the magic block used in each test case. The fix resets the magic block in each test iteration.

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
