### PR TITLE
Fix inconsistent max_stake values

### DIFF
--- a/code/go/0chain.net/miner/testdata/config/sc.yaml
+++ b/code/go/0chain.net/miner/testdata/config/sc.yaml
@@ -41,7 +41,7 @@ smart_contracts:
     x_percent: 0.70 # percentage of prev mb miners required to be part of next mb
     # etc
     min_stake: 0.0 # min stake can be set by a node (boundary for all nodes)
-    max_stake: 100.0 # max stake can be set by a node (boundary for all nodes)
+    max_stake: 20000.0 # max stake can be set by a node (boundary for all nodes)
     start_rounds: 50
     contribute_rounds: 50
     share_rounds: 50

--- a/docker.local/config/sc.yaml
+++ b/docker.local/config/sc.yaml
@@ -41,7 +41,7 @@ smart_contracts:
     x_percent: 0.70 # percentage of prev mb miners required to be part of next mb
     # etc
     min_stake: 0.0 # min stake can be set by a node (boundary for all nodes)
-    max_stake: 100.0 # max stake can be set by a node (boundary for all nodes)
+    max_stake: 20000.0 # max stake can be set by a node (boundary for all nodes)
     start_rounds: 50
     contribute_rounds: 50
     share_rounds: 50

--- a/quickstart/1s_2m_4b/config/1s_2m_4b/0Chain/docker.local/config/sc.yaml
+++ b/quickstart/1s_2m_4b/config/1s_2m_4b/0Chain/docker.local/config/sc.yaml
@@ -29,7 +29,7 @@ smart_contracts:
     k_percent: .75 # of registered
     # etc
     min_stake: 0.0 # 0.01 # min stake can be set by a node (boundary for all nodes)
-    max_stake: 100.0 # max stake can be set by a node (boundary for all nodes)
+    max_stake: 20000.0 # max stake can be set by a node (boundary for all nodes)
     start_rounds: 50
     contribute_rounds: 50
     share_rounds: 50

--- a/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/config/sc.yaml
+++ b/quickstart/1s_2m_4b/config/reference/0Chain/docker.local/config/sc.yaml
@@ -29,7 +29,7 @@ smart_contracts:
     k_percent: .75 # of registered
     # etc
     min_stake: 0.0 # 0.01 # min stake can be set by a node (boundary for all nodes)
-    max_stake: 100.0 # max stake can be set by a node (boundary for all nodes)
+    max_stake: 20000.0 # max stake can be set by a node (boundary for all nodes)
     start_rounds: 50
     contribute_rounds: 50
     share_rounds: 50


### PR DESCRIPTION
## Fixes
Fix inconsistent max_stake values introduced by https://github.com/0chain/0chain/pull/1937
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
