### PR TITLE
Allow update existing stake pool when at max delegates

### DIFF
--- a/code/go/0chain.net/smartcontract/minersc/delegate_pools.go
+++ b/code/go/0chain.net/smartcontract/minersc/delegate_pools.go
@@ -41,7 +41,7 @@ func (msc *MinerSmartContract) addToDelegatePool(t *transaction.Transaction,
 			"max delegates already reached: %d (%d)", numDelegates, mn.Settings.MaxNumDelegates)
 	}
 
-	if numDelegates >= gn.MaxDelegates {
+	if numDelegates >= gn.MaxDelegates && !mn.HasStakePool(t.ClientID) {
 		return "", common.NewErrorf("delegate_pool_add",
 			"SC max delegates already reached: %d (%d)", numDelegates, gn.MaxDelegates)
 	}

--- a/code/go/0chain.net/smartcontract/stakepool/stakepool.go
+++ b/code/go/0chain.net/smartcontract/stakepool/stakepool.go
@@ -81,16 +81,9 @@ func (sp *StakePool) OrderedPoolIds() []string {
 	return ids
 }
 
-func GetStakePool(
-	p spenum.Provider, id string, balances cstate.StateContextI,
-) (*StakePool, error) {
-	var sp = NewStakePool()
-	err := balances.GetTrieNode(stakePoolKey(p, id), sp)
-	if err != nil {
-		return nil, err
-	}
-
-	return sp, nil
+func (sp *StakePool) HasStakePool(user string) bool {
+	_, found := sp.Pools[user]
+	return found
 }
 
 func (sp *StakePool) Save(

--- a/code/go/0chain.net/smartcontract/storagesc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/stakepool.go
@@ -446,7 +446,7 @@ func (ssc *StorageSmartContract) stakePoolLock(t *transaction.Transaction,
 		return "", err
 	}
 
-	if len(sp.Pools) >= conf.MaxDelegates {
+	if len(sp.Pools) >= conf.MaxDelegates && !sp.HasStakePool(t.ClientID) {
 		return "", common.NewErrorf("stake_pool_lock_failed",
 			"max_delegates reached: %v, no more stake pools allowed",
 			conf.MaxDelegates)

--- a/code/go/0chain.net/smartcontract/zcnsc/stakepool.go
+++ b/code/go/0chain.net/smartcontract/zcnsc/stakepool.go
@@ -221,7 +221,7 @@ func (zcn *ZCNSmartContract) AddToDelegatePool(
 		return "", common.NewErrorf(code, "can't get stake pool: %v", err)
 	}
 
-	if len(sp.Pools) >= gn.MaxDelegates {
+	if len(sp.Pools) >= gn.MaxDelegates && !sp.HasStakePool(t.ClientID) {
 		return "", common.NewErrorf(code, "max_delegates reached: %v, no more stake pools allowed", gn.MaxDelegates)
 	}
 


### PR DESCRIPTION
## Fixes
Allows a delegate to lock tokens to an existing pool, when the stake pool has the maximum number of delegates.
Removes some dead code.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
