### PR TITLE
set is_finalized=true before updating events db

### DIFF
--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -374,6 +374,7 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 			zap.Error(err))
 	}
 
+	fb.SetBlockFinalised()
 	c.SetLatestOwnFinalizedBlockRound(fb.Round)
 	c.SetLatestFinalizedBlock(fb)
 
@@ -414,7 +415,7 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 	}
 
 	wg.Run("finalize block - update finalized block", fb.Round, func() {
-		bsh.UpdateFinalizedBlock(ctx, fb)
+		bsh.UpdateFinalizedBlock(ctx, fb) //
 	})
 
 	fr.Finalize(fb)

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -674,7 +674,6 @@ func (mc *Chain) FinalizeBlock(ctx context.Context, b *block.Block) error {
 	for idx, txn := range b.Txns {
 		modifiedTxns[idx] = txn
 	}
-	b.SetBlockFinalised()
 	return mc.deleteTxns(modifiedTxns)
 }
 


### PR DESCRIPTION
## Fixes https://github.com/0chain/0chain/issues/1991


tested by deploying on local:
```
events_db=# select is_finalised from blocks limit 3;
 is_finalised
--------------
 t
 t
 t
```
## Changes


## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
