### PR TITLE
Benchmark Init rate limit

### DIFF
--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/options.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/options.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"0chain.net/core/common"
+
 	bk "0chain.net/smartcontract/benchmark"
 	"github.com/spf13/viper"
 
@@ -39,6 +41,7 @@ func getTestSuites(
 		}
 		return suites
 	}
+	common.ConfigRateLimits()
 	for _, name := range bkNames {
 		if code, ok := bk.SourceCode[name]; ok {
 			suite := benchmarkSources[code](data, &BLS0ChainScheme{})

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/options.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/options.go
@@ -41,7 +41,9 @@ func getTestSuites(
 		}
 		return suites
 	}
+
 	common.ConfigRateLimits()
+
 	for _, name := range bkNames {
 		if code, ok := bk.SourceCode[name]; ok {
 			suite := benchmarkSources[code](data, &BLS0ChainScheme{})

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_rest_tests.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_rest_tests.go
@@ -33,7 +33,6 @@ func BenchmarkRestTests(
 	if err != nil {
 		panic(err)
 	}
-	common.ConfigRateLimits()
 	return bk.GetRestTests(
 		[]bk.TestParameters{
 			{


### PR DESCRIPTION
## Fixes
[ratelimt](https://github.com/0chain/0chain/blob/staging/code/go/0chain.net/core/common/rate_limiter.go#L19) was only being initilsed for `storagesc_rest`, leading to a panic if this suite was omitted. Fixed.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
