### PR TITLE
cleaning up blobber rank API from sharder as moved to 0box

### DIFF
--- a/code/go/0chain.net/chaincore/smartcontract/handler_test.go
+++ b/code/go/0chain.net/chaincore/smartcontract/handler_test.go
@@ -132,7 +132,7 @@ func TestGetSmartContract(t *testing.T) {
 		{
 			name:       "storage",
 			address:    storagesc.ADDRESS,
-			restpoints: 45,
+			restpoints: 44,
 		},
 		{
 			name:       "multisig",

--- a/code/go/0chain.net/sharder/sharder/swagger.yaml
+++ b/code/go/0chain.net/sharder/sharder/swagger.yaml
@@ -2518,24 +2518,6 @@ paths:
                     description: ""
                 "500":
                     description: ""
-    /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/blobber-rank:
-        get:
-            description: challenges passed / total challenges
-            operationId: blobber-rank
-            parameters:
-                - description: id of blobber
-                  in: query
-                  name: id
-                  required: true
-                  type: string
-            responses:
-                "200":
-                    description: Int64Map
-                    schema:
-                        $ref: '#/definitions/Int64Map'
-                "400":
-                    description: ""
-            summary: Gets the rank of a blobber.
     /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/blobber_ids:
         get:
             description: convert list of blobber urls into ids

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -91,46 +91,11 @@ func GetEndpoints(rh rest.RestHandlerI) []rest.Endpoint {
 		rest.MakeEndpoint(storage+"/blobber_ids", common.UserRateLimit(srh.getBlobberIdsByUrls)),
 		rest.MakeEndpoint(storage+"/alloc_blobbers", common.UserRateLimit(srh.getAllocationBlobbers)),
 		rest.MakeEndpoint(storage+"/free_alloc_blobbers", common.UserRateLimit(srh.getFreeAllocationBlobbers)),
-		rest.MakeEndpoint(storage+"/blobber-rank", common.UserRateLimit(srh.getBlobberRank)),
 		rest.MakeEndpoint(storage+"/search", common.UserRateLimit(srh.getSearchHandler)),
 		rest.MakeEndpoint(storage+"/alloc-blobber-term", common.UserRateLimit(srh.getAllocBlobberTerms)),
 		rest.MakeEndpoint(storage+"/replicate-snapshots", common.UserRateLimit(srh.replicateSnapshots)),
 		rest.MakeEndpoint(storage+"/replicate-blobber-aggregates", srh.replicateBlobberAggregates),
 	}
-}
-
-// swagger:route GET /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/blobber-rank blobber-rank
-// Gets the rank of a blobber.
-//
-//	challenges passed / total challenges
-//
-// parameters:
-//
-//	+name: id
-//	 description: id of blobber
-//	 required: true
-//	 in: query
-//	 type: string
-//
-// responses:
-//
-//	200: Int64Map
-//	400:
-func (srh *StorageRestHandler) getBlobberRank(w http.ResponseWriter, r *http.Request) {
-	id := r.URL.Query().Get("id")
-	edb := srh.GetQueryStateContext().GetEventDB()
-	if edb == nil {
-		common.Respond(w, r, nil, common.NewErrInternal("no db connection"))
-		return
-	}
-	rank, err := edb.GetBlobberRank(id)
-	if err != nil {
-		common.Respond(w, r, nil, err)
-		return
-	}
-	common.Respond(w, r, rest.Int64Map{
-		"blobber-rank": rank,
-	}, nil)
 }
 
 // swagger:route GET /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/average-write-price average-write-price


### PR DESCRIPTION
## Fixes

## Changes

Remove /blobber-rank API from sharder since moved to 0box

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
