### PR TITLE
Fix chain slow on chaos and round timeout

### DIFF
--- a/code/go/0chain.net/miner/protocol.go
+++ b/code/go/0chain.net/miner/protocol.go
@@ -1,8 +1,9 @@
 package miner
 
 import (
-	"0chain.net/core/datastore"
 	"context"
+
+	"0chain.net/core/datastore"
 
 	"0chain.net/chaincore/chain"
 
@@ -10,7 +11,7 @@ import (
 	"0chain.net/chaincore/round"
 )
 
-//ProtocolRoundRandomBeacon - an interface for the round random beacon
+// ProtocolRoundRandomBeacon - an interface for the round random beacon
 type ProtocolRoundRandomBeacon interface {
 	AddVRFShare(ctx context.Context, r *Round, vrfs *round.VRFShare) bool
 }
@@ -51,7 +52,7 @@ type ProtocolRound interface {
 
 /*ProtocolBlock - this is the interface that deals with the block level logic of the protocol */
 type ProtocolBlock interface {
-	GenerateBlock(ctx context.Context, b *block.Block, bsh chain.BlockStateHandler, waitOver bool) error
+	GenerateBlock(ctx context.Context, b *block.Block, waitOver bool, waitC chan struct{}) error
 	ValidateMagicBlock(context.Context, *round.Round, *block.Block) bool
 	VerifyBlock(ctx context.Context, b *block.Block) (*block.BlockVerificationTicket, error)
 

--- a/code/go/0chain.net/miner/protocol_block_main.go
+++ b/code/go/0chain.net/miner/protocol_block_main.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"0chain.net/chaincore/block"
-	"0chain.net/chaincore/chain"
 	"0chain.net/chaincore/node"
 )
 
@@ -32,8 +31,11 @@ func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
 	go mc.updateFinalizedBlock(ctx, b)
 }
 
-func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block, _ chain.BlockStateHandler, waitOver bool) error {
+func (mc *Chain) GenerateBlock(ctx context.Context,
+	b *block.Block,
+	waitOver bool,
+	waitC chan struct{}) error {
 	return mc.generateBlockWorker.Run(ctx, func() error {
-		return mc.generateBlock(ctx, b, minerChain, waitOver)
+		return mc.generateBlock(ctx, b, minerChain, waitOver, waitC)
 	})
 }

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -473,7 +473,7 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 		//b.SetStateDB(pb, mc.GetStateDB())
 
 		if err := mc.syncAndRetry(cctx, b, "generate block", func(ctx context.Context, waitC chan struct{}) error {
-			return mc.GenerateBlock(ctx, b, mc, makeBlock)
+			return mc.GenerateBlock(ctx, b, makeBlock, waitC)
 		}); err != nil {
 			cerr, ok := err.(*common.Error)
 			if ok {

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -308,7 +308,7 @@ func (mc *Chain) TryProposeBlock(ctx context.Context, mr *Round) {
 	// though rest of the network is. That's why this is a goroutine.
 	go func() {
 		if _, err := mc.GenerateRoundBlock(ctx, mr); err != nil {
-			logging.Logger.Warn("generate round block failed", zap.Error(err))
+			logging.Logger.Error("generate round block failed", zap.Error(err))
 		}
 	}()
 }
@@ -472,8 +472,9 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 
 		//b.SetStateDB(pb, mc.GetStateDB())
 
-		err := mc.GenerateBlock(cctx, b, mc, makeBlock)
-		if err != nil {
+		if err := mc.syncAndRetry(cctx, b, "generate block", func(ctx context.Context, waitC chan struct{}) error {
+			return mc.GenerateBlock(ctx, b, mc, makeBlock)
+		}); err != nil {
 			cerr, ok := err.(*common.Error)
 			if ok {
 				switch cerr.Code {


### PR DESCRIPTION
## Fixes
- Chain would stuck for a while till round timeout occurs on small network (3 miners and 3 sharders) when chaos is enabled. This happens when one of the generator is down, and the alive generator have 'node not found' error. We did quick node states syncing for block verification before, but didn't do it for block generation process. So when this happens, we will have to wait for the round restart to re-generate the block. The fix is simply do the quick state syncing and retry just like we did for the block verification.
- Fix VRF tickets cache related slow consensus issue. See details in commit description in [47826](https://github.com/0chain/0chain/pull/1890/commits/47826062e6e90b20c5c64ef0e6fe1370724b2ab4)

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
