### PR TITLE
Access event database round

### DIFF
--- a/code/go/0chain.net/sharder/sharder/swagger.md
+++ b/code/go/0chain.net/sharder/sharder/swagger.md
@@ -5081,6 +5081,8 @@ and the other for the allocations that the client (client_id) doesn't own
 |------|------|---------|:--------:| ------- |-------------|---------|
 | Rounds | []int64 (formatted integer)| `[]int64` |  | |  |  |
 
+
+
 ### <span id="user-locked-total-response"></span> userLockedTotalResponse
 
 
@@ -5093,3 +5095,5 @@ and the other for the allocations that the client (client_id) doesn't own
 | Name | Type | Go type | Required | Default | Description | Example |
 |------|------|---------|:--------:| ------- |-------------|---------|
 | Total | int64 (formatted integer)| `int64` |  | |  |  |
+
+

--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
@@ -571,7 +571,7 @@ func newEventsDb() *event.EventDb {
 	timer := time.Now()
 	var eventDb *event.EventDb
 	tick := func() (*event.EventDb, error) {
-		return event.NewEventDb(
+		edb, err := event.NewEventDb(
 			config.DbAccess{
 				Enabled:         viper.GetBool(benchmark.EventDbEnabled),
 				Name:            viper.GetString(benchmark.EventDbName),
@@ -589,7 +589,11 @@ func newEventsDb() *event.EventDb {
 				PageLimit:       viper.GetInt64(benchmark.EventDbPageLimit),
 			},
 		)
-
+		if err != nil {
+			return nil, err
+		}
+		edb.SetRound(viper.GetInt64(benchmark.NumBlocks))
+		return edb, err
 	}
 
 	t := time.NewTicker(time.Second)

--- a/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
@@ -65,6 +65,11 @@ func (edb *EventDb) GetRound() int64 {
 	return edb.lastRound
 }
 
+// SetRound To use in tests and benchmarks
+func (edb *EventDb) SetRound(round int64) {
+	edb.lastRound = round
+}
+
 func (edb *EventDb) CommitTx(tx *EventDb, round int64) {
 	edb.mutex.Lock()
 	defer edb.mutex.Unlock()

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -198,12 +198,7 @@ func (edb *EventDb) addEventsWorker(ctx context.Context) {
 			}
 		}
 
-		if err := tx.Commit(); err != nil {
-			logging.Logger.Error("error committing block events",
-				zap.Int64("block", es.round),
-				zap.Error(err),
-			)
-		}
+		edb.CommitTx(tx, es.round)
 
 		due := time.Since(tse)
 		logging.Logger.Debug("event db process",


### PR DESCRIPTION
## Fixes
When querying information from the event database, we should get the current round from the event database, not the blockchain, as there is no reason they need by in perfect sync.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
