### PR TITLE
Fix benchmark panic in addMiner

### DIFF
--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
@@ -75,8 +75,11 @@ func getBalances(
 	bk.MinerID = data.Miners[0]
 	node.Self.Underlying().SetKey(data.Miners[0])
 	magicBlock := &block.MagicBlock{
+		Miners:   node.NewPool(node.NodeTypeMiner),
 		Sharders: node.NewPool(node.NodeTypeSharder),
 	}
+	magicBlock.Miners.NodesMap = make(map[string]*node.Node)
+	magicBlock.Miners.NodesMap[encryption.Hash("magic_block_miner_1")] = &node.Node{}
 	for i := range data.Sharders {
 		var n = node.Provider()
 		if err := n.SetID(data.Sharders[i]); err != nil {

--- a/code/go/0chain.net/smartcontract/minersc/benchmark_tests.go
+++ b/code/go/0chain.net/smartcontract/minersc/benchmark_tests.go
@@ -102,7 +102,7 @@ func BenchmarkTests(
 			txn:      &transaction.Transaction{CreationDate: creationTime},
 			input: (&MinerNode{
 				SimpleNode: &SimpleNode{
-					ID:        encryption.Hash("my new miner"),
+					ID:        encryption.Hash("magic_block_miner_1"),
 					PublicKey: "miner's public key",
 					N2NHost:   "new n2n_host",
 					Host:      "new host",

--- a/code/go/0chain.net/smartcontract/minersc/miner.go
+++ b/code/go/0chain.net/smartcontract/minersc/miner.go
@@ -48,13 +48,15 @@ func (msc *MinerSmartContract) AddMiner(t *transaction.Transaction,
 	defer lockAllMiners.Unlock()
 
 	magicBlockMiners := balances.GetChainCurrentMagicBlock().Miners
-	
+	if magicBlockMiners == nil {
+		return "", common.NewError("add_miner", "magic block miners nil")
+	}
+
 	if !magicBlockMiners.HasNode(newMiner.ID) {
 		logging.Logger.Error("add_miner: Error in Adding a new miner: Not in magic block")
 		return "", common.NewErrorf("add_miner",
 			"failed to add new miner: Not in magic block")
 	}
-	
 
 	logging.Logger.Info("add_miner: try to add miner", zap.Any("txn", t))
 


### PR DESCRIPTION
## Fixes
The problem is that [this](https://github.com/0chain/0chain/blob/staging/code/go/0chain.net/smartcontract/minersc/miner.go#L52) code fragment crashes the benchmark.
```go
        magicBlockMiners := balances.GetChainCurrentMagicBlock().Miners

	if !magicBlockMiners.HasNode(newMiner.ID) {
		logging.Logger.Error("add_miner: Error in Adding a new miner: Not in magic block")
		return "", common.NewErrorf("add_miner",
			"failed to add new miner: Not in magic block")
	}
```

Minimal changes to fix panic in the benchmark. Add a miner to the magic block so that it can be added. Also added a `magicBlockMiners == nil` check, although this should always pass in an active 0chain.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
