### PR TITLE
fix generateBlock in integration tests

### DIFF
--- a/.github/workflows/build-integration-tests-images.yml
+++ b/.github/workflows/build-integration-tests-images.yml
@@ -12,44 +12,29 @@ jobs:
     runs-on: [self-hosted, arc-runner]
 
     steps:
-    - name: Go 1.18 setup.
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.18'
-
-    - name: Docker Compose Setup.
-      run: |
-        sudo curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-        sudo chmod +x /usr/local/bin/docker-compose
-        docker-compose --version
-
-    - name: Git clone 0chain
-      run: |
-        git clone https://github.com/0chain/0chain.git
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.18'
 
     - name: Docker Init Setup.
       run: |
-        cd 0chain
         make install-mockery
         make build-mocks
         bash ./docker.local/bin/init.setup.sh
 
     - name: Docker Network Setup.
       run: |
-        cd 0chain
         bash ./docker.local/bin/setup.network.sh || true
 
     - name: Building Base Images
       run: |
-        cd 0chain
         bash ./docker.local/bin/build.base.sh
 
     - name: Build Miner Docker Image For Integration Test.
       run: |
-        cd 0chain
         bash ./docker.local/bin/build.miners-integration-tests.sh
 
     - name: Build Sharder Docker Image For Integration Test.
       run: |
-        cd 0chain
         bash ./docker.local/bin/build.sharders-integration-tests.sh

--- a/.github/workflows/build-integration-tests-images.yml
+++ b/.github/workflows/build-integration-tests-images.yml
@@ -1,0 +1,55 @@
+name: Build integration images
+
+on:
+  push:
+    branches: [ master,staging ]
+    tags: [ "v*.*.*" ]
+  pull_request:
+
+jobs:
+  BUILD_INTEGRATION_IMAGES:
+    name: BUILD-INTEGRATION-IMAGES
+    runs-on: [self-hosted, arc-runner]
+
+    steps:
+    - name: Go 1.18 setup.
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.18'
+
+    - name: Docker Compose Setup.
+      run: |
+        sudo curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+        sudo chmod +x /usr/local/bin/docker-compose
+        docker-compose --version
+
+    - name: Git clone 0chain
+      run: |
+        git clone https://github.com/0chain/0chain.git
+
+    - name: Docker Init Setup.
+      run: |
+        cd 0chain
+        make install-mockery
+        make build-mocks
+        bash ./docker.local/bin/init.setup.sh
+
+    - name: Docker Network Setup.
+      run: |
+        cd 0chain
+        bash ./docker.local/bin/setup.network.sh || true
+
+    - name: Building Base Images
+      run: |
+        cd 0chain
+        bash ./docker.local/bin/build.base.sh
+
+    - name: Build Miner Docker Image For Integration Test.
+      run: |
+        cd 0chain
+        bash ./docker.local/bin/build.miners-integration-tests.sh
+
+    - name: Build Sharder Docker Image For Integration Test.
+      run: |
+        cd 0chain
+        bash ./docker.local/bin/build.sharders-integration-tests.sh

--- a/.github/workflows/build-integration-tests-images.yml
+++ b/.github/workflows/build-integration-tests-images.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: [self-hosted, arc-runner]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.18'
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.18'
 
     - name: Docker Init Setup.
       run: |

--- a/code/go/0chain.net/miner/protocol_block_integration_tests.go
+++ b/code/go/0chain.net/miner/protocol_block_integration_tests.go
@@ -193,13 +193,13 @@ func isTestingOnUpdateFinalizedBlock(round int64, s *crpc.State) bool {
 	return isTestingFunc(round, nodeType == generator, typeRank)
 }
 
-func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block, _ chain.BlockStateHandler, waitOver bool) error {
+func (mc *Chain) GenerateBlock(ctx context.Context, b *block.Block, waitOver bool, waitC chan struct{}) error {
 	if isIgnoringGenerateBlock(b.Round) {
 		return nil
 	}
 
 	return mc.generateBlockWorker.Run(ctx, func() error {
-		return mc.generateBlock(ctx, b, minerChain, waitOver)
+		return mc.generateBlock(ctx, b, minerChain, waitOver, waitC)
 	})
 }
 


### PR DESCRIPTION
## Fixes

* Fix generateBlock usage in integration tests
* Add github action to build integration images. This allows the detection of early bugs on conductor tests originated by changing the main miner/sharder code.

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
