### PR TITLE
Remove transaction_id overwriting

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -418,8 +418,6 @@ func (edb *EventDb) addStat(event Event) (err error) {
 
 		for i := range *rms {
 			(*rms)[i].BlockNumber = event.BlockNumber
-			(*rms)[i].TransactionID = event.TxHash
-
 		}
 		return edb.addOrOverwriteReadMarker(*rms)
 	case TagAddOrOverwriteUser:


### PR DESCRIPTION
## Fixes
- ReadMarkers overwrite each other in sharder's event db
## Changes
- Remove overwriting transaction_id which leads to leaving it empty for all RMs where it's used as a conflict column.
## Need to be mentioned in CHANGELOG.md?
idk
## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
