### PR TITLE
uncomment blobber downloading conductor test

### DIFF
--- a/docker.local/config/conductor.blobber-3.yaml
+++ b/docker.local/config/conductor.blobber-3.yaml
@@ -13,8 +13,7 @@ sets:
     - "Not respond to the client on uploading file"
     - "Not respond to the client on deleting file"
     - "Return error to the client on listing file"
-    # next test must be uncommented after https://github.com/0chain/blobber/issues/810 has been resolved
-    # - "Return error to the client on downloading file"
+    - "Return error to the client on downloading file"
     - "Return error to the client on uploading file"
     - "Return error to the client on deleting file"
 


### PR DESCRIPTION
https://github.com/0chain/0chain/issues/1651

## Changes

- Uncomment blobber conductor test "Return error to the client on downloading file".

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
