### PR TITLE
removing timestamp to rounds route as it's moved to 0box

### DIFF
--- a/code/go/0chain.net/chaincore/smartcontract/handler_test.go
+++ b/code/go/0chain.net/chaincore/smartcontract/handler_test.go
@@ -132,7 +132,7 @@ func TestGetSmartContract(t *testing.T) {
 		{
 			name:       "storage",
 			address:    storagesc.ADDRESS,
-			restpoints: 46,
+			restpoints: 45,
 		},
 		{
 			name:       "multisig",

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -96,7 +96,6 @@ func GetEndpoints(rh rest.RestHandlerI) []rest.Endpoint {
 		rest.MakeEndpoint(storage+"/alloc-blobber-term", common.UserRateLimit(srh.getAllocBlobberTerms)),
 		rest.MakeEndpoint(storage+"/replicate-snapshots", common.UserRateLimit(srh.replicateSnapshots)),
 		rest.MakeEndpoint(storage+"/replicate-blobber-aggregates", srh.replicateBlobberAggregates),
-		rest.MakeEndpoint(storage+"/timestamp-to-round", common.UserRateLimit(srh.timestampsToRounds)),
 	}
 }
 
@@ -898,7 +897,7 @@ func (srh *StorageRestHandler) getConfig(w http.ResponseWriter, r *http.Request)
 // swagger:route GET /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/total-stored-data total-stored-data
 // Gets the total data currently storage used across all blobbers.
 //
-// This endpoint returns the summation of all the Size fields in all the WriteMarkers sent to 0chain by blobbers
+// # This endpoint returns the summation of all the Size fields in all the WriteMarkers sent to 0chain by blobbers
 //
 // responses:
 //
@@ -2821,64 +2820,6 @@ func (srh *StorageRestHandler) getBlobber(w http.ResponseWriter, r *http.Request
 
 	sn := blobberTableToStorageNode(*blobber)
 	common.Respond(w, r, sn, nil)
-}
-
-// swagger:model timestampToRoundResp
-type timestampToRoundResp struct {
-	Rounds []int64 `json:"rounds"`
-}
-
-// swagger:route GET /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/timestamp-to-round timestampsToRounds
-// Get round(s) number for timestamp(s)
-//
-// parameters:
-//
-//	 +name: timestamps
-//		 description: timestamps you want to convert to rounds
-//		 required: true
-//		 in: query
-//		 type: string
-//
-// responses:
-//
-//	200: timestampToRoundResp
-//	400:
-//	500:
-func (srh *StorageRestHandler) timestampsToRounds(w http.ResponseWriter, r *http.Request) {
-	var timestamps = r.URL.Query().Get("timestamps")
-
-	if timestamps == "" {
-		err := common.NewErrBadRequest("missing query parameter: timestamps")
-		common.Respond(w, r, nil, err)
-		return
-	}
-
-	edb := srh.GetQueryStateContext().GetEventDB()
-	if edb == nil {
-		common.Respond(w, r, nil, common.NewErrInternal("no db connection"))
-		return
-	}
-
-	var timeStamps []int64
-	if err := json.Unmarshal([]byte(timestamps), &timeStamps); err != nil {
-		common.Respond(w, r, nil, common.NewErrBadRequest("timestamps are not valid"))
-		return
-	}
-	var rounds []int64
-	for _, timestamp := range timeStamps {
-		round, err := edb.GetRoundFromTime(time.Unix(timestamp, 0), true)
-		if err != nil {
-			err := common.NewErrNoResource(err.Error())
-			common.Respond(w, r, nil, err)
-			return
-		}
-		rounds = append(rounds, round)
-	}
-
-	common.Respond(w, r, timestampToRoundResp{
-		Rounds: rounds,
-	}, nil)
-	return
 }
 
 // swagger:route GET /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/alloc-blobber-term getAllocBlobberTerms


### PR DESCRIPTION
## Fixes

removing timestamp to rounds route as it's moved to 0box

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
