### PR TITLE
1963 logs clean up

### DIFF
--- a/code/go/0chain.net/chaincore/block/block_eventdb.go
+++ b/code/go/0chain.net/chaincore/block/block_eventdb.go
@@ -35,7 +35,7 @@ func blockToBlockEvent(block *Block) *event.Block {
 }
 
 func CreateBlockEvent(block *Block) (error, event.Event) {
-	logging.Logger.Info("create block event", zap.Any("block", block))
+	logging.Logger.Info("create block event", zap.String("blockHash", block.Hash), zap.Int64("round", block.Round))
 	// todo block.Round is zero, need to replace with block/round number
 	return nil, event.Event{
 		BlockNumber: block.Round,

--- a/code/go/0chain.net/chaincore/block/entity.go
+++ b/code/go/0chain.net/chaincore/block/entity.go
@@ -899,7 +899,7 @@ func (b *Block) ComputeState(ctx context.Context, c Chainer, waitC ...chan struc
 		logging.Logger.Error("previous state not compute yet",
 			zap.Int64("round", b.Round),
 			zap.String("block", b.Hash),
-			zap.Any("state status", pb.GetStateStatus()))
+			zap.Int8("state status", pb.GetStateStatus()))
 		return ErrPreviousStateNotComputed
 	}
 	//b.SetStateDB(pb, c.GetStateDB())
@@ -1052,7 +1052,7 @@ func (b *Block) ApplyBlockStateChange(bsc *StateChange, c Chainer) error {
 		du := time.Since(ts)
 		if du > 5*time.Second {
 			logging.Logger.Error("apply block state changes took too long",
-				zap.Any("duration", du))
+				zap.Duration("duration", du))
 		}
 	}()
 

--- a/code/go/0chain.net/chaincore/block/sos.go
+++ b/code/go/0chain.net/chaincore/block/sos.go
@@ -49,12 +49,12 @@ func (sos *ShareOrSigns) Validate(mpks *Mpks, publicKeys map[string]string, sche
 				return nil, false
 			}
 			if err := signatureScheme.SetPublicKey(pk); err != nil {
-				logging.Logger.Error("failed to validate share or signs", zap.Any("share", share), zap.Any("message", share.Message), zap.Any("sign", share.Sign))
+				logging.Logger.Error("failed to validate share or signs", zap.Any("share", share), zap.String("message", share.Message), zap.String("sign", share.Sign))
 				return nil, false
 			}
 			sigOK, err := signatureScheme.Verify(share.Sign, share.Message)
 			if !sigOK || err != nil {
-				logging.Logger.Error("failed to validate share or signs", zap.Any("share", share), zap.Any("message", share.Message), zap.Any("sign", share.Sign))
+				logging.Logger.Error("failed to validate share or signs", zap.Any("share", share), zap.String("message", share.Message), zap.String("sign", share.Sign))
 				return nil, false
 			}
 		} else {
@@ -69,7 +69,7 @@ func (sos *ShareOrSigns) Validate(mpks *Mpks, publicKeys map[string]string, sche
 			}
 
 			if !bls.ValidateShare(pks, sij, bls.ComputeIDdkg(key)) {
-				logging.Logger.Error("failed to validate share or signs", zap.Any("share", share), zap.Any("sij.pi", sij.GetPublicKey().GetHexString()))
+				logging.Logger.Error("failed to validate share or signs", zap.Any("share", share), zap.String("sij.pi", sij.GetPublicKey().GetHexString()))
 				return nil, false
 			}
 			keys = append(keys, key)

--- a/code/go/0chain.net/chaincore/block/state_debug.go
+++ b/code/go/0chain.net/chaincore/block/state_debug.go
@@ -52,7 +52,7 @@ func validateStateChangesRoot(b *Block) error {
 		if bsc.GetRoot() != nil {
 			computedRoot = bsc.GetRoot().GetHash()
 		}
-		logging.Logger.Error("block state change - root mismatch", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.String("state_root", util.ToHex(b.ClientStateHash)), zap.Any("computed_root", computedRoot))
+		logging.Logger.Error("block state change - root mismatch", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.String("state_root", util.ToHex(b.ClientStateHash)), zap.String("computed_root", computedRoot))
 		return ErrStateMismatch
 	}
 	return nil
@@ -92,9 +92,9 @@ func ValidateState(ctx context.Context, b *Block, priorRoot util.Key) error {
 				b.ClientState.PrettyPrint(StateOut)
 			}
 			if state.DebugBlock() {
-				logging.Logger.DPanic("validate state", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Any("state", util.ToHex(b.ClientState.GetRoot())), zap.String("computed_state", stateRoot.GetHash()), zap.Int("changes", len(changes.Nodes)))
+				logging.Logger.DPanic("validate state", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.String("state", util.ToHex(b.ClientState.GetRoot())), zap.String("computed_state", stateRoot.GetHash()), zap.Int("changes", len(changes.Nodes)))
 			} else {
-				logging.Logger.Error("validate state", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Any("state", util.ToHex(b.ClientState.GetRoot())), zap.String("computed_state", stateRoot.GetHash()), zap.Int("changes", len(changes.Nodes)))
+				logging.Logger.Error("validate state", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.String("state", util.ToHex(b.ClientState.GetRoot())), zap.String("computed_state", stateRoot.GetHash()), zap.Int("changes", len(changes.Nodes)))
 			}
 		}
 		if priorRoot == nil {

--- a/code/go/0chain.net/chaincore/chain/block_fetcher.go
+++ b/code/go/0chain.net/chaincore/chain/block_fetcher.go
@@ -408,8 +408,7 @@ func (c *Chain) getFinalizedBlockFromSharders(ctx context.Context,
 	validateBlock := func(b *block.Block) (*block.Block, error) {
 		if err = b.Validate(ctx); err != nil {
 			logging.Logger.Error("fetch_fb_from_sharders - invalid",
-				zap.Int64("round", b.Round), zap.String("block", b.Hash),
-				zap.Any("block_obj", b), zap.Error(err))
+				zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Error(err))
 			return nil, err
 		}
 
@@ -535,14 +534,13 @@ func (c *Chain) GetNotarizedBlockFromMiners(ctx context.Context, hash string, ro
 		nb, ok := <-blockC
 		if !ok {
 			logging.Logger.Debug("fetch_nb_from_miners - no notarized block given",
-				zap.Any("duration", time.Since(ts)))
+				zap.Duration("duration", time.Since(ts)))
 			return nil, common.NewErrorf("fetch_nb_from_miners", "no notarized block given")
 		}
 
 		if err = nb.Validate(ctx); err != nil {
 			logging.Logger.Error("fetch_nb_from_miners - invalid",
-				zap.Int64("round", nb.Round), zap.String("block", hash),
-				zap.Any("block_obj", nb), zap.Error(err))
+				zap.Int64("round", nb.Round), zap.String("block", hash), zap.Error(err))
 			continue
 		}
 
@@ -554,13 +552,13 @@ func (c *Chain) GetNotarizedBlockFromMiners(ctx context.Context, hash string, ro
 			case context.DeadlineExceeded:
 				logging.Logger.Error("fetch_nb_from_miners - verify notarization tickets timeout",
 					zap.Int64("round", nb.Round), zap.String("block", hash),
-					zap.Any("duration", time.Since(ts)),
+					zap.Duration("duration", time.Since(ts)),
 					zap.Error(err))
 				return nil, err
 			case context.Canceled:
 				logging.Logger.Debug("fetch_nb_from_miners - verify notarization tickets canceled",
 					zap.Int64("round", nb.Round), zap.String("block", hash),
-					zap.Any("duration", time.Since(ts)),
+					zap.Duration("duration", time.Since(ts)),
 					zap.Error(err))
 				return nil, err
 			default:

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -616,7 +616,7 @@ func (c *Chain) setupInitialState(initStates *state.InitStates, gb *block.Block)
 	if err := pmt.SaveChanges(context.Background(), stateDB, false); err != nil {
 		logging.Logger.Panic("chain.stateDB save changes failed", zap.Error(err))
 	}
-	logging.Logger.Info("initial state root", zap.Any("hash", util.ToHex(pmt.GetRoot())))
+	logging.Logger.Info("initial state root", zap.String("hash", util.ToHex(pmt.GetRoot())))
 	return pmt
 }
 
@@ -936,8 +936,8 @@ func (c *Chain) GetGenerators(r round.RoundI) []*node.Node {
 	genNum := getGeneratorsNum(len(miners), c.MinGenerators(), c.GeneratorsPercent())
 	if genNum > len(miners) {
 		logging.Logger.Warn("get generators -- the number of generators is greater than the number of miners",
-			zap.Any("num_generators", genNum), zap.Int("miner_by_rank", len(miners)),
-			zap.Any("round", r.GetRoundNumber()))
+			zap.Int("num_generators", genNum), zap.Int("miner_by_rank", len(miners)),
+			zap.Int64("round", r.GetRoundNumber()))
 		return miners
 	}
 	return miners[:genNum]
@@ -1198,12 +1198,12 @@ func (c *Chain) getBlocks() []*block.Block {
 func (c *Chain) SetRoundRank(r round.RoundI, b *block.Block) {
 	miners := c.GetMiners(r.GetRoundNumber())
 	if miners == nil || miners.Size() == 0 {
-		logging.Logger.DPanic("set_round_rank  --  empty miners", zap.Any("round", r.GetRoundNumber()), zap.Any("block", b.Hash))
+		logging.Logger.DPanic("set_round_rank  --  empty miners", zap.Int64("round", r.GetRoundNumber()), zap.String("block", b.Hash))
 	}
 	bNode := miners.GetNode(b.MinerID)
 	if bNode == nil {
-		logging.Logger.Warn("set_round_rank  --  get node by id", zap.Any("round", r.GetRoundNumber()),
-			zap.Any("block", b.Hash), zap.Any("miner_id", b.MinerID), zap.Any("miners", miners))
+		logging.Logger.Warn("set_round_rank  --  get node by id", zap.Int64("round", r.GetRoundNumber()),
+			zap.String("block", b.Hash), zap.String("miner_id", b.MinerID))
 		return
 	}
 	b.RoundRank = r.GetMinerRank(bNode)
@@ -1477,7 +1477,7 @@ func (c *Chain) updateConfig(pb *block.Block) {
 
 	configMap, err := getConfigMap(clientState)
 	if err != nil {
-		logging.Logger.Info("cannot get global settings",
+		logging.Logger.Error("cannot get global settings",
 			zap.Int64("start of round", pb.Round),
 			zap.Error(err),
 		)
@@ -1548,8 +1548,8 @@ func (c *Chain) UpdateMagicBlock(newMagicBlock *block.MagicBlock) error {
 		lfmb.MagicBlock.Hash != newMagicBlock.PreviousMagicBlockHash {
 
 		logging.Logger.Error("failed to update magic block",
-			zap.Any("finalized_magic_block_hash", lfmb.MagicBlock.Hash),
-			zap.Any("new_magic_block_previous_hash", newMagicBlock.PreviousMagicBlockHash))
+			zap.String("finalized_magic_block_hash", lfmb.MagicBlock.Hash),
+			zap.String("new_magic_block_previous_hash", newMagicBlock.PreviousMagicBlockHash))
 		return common.NewError("failed to update magic block",
 			fmt.Sprintf("magic block's previous magic block hash (%v) doesn't equal latest finalized magic block id (%v)", newMagicBlock.PreviousMagicBlockHash, lfmb.MagicBlock.Hash))
 	}
@@ -1573,8 +1573,8 @@ func (c *Chain) UpdateMagicBlock(newMagicBlock *block.MagicBlock) error {
 
 		if lfmb.Hash == newMagicBlock.PreviousMagicBlockHash {
 			logging.Logger.Info("update magic block -- hashes match ",
-				zap.Any("LFMB previous MB hash", lfmb.PreviousMagicBlockHash),
-				zap.Any("new MB previous MB hash", newMagicBlock.PreviousMagicBlockHash))
+				zap.String("LFMB previous MB hash", lfmb.PreviousMagicBlockHash),
+				zap.String("new MB previous MB hash", newMagicBlock.PreviousMagicBlockHash))
 			c.PreviousMagicBlock = lfmb.MagicBlock
 		}
 	}

--- a/code/go/0chain.net/chaincore/chain/magic_block_source.go
+++ b/code/go/0chain.net/chaincore/chain/magic_block_source.go
@@ -55,9 +55,9 @@ func ReadMagicBlockFile(path string) (mb *block.MagicBlock, err error) {
 	}
 
 	logging.Logger.Info("read magic block file",
-		zap.Any("number", mb.MagicBlockNumber),
-		zap.Any("sr", mb.StartingRound),
-		zap.Any("hash", mb.Hash))
+		zap.Int64("number", mb.MagicBlockNumber),
+		zap.Int64("sr", mb.StartingRound),
+		zap.String("hash", mb.Hash))
 	return
 }
 
@@ -75,8 +75,8 @@ func GetMagicBlockFrom0DNS(urlBase string) (mb *block.MagicBlock, err error) {
 		return nil, fmt.Errorf("getting MB from 0DNS %q: %v", full, err)
 	}
 	logging.Logger.Info("get magic block file from 0DNS", zap.String("0dns", full),
-		zap.Any("number", mb.MagicBlockNumber),
-		zap.Any("sr", mb.StartingRound),
-		zap.Any("hash", mb.Hash))
+		zap.Int64("number", mb.MagicBlockNumber),
+		zap.Int64("sr", mb.StartingRound),
+		zap.String("hash", mb.Hash))
 	return
 }

--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -459,7 +459,7 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 
 	logging.Logger.Debug("finalized block - done",
 		zap.Int64("round", fb.Round), zap.String("block", fb.Hash),
-		zap.Any("duration", time.Since(ts)))
+		zap.Duration("duration", time.Since(ts)))
 	return nil
 }
 
@@ -483,7 +483,7 @@ func (wgs *waitGroupSync) Run(name string, round int64, f func()) {
 		if du.Milliseconds() > 50 {
 			logging.Logger.Debug("Run slow on", zap.String("name", name),
 				zap.Int64("round", round),
-				zap.Any("duration", du))
+				zap.Duration("duration", du))
 		}
 	}()
 }

--- a/code/go/0chain.net/chaincore/chain/protocol_round.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_round.go
@@ -391,7 +391,7 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 					if du > 3*time.Second {
 						logging.Logger.Debug("finalize round slow",
 							zap.Int64("round", roundNumber),
-							zap.Any("duration", time.Since(ts)))
+							zap.Duration("duration", time.Since(ts)))
 					}
 				}
 			case <-time.NewTimer(500 * time.Millisecond).C: // TODO: make the timeout configurable

--- a/code/go/0chain.net/chaincore/chain/protocol_view_change.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change.go
@@ -86,7 +86,7 @@ func (c *Chain) RegisterClient() {
 			if err != nil {
 				logging.Logger.Error("error in register client",
 					zap.Error(err),
-					zap.Any("body", body),
+					zap.ByteString("body", body),
 					zap.Int("registered", registered),
 					zap.Int("consensus", consensus))
 			} else {
@@ -149,7 +149,7 @@ func (c *Chain) isRegisteredEx(ctx context.Context, getStatePath func(n *node.No
 
 		if err != nil {
 			logging.Logger.Error("failed to get block state node",
-				zap.Any("error", err), zap.String("path", sp))
+				zap.Error(err), zap.String("path", sp))
 			return false
 		}
 
@@ -165,7 +165,7 @@ func (c *Chain) isRegisteredEx(ctx context.Context, getStatePath func(n *node.No
 		err = httpclientutil.MakeSCRestAPICall(ctx, minersc.ADDRESS, relPath, nil,
 			sharders, allNodesList, 1)
 		if err != nil {
-			logging.Logger.Error("is registered", zap.Any("error", err))
+			logging.Logger.Error("is registered", zap.Error(err))
 			return false
 		}
 	}
@@ -222,7 +222,7 @@ func (c *Chain) ConfirmTransaction(ctx context.Context, t *httpclientutil.Transa
 		} else {
 			blockSummary, err := httpclientutil.GetBlockSummaryCall(urls, 1, false)
 			if err != nil {
-				logging.Logger.Info("confirm transaction", zap.Any("confirmation", false))
+				logging.Logger.Info("confirm transaction", zap.Bool("confirmation", false))
 				return false
 			}
 			pastTime = blockSummary != nil && !common.WithinTime(int64(blockSummary.CreationDate), int64(t.CreationDate), transaction.TXN_TIME_TOLERANCE)
@@ -507,7 +507,7 @@ func GetFromSharders(ctx context.Context, address, relative string, sharders []s
 
 	t := time.Now()
 	defer func() {
-		logging.Logger.Debug("GetFromSharders", zap.Any("duration", time.Since(t)))
+		logging.Logger.Debug("GetFromSharders", zap.Duration("duration", time.Since(t)))
 	}()
 
 	wg := &sync.WaitGroup{}

--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -60,14 +60,14 @@ func (c *Chain) ComputeOrSyncState(ctx context.Context, b *block.Block) error {
 		if bsc != nil {
 			if err = c.ApplyBlockStateChange(b, bsc); err != nil {
 				logging.Logger.Error("compute state - applying state change",
-					zap.Any("round", b.Round), zap.Any("block", b.Hash),
+					zap.Int64("round", b.Round), zap.String("block", b.Hash),
 					zap.Error(err))
 				return err
 			}
 		}
 		if !b.IsStateComputed() {
 			logging.Logger.Error("compute state - state change error",
-				zap.Any("round", b.Round), zap.Any("block", b.Hash),
+				zap.Int64("round", b.Round), zap.String("block", b.Hash),
 				zap.Error(err))
 			return err
 		}
@@ -209,7 +209,7 @@ func (c *Chain) EstimateTransactionCost(ctx context.Context,
 		err := json.Unmarshal(dataBytes, &scData)
 		if err != nil {
 			logging.Logger.Error("Error while decoding the JSON from transaction",
-				zap.Any("input", txn.TransactionData), zap.Any("error", err))
+				zap.String("input", txn.TransactionData), zap.Error(err))
 			return math.MaxInt32, err
 		}
 		cost, err := smartcontract.EstimateTransactionCost(txn, scData, sctx)
@@ -311,7 +311,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 
 		if err = json.Unmarshal(dataBytes, &scData); err != nil {
 			logging.Logger.Error("Error while decoding the JSON from transaction",
-				zap.Any("input", txn.TransactionData), zap.Any("error", err))
+				zap.String("input", txn.TransactionData), zap.Error(err))
 			return nil, err
 		}
 
@@ -327,7 +327,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				zap.String("begin client state", util.ToHex(startRoot)),
 				zap.String("prev block", b.PrevBlock.Hash),
 				zap.Duration("time_spent", time.Since(t)),
-				zap.Any("txn", txn))
+				zap.String("txn", txn.Hash))
 			//return original error, to handle upwards
 			return nil, err
 		case context.Canceled:
@@ -338,7 +338,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				zap.String("begin client state", util.ToHex(startRoot)),
 				zap.String("prev block", b.PrevBlock.Hash),
 				zap.Duration("time_spent", time.Since(t)),
-				zap.Any("txn", txn))
+				zap.String("txn", txn.Hash))
 			//return original error, to handle upwards
 			return nil, err
 		default:
@@ -351,7 +351,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 						zap.String("begin client state", util.ToHex(startRoot)),
 						zap.String("prev block", b.PrevBlock.Hash),
 						zap.Duration("time_spent", time.Since(t)),
-						zap.Any("txn", txn))
+						zap.String("txn", txn.Hash))
 					return nil, err
 				}
 
@@ -362,7 +362,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 					zap.String("begin client state", util.ToHex(startRoot)),
 					zap.String("prev block", b.PrevBlock.Hash),
 					zap.Duration("time_spent", time.Since(t)),
-					zap.Any("txn", txn))
+					zap.String("txn", txn.Hash))
 
 				//refresh client state context, so all changes made by broken smart contract are rejected, it will be used to add fee
 				clientState = CreateTxnMPT(bState) // begin transaction
@@ -392,9 +392,9 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		err = sctx.AddTransfer(state.NewTransfer(txn.ClientID, txn.ToClientID, txn.Value))
 		if err != nil {
 			logging.Logger.Error("Failed to add transfer",
-				zap.Any("txn type", txn.TransactionType),
-				zap.Any("transaction_ClientID", txn.ClientID),
-				zap.Any("minersc_address", minersc.ADDRESS),
+				zap.Int("txn type", txn.TransactionType),
+				zap.String("transaction_ClientID", txn.ClientID),
+				zap.String("minersc_address", minersc.ADDRESS),
 				zap.Any("state_balance", txn.Fee),
 				zap.Any("current_root", sctx.GetState().GetRoot()))
 			return nil, err
@@ -408,9 +408,9 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		err = sctx.AddTransfer(state.NewTransfer(txn.ClientID, minersc.ADDRESS, txn.Fee))
 		if err != nil {
 			logging.Logger.Error("Failed to add transfer",
-				zap.Any("txn type", txn.TransactionType),
-				zap.Any("transaction_ClientID", txn.ClientID),
-				zap.Any("minersc_address", minersc.ADDRESS),
+				zap.Int("txn type", txn.TransactionType),
+				zap.String("transaction_ClientID", txn.ClientID),
+				zap.String("minersc_address", minersc.ADDRESS),
 				zap.Any("state_balance", txn.Fee))
 			return nil, err
 		}
@@ -421,10 +421,10 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		tEvents, err := c.transferAmount(sctx, transfer.ClientID, transfer.ToClientID, transfer.Amount)
 		if err != nil {
 			logging.Logger.Error("Failed to transfer amount",
-				zap.Any("txn type", txn.TransactionType),
+				zap.Int("txn type", txn.TransactionType),
 				zap.String("txn data", txn.TransactionData),
-				zap.Any("transfer_ClientID", transfer.ClientID),
-				zap.Any("to_ClientID", transfer.ToClientID),
+				zap.String("transfer_ClientID", transfer.ClientID),
+				zap.String("to_ClientID", transfer.ToClientID),
 				zap.Any("amount", transfer.Amount),
 				zap.Error(err))
 			return nil, err
@@ -439,8 +439,8 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 			signedTransfer.ToClientID, signedTransfer.Amount)
 		if err != nil {
 			logging.Logger.Error("Failed to process signed transfer",
-				zap.Any("signedTransfer_ClientID", signedTransfer.ClientID),
-				zap.Any("signedTransfer_to_ClientID", signedTransfer.ToClientID),
+				zap.String("signedTransfer_ClientID", signedTransfer.ClientID),
+				zap.String("signedTransfer_to_ClientID", signedTransfer.ToClientID),
 				zap.Any("signedTransfer_amount", signedTransfer.Amount))
 			return nil, err
 		}
@@ -452,8 +452,8 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 	for _, mint := range sctx.GetMints() {
 		u, err := c.mintAmount(sctx, mint.ToClientID, mint.Amount)
 		if err != nil {
-			logging.Logger.Error("mint error", zap.Any("error", err),
-				zap.Any("transaction", txn.Hash),
+			logging.Logger.Error("mint error", zap.Error(err),
+				zap.String("transaction", txn.Hash),
 				zap.String("to clientID", mint.ToClientID))
 			return nil, err
 		}
@@ -464,8 +464,8 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 
 	u, err := c.incrementNonce(sctx, txn.ClientID)
 	if err != nil {
-		logging.Logger.Error("update nonce error", zap.Any("error", err),
-			zap.Any("transaction", txn.Hash),
+		logging.Logger.Error("update nonce error", zap.Error(err),
+			zap.String("transaction", txn.Hash),
 			zap.String("clientID", txn.ClientID))
 		return nil, err
 	}
@@ -483,10 +483,10 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		if state.DebugTxn() {
 			logging.Logger.DPanic("update state - merge mpt error",
 				zap.Int64("round", b.Round), zap.String("block", b.Hash),
-				zap.Any("txn", txn), zap.Error(err))
+				zap.String("txn", txn.Hash), zap.Error(err))
 		}
 
-		logging.Logger.Error("error committing txn", zap.Any("error", err))
+		logging.Logger.Error("error committing txn", zap.Error(err))
 		return nil, err
 	}
 
@@ -566,7 +566,7 @@ func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient 
 		logging.Logger.Error("transfer amount - error",
 			zap.Int64("round", b.Round),
 			zap.String("block", b.Hash),
-			zap.Any("txn", txn), zap.Error(err))
+			zap.String("txn", txn.Hash), zap.Error(err))
 		return nil, err
 	}
 
@@ -611,7 +611,7 @@ func (c *Chain) mintAmount(sctx bcstate.StateContextI, toClient datastore.Key, a
 		logging.Logger.Error("transfer amount - error",
 			zap.Int64("round", b.Round),
 			zap.String("block", b.Hash),
-			zap.Any("txn", txn),
+			zap.String("txn", txn.Hash),
 			zap.Error(err))
 		return nil, err
 	}
@@ -636,8 +636,8 @@ func (c *Chain) validateNonce(sctx bcstate.StateContextI, fromClient datastore.K
 	if nonce+1 != txnNonce {
 		b := sctx.GetBlock()
 		logging.Logger.Error("validate nonce - error",
-			zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Any("txn_nonce", txnNonce),
-			zap.Any("local_nonce", s.Nonce), zap.Error(err))
+			zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Int64("txn_nonce", txnNonce),
+			zap.Int64("local_nonce", s.Nonce), zap.Error(err))
 		return ErrWrongNonce
 	}
 

--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -327,7 +327,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				zap.String("begin client state", util.ToHex(startRoot)),
 				zap.String("prev block", b.PrevBlock.Hash),
 				zap.Duration("time_spent", time.Since(t)),
-				zap.String("txn", txn.Hash))
+				zap.Any("txn", txn))
 			//return original error, to handle upwards
 			return nil, err
 		case context.Canceled:
@@ -338,7 +338,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 				zap.String("begin client state", util.ToHex(startRoot)),
 				zap.String("prev block", b.PrevBlock.Hash),
 				zap.Duration("time_spent", time.Since(t)),
-				zap.String("txn", txn.Hash))
+				zap.Any("txn", txn))
 			//return original error, to handle upwards
 			return nil, err
 		default:
@@ -351,7 +351,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 						zap.String("begin client state", util.ToHex(startRoot)),
 						zap.String("prev block", b.PrevBlock.Hash),
 						zap.Duration("time_spent", time.Since(t)),
-						zap.String("txn", txn.Hash))
+						zap.Any("txn", txn))
 					return nil, err
 				}
 
@@ -362,7 +362,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 					zap.String("begin client state", util.ToHex(startRoot)),
 					zap.String("prev block", b.PrevBlock.Hash),
 					zap.Duration("time_spent", time.Since(t)),
-					zap.String("txn", txn.Hash))
+					zap.Any("txn", txn))
 
 				//refresh client state context, so all changes made by broken smart contract are rejected, it will be used to add fee
 				clientState = CreateTxnMPT(bState) // begin transaction
@@ -453,7 +453,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		u, err := c.mintAmount(sctx, mint.ToClientID, mint.Amount)
 		if err != nil {
 			logging.Logger.Error("mint error", zap.Error(err),
-				zap.String("transaction", txn.Hash),
+				zap.Any("transaction", txn),
 				zap.String("to clientID", mint.ToClientID))
 			return nil, err
 		}
@@ -465,7 +465,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 	u, err := c.incrementNonce(sctx, txn.ClientID)
 	if err != nil {
 		logging.Logger.Error("update nonce error", zap.Error(err),
-			zap.String("transaction", txn.Hash),
+			zap.Any("transaction", txn),
 			zap.String("clientID", txn.ClientID))
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 		if state.DebugTxn() {
 			logging.Logger.DPanic("update state - merge mpt error",
 				zap.Int64("round", b.Round), zap.String("block", b.Hash),
-				zap.String("txn", txn.Hash), zap.Error(err))
+				zap.Any("txn", txn), zap.Error(err))
 		}
 
 		logging.Logger.Error("error committing txn", zap.Error(err))
@@ -566,7 +566,7 @@ func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient 
 		logging.Logger.Error("transfer amount - error",
 			zap.Int64("round", b.Round),
 			zap.String("block", b.Hash),
-			zap.String("txn", txn.Hash), zap.Error(err))
+			zap.Any("txn", txn), zap.Error(err))
 		return nil, err
 	}
 
@@ -611,7 +611,7 @@ func (c *Chain) mintAmount(sctx bcstate.StateContextI, toClient datastore.Key, a
 		logging.Logger.Error("transfer amount - error",
 			zap.Int64("round", b.Round),
 			zap.String("block", b.Hash),
-			zap.String("txn", txn.Hash),
+			zap.Any("txn", txn),
 			zap.Error(err))
 		return nil, err
 	}

--- a/code/go/0chain.net/chaincore/chain/state_sync.go
+++ b/code/go/0chain.net/chaincore/chain/state_sync.go
@@ -27,7 +27,7 @@ func (c *Chain) GetBlockStateChangeForce(ctx context.Context, b *block.Block) er
 	return common.RunWithRetries(ctx, 20, func() error {
 		err := c.GetBlockStateChange(b)
 		if err != nil {
-			logging.Logger.Info("can't get block state changes, retrying", zap.Error(err))
+			logging.Logger.Error("can't get block state changes, retrying", zap.Error(err))
 		}
 		return err
 	})
@@ -37,7 +37,7 @@ func (c *Chain) GetBlockStateChangeForce(ctx context.Context, b *block.Block) er
 func (c *Chain) GetBlockStateChange(b *block.Block) error {
 	ts := time.Now()
 	if b.PrevBlock != nil && bytes.Equal(b.PrevBlock.ClientStateHash, b.ClientStateHash) {
-		logging.Logger.Debug("block has the same state", zap.Any("block", b.Hash),
+		logging.Logger.Debug("block has the same state", zap.String("block", b.Hash),
 			zap.Any("block_state_hash", b.ClientStateHash))
 		if !b.PrevBlock.IsStateComputed() {
 			return common.NewError("get_block_state_changes", "block is not changed but prev block state is not computed")
@@ -48,7 +48,7 @@ func (c *Chain) GetBlockStateChange(b *block.Block) error {
 
 		logging.Logger.Debug("get_block_state_changes - apply took",
 			zap.Int64("round", b.Round),
-			zap.Any("duration", time.Since(ts)))
+			zap.Duration("duration", time.Since(ts)))
 		return nil
 	}
 	bsc, err := c.getBlockStateChange(b)
@@ -57,7 +57,7 @@ func (c *Chain) GetBlockStateChange(b *block.Block) error {
 	}
 	logging.Logger.Debug("get_block_state_changes - get took",
 		zap.Int64("round", b.Round),
-		zap.Any("duration", time.Since(ts)))
+		zap.Duration("duration", time.Since(ts)))
 
 	ts = time.Now()
 	err = c.ApplyBlockStateChange(b, bsc)
@@ -67,7 +67,7 @@ func (c *Chain) GetBlockStateChange(b *block.Block) error {
 
 	logging.Logger.Debug("get_block_state_changes - apply took",
 		zap.Int64("round", b.Round),
-		zap.Any("duration", time.Since(ts)))
+		zap.Duration("duration", time.Since(ts)))
 	return nil
 }
 
@@ -106,7 +106,7 @@ func (c *Chain) GetStateNodesFromSharders(ctx context.Context, keys []util.Key) 
 			skeys[idx] = util.ToHex(key)
 		}
 		logging.Logger.Error("get state nodes", zap.Int("num_keys", len(keys)),
-			zap.Any("keys", skeys), zap.Error(err))
+			zap.Strings("keys", skeys), zap.Error(err))
 		return
 	}
 	keysStr := make([]string, len(keys))

--- a/code/go/0chain.net/chaincore/chain/worker.go
+++ b/code/go/0chain.net/chaincore/chain/worker.go
@@ -263,7 +263,7 @@ func (c *Chain) FinalizedBlockWorker(ctx context.Context, bsh BlockStateHandler)
 					errC <- c.finalizeBlockProcess(cctx, fbr.block, bsh)
 					logging.Logger.Debug("finalize block processed",
 						zap.Int64("round", fbr.block.Round),
-						zap.Any("duration", time.Since(ts)))
+						zap.Duration("duration", time.Since(ts)))
 				}()
 
 				select {
@@ -497,7 +497,7 @@ func (c *Chain) SyncLFBStateWorker(ctx context.Context) {
 			logging.Logger.Debug("BC may get stuck",
 				zap.Int64("lastRound", lastRound.round),
 				zap.String("state_hash", util.ToHex(lastRound.stateHash)),
-				zap.Any("stuck time", ts))
+				zap.Duration("stuck time", ts))
 		case mns := <-c.syncMissingNodesC:
 			func() {
 				var synced bool
@@ -518,12 +518,12 @@ func (c *Chain) SyncLFBStateWorker(ctx context.Context) {
 
 				logging.Logger.Debug("sync missing nodes",
 					zap.Int64("round", mns.round),
-					zap.Any("keys", keysStr))
+					zap.Strings("keys", keysStr))
 
 				if err := c.GetStateNodes(ctx, mns.keys); err != nil {
 					logging.Logger.Debug("sync missing nodes failed",
 						zap.Int64("round", mns.round),
-						zap.Any("keys", keysStr),
+						zap.Strings("keys", keysStr),
 						zap.Error(err))
 					return
 				}
@@ -589,8 +589,8 @@ func (c *Chain) VerifyChainHistoryAndRepairOn(ctx context.Context,
 		}
 
 		logging.Logger.Info("verify chain history",
-			zap.Any("mb_sr", magicBlock.StartingRound),
-			zap.Any("mb_hash", magicBlock.Hash),
+			zap.Int64("mb_sr", magicBlock.StartingRound),
+			zap.String("mb_hash", magicBlock.Hash),
 			zap.Int64("mb_num", magicBlock.MagicBlockNumber))
 
 		if err = c.UpdateMagicBlock(magicBlock.MagicBlock); err != nil {
@@ -668,9 +668,9 @@ func (c *Chain) UpdateLatestMagicBlockFromShardersOn(ctx context.Context,
 	}
 
 	logging.Logger.Info("get magic lfmb from sharders",
-		zap.Any("number", lfmb.MagicBlockNumber),
-		zap.Any("sr", lfmb.StartingRound),
-		zap.Any("hash", lfmb.Hash),
+		zap.Int64("number", lfmb.MagicBlockNumber),
+		zap.Int64("sr", lfmb.StartingRound),
+		zap.String("hash", lfmb.Hash),
 		zap.Int64("local lfmb", lfmb.StartingRound))
 
 	if lfmb.MagicBlock.StartingRound <= cmb.StartingRound {
@@ -679,9 +679,9 @@ func (c *Chain) UpdateLatestMagicBlockFromShardersOn(ctx context.Context,
 			c.SetLatestFinalizedMagicBlock(lfmb)
 			logging.Logger.Debug(
 				"updated lfmb to add lfmb's parent lfmb to magicBlockStartRounds cache",
-				zap.Any("lfmb hash", lfmb.Hash),
-				zap.Any("lfmb round", lfmb.Round),
-				zap.Any("lfmb starting round", lfmb.StartingRound),
+				zap.String("lfmb hash", lfmb.Hash),
+				zap.Int64("lfmb round", lfmb.Round),
+				zap.Int64("lfmb starting round", lfmb.StartingRound),
 			)
 		}
 		return nil // earlier than the current one

--- a/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
+++ b/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
@@ -170,7 +170,7 @@ func GetTransactionStatus(txnHash string, urls []string, sf int) (*Transaction, 
 		urlString := fmt.Sprintf("%v/%v%v", sharder, txnVerifyURL, txnHash)
 		response, err := httpClient.Get(urlString)
 		if err != nil {
-			logging.N2n.Error("get transaction status -- failed", zap.Any("error", err))
+			logging.N2n.Error("get transaction status -- failed", zap.Error(err))
 			numErrs++
 		} else {
 			contents, err := ioutil.ReadAll(response.Body)
@@ -181,14 +181,14 @@ func GetTransactionStatus(txnHash string, urls []string, sf int) (*Transaction, 
 				continue
 			}
 			if err != nil {
-				logging.Logger.Error("Error reading response from transaction confirmation", zap.Any("error", err))
+				logging.Logger.Error("Error reading response from transaction confirmation", zap.Error(err))
 				response.Body.Close()
 				continue
 			}
 			var objmap map[string]*json.RawMessage
 			err = json.Unmarshal(contents, &objmap)
 			if err != nil {
-				logging.Logger.Error("Error unmarshalling response", zap.Any("error", err))
+				logging.Logger.Error("Error unmarshalling response", zap.Error(err))
 				errString = errString + urlString + ":" + err.Error()
 				response.Body.Close()
 				continue
@@ -201,7 +201,7 @@ func GetTransactionStatus(txnHash string, urls []string, sf int) (*Transaction, 
 			txn := &Transaction{}
 			err = json.Unmarshal(*objmap["txn"], &txn)
 			if err != nil {
-				logging.Logger.Error("Error unmarshalling to get transaction response", zap.Any("error", err))
+				logging.Logger.Error("Error unmarshalling to get transaction response", zap.Error(err))
 				errString = errString + urlString + ":" + err.Error()
 			}
 			if len(txn.Signature) > 0 {
@@ -229,7 +229,7 @@ func sendTransactionToURL(url string, txn *Transaction, ID string, pkey string, 
 	}
 	jsObj, err := json.Marshal(txn)
 	if err != nil {
-		logging.Logger.Error("Error in serializing the transaction", zap.String("error", err.Error()), zap.Any("transaction", txn))
+		logging.Logger.Error("Error in serializing the transaction", zap.String("error", err.Error()), zap.String("transaction", txn.Hash))
 		return nil, err
 	}
 
@@ -304,7 +304,7 @@ func MakeClientStateRequest(ctx context.Context, clientID string, urls []string,
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 		if err != nil {
-			logging.N2n.Error("Error creating request for sc rest api", zap.Any("error", err))
+			logging.N2n.Error("Error creating request for sc rest api", zap.Error(err))
 			numErrs++
 			errString = errString + sharder + ":" + err.Error()
 			continue
@@ -312,14 +312,14 @@ func MakeClientStateRequest(ctx context.Context, clientID string, urls []string,
 
 		response, err := httpClient.Do(req)
 		if err != nil {
-			logging.N2n.Error("Error getting response for sc rest api", zap.Any("error", err))
+			logging.N2n.Error("Error getting response for sc rest api", zap.Error(err))
 			numErrs++
 			errString = errString + sharder + ":" + err.Error()
 			continue
 		}
 
 		if response.StatusCode != 200 {
-			logging.N2n.Error("Error getting response from", zap.String("URL", sharder), zap.Any("response Status", response.StatusCode))
+			logging.N2n.Error("Error getting response from", zap.String("URL", sharder), zap.Int("response Status", response.StatusCode))
 			numErrs++
 			errString = errString + sharder + ": response_code: " + strconv.Itoa(response.StatusCode)
 			response.Body.Close()
@@ -331,7 +331,7 @@ func MakeClientStateRequest(ctx context.Context, clientID string, urls []string,
 		err = d.Decode(&clientState)
 		response.Body.Close()
 		if err != nil {
-			logging.Logger.Error("Error unmarshalling response", zap.Any("error", err))
+			logging.Logger.Error("Error unmarshalling response", zap.Error(err))
 			numErrs++
 			errString = errString + sharder + ":" + err.Error()
 			continue
@@ -402,14 +402,14 @@ func MakeSCRestAPICall(ctx context.Context, scAddress string, relativePath strin
 
 			rsp, err := httpClient.Do(req)
 			if err != nil {
-				logging.N2n.Error("SCRestAPI - error getting response for sc rest api", zap.Any("error", err))
+				logging.N2n.Error("SCRestAPI - error getting response for sc rest api", zap.Error(err))
 				atomic.AddInt32(&numErrs, 1)
 				errStringC <- sharderURL + ":" + err.Error()
 				return
 			}
 			defer rsp.Body.Close()
 			if rsp.StatusCode != 200 {
-				logging.N2n.Error("SCRestAPI Error getting response from", zap.String("URL", sharderURL), zap.Any("response Status", rsp.StatusCode))
+				logging.N2n.Error("SCRestAPI Error getting response from", zap.String("URL", sharderURL), zap.Int("response Status", rsp.StatusCode))
 				atomic.AddInt32(&numErrs, 1)
 				errStringC <- sharderURL + ": response_code: " + strconv.Itoa(rsp.StatusCode)
 				return
@@ -417,11 +417,11 @@ func MakeSCRestAPICall(ctx context.Context, scAddress string, relativePath strin
 
 			bodyBytes, err := ioutil.ReadAll(rsp.Body)
 			if err != nil {
-				logging.Logger.Error("SCRestAPI - failed to read body response", zap.String("URL", sharderURL), zap.Any("error", err))
+				logging.Logger.Error("SCRestAPI - failed to read body response", zap.String("URL", sharderURL), zap.Error(err))
 			}
 			newEntity := reflect.New(entityType).Interface().(util.Serializable)
 			if err := newEntity.Decode(bodyBytes); err != nil {
-				logging.Logger.Error("SCRestAPI - error unmarshalling response", zap.Any("error", err))
+				logging.Logger.Error("SCRestAPI - error unmarshalling response", zap.Error(err))
 				atomic.AddInt32(&numErrs, 1)
 				errStringC <- sharderURL + ":" + err.Error()
 				return
@@ -454,7 +454,7 @@ func MakeSCRestAPICall(ctx context.Context, scAddress string, relativePath strin
 
 	nSuccess := atomic.LoadInt32(&numSuccess)
 	nErrs := atomic.LoadInt32(&numErrs)
-	logging.Logger.Info("SCRestAPI - sc rest consensus", zap.Any("success", nSuccess))
+	logging.Logger.Info("SCRestAPI - sc rest consensus", zap.Int32("success", nSuccess))
 	if nSuccess+nErrs == 0 {
 		return common.NewError("req_not_run", "Could not run the request") //why???
 	}
@@ -513,12 +513,12 @@ func GetBlockSummaryCall(urls []string, consensus int, magicBlock bool) (*block.
 		}
 		response, err := httpClient.Get(fmt.Sprintf("%v/%v", sharder, blockUrl))
 		if err != nil {
-			logging.N2n.Error("Error getting response for sc rest api", zap.Any("error", err))
+			logging.N2n.Error("Error getting response for sc rest api", zap.Error(err))
 			numErrs++
 			errString = errString + sharder + ":" + err.Error()
 		} else {
 			if response.StatusCode != 200 {
-				logging.N2n.Error("Error getting response from", zap.String("URL", sharder), zap.Any("response Status", response.StatusCode))
+				logging.N2n.Error("Error getting response from", zap.String("URL", sharder), zap.Int("response Status", response.StatusCode))
 				numErrs++
 				errString = errString + sharder + ": response_code: " + strconv.Itoa(response.StatusCode)
 				response.Body.Close()
@@ -527,16 +527,16 @@ func GetBlockSummaryCall(urls []string, consensus int, magicBlock bool) (*block.
 			bodyBytes, err := ioutil.ReadAll(response.Body)
 			response.Body.Close()
 			if err != nil {
-				logging.Logger.Error("Failed to read body response", zap.String("URL", sharder), zap.Any("error", err))
+				logging.Logger.Error("Failed to read body response", zap.String("URL", sharder), zap.Error(err))
 			}
 			err = summary.Decode(bodyBytes)
 			if err != nil {
-				logging.Logger.Error("Error unmarshalling response", zap.Any("error", err))
+				logging.Logger.Error("Error unmarshalling response", zap.Error(err))
 				numErrs++
 				errString = errString + sharder + ":" + err.Error()
 				continue
 			}
-			logging.Logger.Info("get magic block -- entity", zap.Any("summary", summary))
+			logging.Logger.Info("get magic block -- entity", zap.String("hash", summary.Hash), zap.Int64("round", summary.Round))
 			retObj = summary
 			numSuccess++
 		}
@@ -677,22 +677,22 @@ func GetMagicBlockCall(urls []string, magicBlockNumber int64, consensus int) (*b
 			}
 			response.Body.Close()
 			logging.N2n.Warn("attempt to retry the request",
-				zap.Any("response Status", response.StatusCode),
-				zap.Any("response Status text", response.Status), zap.String("URL", u),
-				zap.Any("retried", retried+1))
+				zap.Int("response Status", response.StatusCode),
+				zap.String("response Status text", response.Status), zap.String("URL", u),
+				zap.Int("retried", retried+1))
 			time.Sleep(timeoutRetry)
 			retried++
 		}
 
 		if err != nil {
-			logging.N2n.Error("Error getting response for sc rest api", zap.Any("error", err))
+			logging.N2n.Error("Error getting response for sc rest api", zap.Error(err))
 			numErrs++
 			errString = errString + sharder + ":" + err.Error()
 		} else {
 			if response.StatusCode != 200 {
 				logging.N2n.Error("Error getting response from", zap.String("URL", u),
-					zap.Any("response Status", response.StatusCode),
-					zap.Any("response Status text", response.Status))
+					zap.Int("response Status", response.StatusCode),
+					zap.String("response Status text", response.Status))
 				numErrs++
 				errString = errString + sharder + ": response_code: " + strconv.Itoa(response.StatusCode)
 				response.Body.Close()
@@ -701,15 +701,15 @@ func GetMagicBlockCall(urls []string, magicBlockNumber int64, consensus int) (*b
 			bodyBytes, err := ioutil.ReadAll(response.Body)
 			response.Body.Close()
 			if err != nil {
-				logging.Logger.Error("Failed to read body response", zap.String("URL", sharder), zap.Any("error", err))
+				logging.Logger.Error("Failed to read body response", zap.String("URL", sharder), zap.Error(err))
 			}
 			err = receivedBlock.Decode(bodyBytes)
 			if err != nil {
-				logging.Logger.Error("failed to decode block", zap.Any("error", err))
+				logging.Logger.Error("failed to decode block", zap.Error(err))
 			}
 
 			if err != nil {
-				logging.Logger.Error("Error unmarshalling response", zap.Any("error", err))
+				logging.Logger.Error("Error unmarshalling response", zap.Error(err))
 				numErrs++
 				errString = errString + sharder + ":" + err.Error()
 				continue
@@ -780,7 +780,7 @@ func SendSmartContractTxn(txn *Transaction,
 
 	err = txn.ComputeHashAndSign(signer)
 	if err != nil {
-		logging.Logger.Info("Signing Failed during registering miner to the mining network", zap.Error(err))
+		logging.Logger.Error("Signing Failed during registering miner to the mining network", zap.Error(err))
 		return err
 	}
 

--- a/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
+++ b/code/go/0chain.net/chaincore/httpclientutil/http_client_util.go
@@ -229,7 +229,7 @@ func sendTransactionToURL(url string, txn *Transaction, ID string, pkey string, 
 	}
 	jsObj, err := json.Marshal(txn)
 	if err != nil {
-		logging.Logger.Error("Error in serializing the transaction", zap.String("error", err.Error()), zap.String("transaction", txn.Hash))
+		logging.Logger.Error("Error in serializing the transaction", zap.String("error", err.Error()), zap.Any("transaction", txn))
 		return nil, err
 	}
 

--- a/code/go/0chain.net/chaincore/node/handler.go
+++ b/code/go/0chain.net/chaincore/node/handler.go
@@ -83,12 +83,12 @@ func (n *Node) PrintSendStats(w io.Writer) {
 func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	id := r.FormValue("id")
 	if id == "" {
-		logging.N2n.Error("status handler -- missing id", zap.Any("from", r.RemoteAddr))
+		logging.N2n.Error("status handler -- missing id", zap.String("from", r.RemoteAddr))
 		return
 	}
 	nd := GetNode(id)
 	if nd == nil {
-		logging.N2n.Error("status handler -- node nil", zap.Any("id", id))
+		logging.N2n.Error("status handler -- node nil", zap.String("id", id))
 		return
 	}
 	if nd.IsActive() {
@@ -101,11 +101,11 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	hash := r.FormValue("hash")
 	signature := r.FormValue("signature")
 	if data == "" || hash == "" || signature == "" {
-		logging.N2n.Error("status handler -- missing fields", zap.Any("data", data), zap.Any("hash", hash), zap.Any("signature", signature), zap.String("node_type", nd.GetNodeTypeName()), zap.Int("set_index", nd.SetIndex), zap.Any("key", nd.GetKey()))
+		logging.N2n.Error("status handler -- missing fields", zap.String("data", data), zap.String("hash", hash), zap.String("signature", signature), zap.String("node_type", nd.GetNodeTypeName()), zap.Int("set_index", nd.SetIndex), zap.String("key", nd.GetKey()))
 		return
 	}
 	if ok, err := ValidateSignatureTime(data); !ok {
-		logging.N2n.Error("status handler -- validate time failed", zap.Any("error", err), zap.String("node_type", nd.GetNodeTypeName()), zap.Int("set_index", nd.SetIndex), zap.Any("key", nd.GetKey()))
+		logging.N2n.Error("status handler -- validate time failed", zap.Error(err), zap.String("node_type", nd.GetNodeTypeName()), zap.Int("set_index", nd.SetIndex), zap.String("key", nd.GetKey()))
 		return
 	}
 	/*
@@ -114,13 +114,13 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		} */
 	if ok, err := nd.Verify(signature, hash); !ok || err != nil {
-		logging.N2n.Error("status handler -- signature failed", zap.Any("error", err), zap.String("node_type", nd.GetNodeTypeName()), zap.Int("set_index", nd.SetIndex), zap.Any("key", nd.GetKey()))
+		logging.N2n.Error("status handler -- signature failed", zap.Error(err), zap.String("node_type", nd.GetNodeTypeName()), zap.Int("set_index", nd.SetIndex), zap.String("key", nd.GetKey()))
 		return
 	}
 	nd.SetLastActiveTime(time.Now().UTC())
 	if nd.GetStatus() == NodeStatusInactive {
 		nd.SetStatus(NodeStatusActive)
-		logging.N2n.Info("Node active", zap.String("node_type", nd.GetNodeTypeName()), zap.Int("set_index", nd.SetIndex), zap.Any("key", nd.GetKey()))
+		logging.N2n.Info("Node active", zap.String("node_type", nd.GetNodeTypeName()), zap.Int("set_index", nd.SetIndex), zap.String("key", nd.GetKey()))
 	}
 	info := Self.Underlying().Info
 	logging.N2n.Info("status handler -- sending data", zap.Any("data", info))

--- a/code/go/0chain.net/chaincore/node/n2n_push2pull.go
+++ b/code/go/0chain.net/chaincore/node/n2n_push2pull.go
@@ -71,7 +71,7 @@ func pullEntityHandler(ctx context.Context, nd *Node, uri string, handler datast
 		duration := time.Since(start)
 		if err != nil {
 			logging.N2n.Error("message pull", zap.String("from", nd.GetPseudoName()),
-				zap.String("to", Self.Underlying().GetPseudoName()), zap.String("handler", uri), zap.Duration("duration", duration), zap.String("entity", entityName), zap.Any("id", entity.GetKey()), zap.Error(err))
+				zap.String("to", Self.Underlying().GetPseudoName()), zap.String("handler", uri), zap.Duration("duration", duration), zap.String("entity", entityName), zap.String("id", entity.GetKey()), zap.Error(err))
 			return nil, err
 		}
 		//N2n.Debug("message pull", zap.String("from", nd.GetPseudoName()), zap.String("to", Self.Underlying().GetPseudoName()), zap.String("handler", uri), zap.Duration("duration", duration), zap.String("entity", entityName), zap.Any("id", entity.GetKey()))

--- a/code/go/0chain.net/chaincore/node/n2n_request.go
+++ b/code/go/0chain.net/chaincore/node/n2n_request.go
@@ -317,7 +317,7 @@ func RequestEntityHandler(uri string, options *SendOptions, entityMetadata datas
 					zap.String("handler", uri),
 					zap.String("entity", eName),
 					zap.Any("params", params),
-					zap.Any("status_code", resp.StatusCode),
+					zap.Int("status_code", resp.StatusCode),
 					zap.String("response", data))
 				return false
 			}
@@ -362,7 +362,7 @@ func RequestEntityHandler(uri string, options *SendOptions, entityMetadata datas
 				zap.Duration("duration", duration),
 				zap.String("handler", uri),
 				zap.String("entity", eName),
-				zap.Any("id", entity.GetKey()),
+				zap.String("id", entity.GetKey()),
 				zap.Any("params", params),
 				zap.String("codec", resp.Header.Get(HeaderRequestCODEC)))
 			_, err = handler(ctx, entity)

--- a/code/go/0chain.net/chaincore/node/n2n_send.go
+++ b/code/go/0chain.net/chaincore/node/n2n_send.go
@@ -37,7 +37,7 @@ func (np *Pool) SendAll(ctx context.Context, handler SendHandler) []*Node {
 	defer func() {
 		if time.Since(ts) > time.Second*3 {
 			logging.Logger.Warn("Send to all slow - more than 3 seconds",
-				zap.Any("duration", time.Since(ts)),
+				zap.Duration("duration", time.Since(ts)),
 				zap.Int("num", np.Size()))
 		}
 	}()
@@ -328,8 +328,8 @@ func SendEntityHandler(uri string, options *SendOptions) EntitySendHandler {
 				zap.String("handler", uri),
 				zap.Duration("duration", time.Since(ts)),
 				zap.String("entity", entity.GetEntityMetadata().GetName()),
-				zap.Any("id", entity.GetKey()),
-				zap.Any("err", err))
+				zap.String("id", entity.GetKey()),
+				zap.Error(err))
 			switch err {
 			case nil:
 			default:
@@ -337,7 +337,7 @@ func SendEntityHandler(uri string, options *SendOptions) EntitySendHandler {
 				if ok && ue.Unwrap() != context.Canceled {
 					receiver.AddSendErrors(1)
 					receiver.AddErrorCount(1)
-					logging.N2n.Error("sending", zap.String("from", selfNode.GetPseudoName()), zap.String("to", receiver.GetPseudoName()), zap.String("handler", uri), zap.Duration("duration", time.Since(ts)), zap.String("entity", entity.GetEntityMetadata().GetName()), zap.Any("id", entity.GetKey()), zap.Error(err))
+					logging.N2n.Error("sending", zap.String("from", selfNode.GetPseudoName()), zap.String("to", receiver.GetPseudoName()), zap.String("handler", uri), zap.Duration("duration", time.Since(ts)), zap.String("entity", entity.GetEntityMetadata().GetName()), zap.String("id", entity.GetKey()), zap.Error(err))
 				}
 				return false
 			}
@@ -354,7 +354,7 @@ func SendEntityHandler(uri string, options *SendOptions) EntitySendHandler {
 				sizer.Update(int64(len(data)))
 			}
 			if !(resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent) {
-				logging.N2n.Error("sending", zap.String("from", selfNode.GetPseudoName()), zap.String("to", receiver.GetPseudoName()), zap.String("handler", uri), zap.Duration("duration", time.Since(ts)), zap.String("entity", entity.GetEntityMetadata().GetName()), zap.Any("id", entity.GetKey()), zap.Any("status_code", resp.StatusCode))
+				logging.N2n.Error("sending", zap.String("from", selfNode.GetPseudoName()), zap.String("to", receiver.GetPseudoName()), zap.String("handler", uri), zap.Duration("duration", time.Since(ts)), zap.String("entity", entity.GetEntityMetadata().GetName()), zap.String("id", entity.GetKey()), zap.Int("status_code", resp.StatusCode))
 				return false
 			}
 			return true
@@ -405,13 +405,13 @@ func validateSendRequest(sender *Node, r *http.Request) bool {
 	reqTS := r.Header.Get(HeaderRequestTimeStamp)
 	if reqTS == "" {
 		logging.N2n.Error("message received - no timestamp for the message", zap.String("from", sender.GetPseudoName()),
-			zap.String("to", selfPseudoName), zap.String("handler", r.RequestURI), zap.String("entity", entityName), zap.Any("id", entityID))
+			zap.String("to", selfPseudoName), zap.String("handler", r.RequestURI), zap.String("entity", entityName), zap.String("id", entityID))
 		return false
 	}
 	reqTSn, err := strconv.ParseInt(reqTS, 10, 64)
 	if err != nil {
 		logging.N2n.Error("message received", zap.String("from", sender.GetPseudoName()),
-			zap.String("to", selfPseudoName), zap.String("handler", r.RequestURI), zap.String("entity", entityName), zap.Any("id", entityID), zap.Error(err))
+			zap.String("to", selfPseudoName), zap.String("handler", r.RequestURI), zap.String("entity", entityName), zap.String("id", entityID), zap.Error(err))
 		return false
 	}
 	sender.SetStatus(NodeStatusActive)
@@ -571,10 +571,10 @@ func ToN2NReceiveEntityHandler(handler datastore.JSONEntityReqResponderF, option
 			duration := time.Since(start)
 			if err != nil {
 				logging.N2n.Error("message received", zap.String("from", sender.GetPseudoName()),
-					zap.String("to", Self.Underlying().GetPseudoName()), zap.String("handler", r.RequestURI), zap.Duration("duration", duration), zap.String("entity", entityName), zap.Any("id", entity.GetKey()), zap.Error(err))
+					zap.String("to", Self.Underlying().GetPseudoName()), zap.String("handler", r.RequestURI), zap.Duration("duration", duration), zap.String("entity", entityName), zap.String("id", entity.GetKey()), zap.Error(err))
 			} else {
 				logging.N2n.Info("message received", zap.String("from", sender.GetPseudoName()),
-					zap.String("to", Self.Underlying().GetPseudoName()), zap.String("handler", r.RequestURI), zap.Duration("duration", duration), zap.String("entity", entityName), zap.Any("id", entity.GetKey()))
+					zap.String("to", Self.Underlying().GetPseudoName()), zap.String("handler", r.RequestURI), zap.Duration("duration", duration), zap.String("entity", entityName), zap.String("id", entity.GetKey()))
 			}
 			sender.AddReceived(1)
 

--- a/code/go/0chain.net/chaincore/node/node_pool_scorer.go
+++ b/code/go/0chain.net/chaincore/node/node_pool_scorer.go
@@ -53,7 +53,7 @@ func (hps *HashPoolScorer) ScoreHash(np *Pool, hash []byte) []*Score {
 func (hps *HashPoolScorer) ScoreHashString(np *Pool, hash string) []*Score {
 	hBytes, err := hex.DecodeString(hash)
 	if err != nil {
-		logging.Logger.Info("decode failed for hash", zap.String("hash", hash), zap.Error(err))
+		logging.Logger.Error("decode failed for hash", zap.String("hash", hash), zap.Error(err))
 		return nil
 	}
 	return hps.ScoreHash(np, hBytes)

--- a/code/go/0chain.net/chaincore/node/worker.go
+++ b/code/go/0chain.net/chaincore/node/worker.go
@@ -23,7 +23,7 @@ const (
 func (np *Pool) StatusMonitor(ctx context.Context, startRound int64, waitC chan struct{}) {
 	logging.N2n.Debug("[monitor] start status monitor",
 		zap.Int64("starting round", startRound),
-		zap.Any("node type", NodeTypeNames[np.Type].Code))
+		zap.String("node type", NodeTypeNames[np.Type].Code))
 	np.statusMonitor(ctx, startRound)
 	updateTimer := time.NewTimer(time.Second)
 	monitorTimer := time.NewTimer(time.Second)
@@ -31,7 +31,7 @@ func (np *Pool) StatusMonitor(ctx context.Context, startRound int64, waitC chan 
 		select {
 		case <-ctx.Done():
 			logging.N2n.Debug("[monitor] status monitor canceled, StatusMonitor",
-				zap.Any("node type", NodeTypeNames[np.Type].Code),
+				zap.String("node type", NodeTypeNames[np.Type].Code),
 				zap.Int64("start round", startRound))
 			close(waitC)
 			return
@@ -87,7 +87,7 @@ func (np *Pool) statusMonitor(ctx context.Context, startRound int64) {
 		select {
 		case <-ctx.Done():
 			logging.N2n.Debug("[monitor] status monitor canceled - statusMonitor",
-				zap.Any("node type", NodeTypeNames[np.Type].Code),
+				zap.String("node type", NodeTypeNames[np.Type].Code),
 				zap.Int64("starting round", startRound))
 			return
 		default:
@@ -167,7 +167,7 @@ func (np *Pool) statusMonitor(ctx context.Context, startRound int64) {
 				logging.N2n.Info("Node active",
 					zap.String("node_type", nd.GetNodeTypeName()),
 					zap.Int("set_index", nd.SetIndex),
-					zap.Any("key", nd.GetKey()))
+					zap.String("key", nd.GetKey()))
 			}
 			nd.SetErrorCount(0)
 			nd.SetStatus(NodeStatusActive)
@@ -181,7 +181,7 @@ func (n *Node) MemoryUsage() {
 	ticker := time.NewTicker(5 * time.Minute)
 	for {
 		<-ticker.C
-		common.LogRuntime(logging.MemUsage, zap.Any(n.Description, n.SetIndex))
+		common.LogRuntime(logging.MemUsage, zap.Int(n.Description, n.SetIndex))
 
 		// Average time duration to add go routine logs to 0chain.log file => 618.184µs
 		// Average increase in file size for each update => 10 kB

--- a/code/go/0chain.net/chaincore/round/entity.go
+++ b/code/go/0chain.net/chaincore/round/entity.go
@@ -324,7 +324,7 @@ func (r *Round) AddNotarizedBlock(b *block.Block) {
 			zap.Int64("round", r.GetRoundNumber()), zap.String("hash", fb.Hash),
 			zap.Int64("fb_RRS", fb.GetRoundRandomSeed()),
 			zap.Int("fb_toc", fb.RoundTimeoutCount),
-			zap.Any("fb_Sender", fb.MinerID))
+			zap.String("fb_Sender", fb.MinerID))
 		// remove the old block with the same rank and add it below
 		r.notarizedBlocks = append(r.notarizedBlocks[:found], r.notarizedBlocks[found+1:]...)
 	}
@@ -570,8 +570,8 @@ func (r *Round) GetMinerRank(miner *node.Node) int {
 	}
 	if miner.SetIndex >= len(r.minerPerm) {
 		logging.Logger.Warn("get miner rank -- the node index in the permutation is missing. Returns: -1.",
-			zap.Any("r.minerPerm", r.minerPerm), zap.Any("set_index", miner.SetIndex),
-			zap.Any("node", miner))
+			zap.Ints("r.minerPerm", r.minerPerm), zap.Int("set_index", miner.SetIndex),
+			zap.String("node", miner.ID))
 		return -1
 	}
 	return r.minerPerm[miner.SetIndex]
@@ -581,23 +581,23 @@ func (r *Round) GetMinerRank(miner *node.Node) int {
 func (r *Round) GetMinersByRank(nodes []*node.Node) []*node.Node {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
-	logging.Logger.Info("get miners by rank", zap.Any("num_miners", len(nodes)),
-		zap.Any("round", r.Number), zap.Any("r.minerPerm", r.minerPerm))
+	logging.Logger.Info("get miners by rank", zap.Int("num_miners", len(nodes)),
+		zap.Int64("round", r.Number), zap.Ints("r.minerPerm", r.minerPerm))
 	sort.Slice(nodes, func(i, j int) bool {
 		idxi, idxj := 0, 0
 		if nodes[i].SetIndex < len(r.minerPerm) {
 			idxi = r.minerPerm[nodes[i].SetIndex]
 		} else {
 			logging.Logger.Warn("get miner by rank -- the node index in the permutation is missing",
-				zap.Any("r.minerPerm", r.minerPerm), zap.Any("set_index", nodes[i].SetIndex),
-				zap.Any("node", nodes[i]))
+				zap.Ints("r.minerPerm", r.minerPerm), zap.Int("set_index", nodes[i].SetIndex),
+				zap.String("node", nodes[i].ID))
 		}
 		if nodes[j].SetIndex < len(r.minerPerm) {
 			idxj = r.minerPerm[nodes[j].SetIndex]
 		} else {
 			logging.Logger.Warn("get miner by rank -- the node index in the permutation is missing",
-				zap.Any("r.minerPerm", r.minerPerm), zap.Any("set_index", nodes[j].SetIndex),
-				zap.Any("node", nodes[j]))
+				zap.Ints("r.minerPerm", r.minerPerm), zap.Int("set_index", nodes[j].SetIndex),
+				zap.String("node", nodes[j].ID))
 		}
 		return idxi > idxj
 	})

--- a/code/go/0chain.net/chaincore/smartcontract/bccontext.go
+++ b/code/go/0chain.net/chaincore/smartcontract/bccontext.go
@@ -40,7 +40,7 @@ func (bc *BCContext) GetNodepoolInfo() interface{} {
 		pm.Port = strconv.Itoa(n.Port)
 		typename, err := node.GetNodeTypeName(n)
 		if err != nil {
-			logging.Logger.Info(err.Error())
+			logging.Logger.Error(err.Error())
 		} else {
 			pm.Type = typename
 		}

--- a/code/go/0chain.net/chaincore/transaction/entity.go
+++ b/code/go/0chain.net/chaincore/transaction/entity.go
@@ -423,7 +423,7 @@ func (t *Transaction) ComputeOutputHash() string {
 /*VerifyOutputHash - Verify the hash of the transaction */
 func (t *Transaction) VerifyOutputHash(ctx context.Context) error {
 	if t.OutputHash != t.ComputeOutputHash() {
-		logging.Logger.Info("verify output hash (hash mismatch)", zap.String("hash", t.OutputHash), zap.String("computed_hash", t.ComputeOutputHash()), zap.String("hash_data", t.TransactionOutput), zap.String("txn", datastore.ToJSON(t).String()))
+		logging.Logger.Error("verify output hash (hash mismatch)", zap.String("hash", t.OutputHash), zap.String("computed_hash", t.ComputeOutputHash()), zap.String("hash_data", t.TransactionOutput), zap.String("txn", datastore.ToJSON(t).String()))
 		return common.NewError("hash_mismatch", fmt.Sprintf("The hash of the output doesn't match with the provided hash: %v %v %v %v", t.Hash, t.OutputHash, t.ComputeOutputHash(), t.TransactionOutput))
 	}
 	return nil

--- a/code/go/0chain.net/chaincore/transaction/handler.go
+++ b/code/go/0chain.net/chaincore/transaction/handler.go
@@ -54,7 +54,7 @@ func PutTransaction(ctx context.Context, entity datastore.Entity) (interface{}, 
 	}
 	err = entity.GetEntityMetadata().GetStore().Write(ctx, txn)
 	if err != nil {
-		logging.Logger.Info("put transaction", zap.Any("error", err), zap.Any("txn", txn.Hash), zap.Any("txn_obj", datastore.ToJSON(txn).String()))
+		logging.Logger.Error("put transaction", zap.Error(err), zap.String("txn", txn.Hash), zap.String("txn_obj", datastore.ToJSON(txn).String()))
 		return nil, err
 	}
 
@@ -88,7 +88,7 @@ func PutTransactionWithoutVerifySig(ctx context.Context, entity datastore.Entity
 	}
 	err = entity.GetEntityMetadata().GetStore().Write(ctx, txn)
 	if err != nil {
-		logging.Logger.Info("put transaction", zap.Any("error", err), zap.Any("txn", txn.Hash), zap.Any("txn_obj", datastore.ToJSON(txn).String()))
+		logging.Logger.Error("put transaction", zap.Error(err), zap.String("txn", txn.Hash), zap.String("txn_obj", datastore.ToJSON(txn).String()))
 		return nil, err
 	}
 

--- a/code/go/0chain.net/chaincore/transaction/worker.go
+++ b/code/go/0chain.net/chaincore/transaction/worker.go
@@ -62,7 +62,7 @@ func CleanupWorker(ctx context.Context) {
 				logging.Logger.Error("Error in IterateCollectionAsc", zap.Error(err))
 			}
 			if len(invalidTxns) > 0 {
-				logging.Logger.Info("transactions cleanup", zap.String("collection", collectionName), zap.Int("invalid_count", len(invalidTxns)), zap.Any("collection_size", mstore.GetCollectionSize(cctx, transactionEntityMetadata, collectionName)))
+				logging.Logger.Info("transactions cleanup", zap.String("collection", collectionName), zap.Int("invalid_count", len(invalidTxns)), zap.Int64("collection_size", mstore.GetCollectionSize(cctx, transactionEntityMetadata, collectionName)))
 				err = transactionEntityMetadata.GetStore().MultiDelete(cctx, transactionEntityMetadata, invalidTxns)
 				if err != nil {
 					logging.Logger.Error("Error in MultiDelete", zap.Error(err))

--- a/code/go/0chain.net/core/memorystore/collection.go
+++ b/code/go/0chain.net/core/memorystore/collection.go
@@ -77,12 +77,12 @@ func (ms *Store) iterateCollection(ctx context.Context, entityMetadata datastore
 			if ok {
 				score, err := strconv.ParseInt(string(scoredata), 10, 63)
 				if err != nil {
-					Logger.Debug("iterator error", zap.Any("score", scoredata), zap.Any("type", fmt.Sprintf("%T", bkeys[2*i+1])))
+					Logger.Debug("iterator error", zap.ByteString("score", scoredata), zap.String("type", fmt.Sprintf("%T", bkeys[2*i+1])))
 					return err
 				}
 				ce.SetCollectionScore(score)
 			} else {
-				Logger.Info("iterator error", zap.Any("score", bkeys[2*i+1]), zap.Any("type", fmt.Sprintf("%T", bkeys[2*i+1])))
+				Logger.Info("iterator error", zap.Any("score", bkeys[2*i+1]), zap.String("type", fmt.Sprintf("%T", bkeys[2*i+1])))
 			}
 		}
 		err = ms.MultiRead(ctx, entityMetadata, keys[:count], bucket)

--- a/code/go/0chain.net/core/memorystore/connection.go
+++ b/code/go/0chain.net/core/memorystore/connection.go
@@ -46,7 +46,7 @@ func GetInfo() {
 			panic("invalid setup")
 		}
 		if re.MatchString(info) {
-			Logger.Info("Redis is not ready to take connections", zap.Any("retry", tries))
+			Logger.Info("Redis is not ready to take connections", zap.Int("retry", tries))
 			time.Sleep(delay)
 		} else {
 			break

--- a/code/go/0chain.net/core/memorystore/worker.go
+++ b/code/go/0chain.net/core/memorystore/worker.go
@@ -87,7 +87,7 @@ func (mcp *MemoryDBChunkProcessor) Process(ctx context.Context, chunk datastore.
 	store := mcp.EntityMetadata.GetStore()
 	err := store.MultiWrite(lctx, mcp.EntityMetadata, mchunk.Buffer)
 	if err != nil {
-		Logger.Info("memorystore - memory chunk process", zap.Any("error", err))
+		Logger.Info("memorystore - memory chunk process", zap.Error(err))
 	}
 }
 

--- a/code/go/0chain.net/core/persistencestore/connection.go
+++ b/code/go/0chain.net/core/persistencestore/connection.go
@@ -77,11 +77,11 @@ func initSession(delay time.Duration, maxTries int) error {
 		start := time.Now()
 		s, err := cluster.CreateSession()
 		if err != nil {
-			Logger.Error("error creating session", zap.Any("retry", tries), zap.Error(err))
+			Logger.Error("error creating session", zap.Int("retry", tries), zap.Error(err))
 			time.Sleep(delay)
 		} else {
 			Session = NewSession(s)
-			Logger.Info("time to create cassandra session", zap.Duration("total_duration", time.Since(start0)), zap.Any("try_duration", time.Since(start)))
+			Logger.Info("time to create cassandra session", zap.Duration("total_duration", time.Since(start0)), zap.Duration("try_duration", time.Since(start)))
 			return nil
 		}
 	}

--- a/code/go/0chain.net/miner/chain.go
+++ b/code/go/0chain.net/miner/chain.go
@@ -197,7 +197,7 @@ func (mc *Chain) PushBlockMessageChannel(bm *BlockMessage) {
 		case mc.blockMessageChannel <- bm:
 		case <-time.After(3 * time.Second):
 			logging.Logger.Warn("push block message to channel timeout",
-				zap.Any("message type", bm.Type))
+				zap.Int("message type", bm.Type))
 		}
 	}()
 }
@@ -390,18 +390,18 @@ func StartChainRequestHandler(_ context.Context, req *http.Request) (interface{}
 
 	r, err := strconv.Atoi(req.FormValue("round"))
 	if err != nil {
-		logging.Logger.Error("failed to send start chain", zap.Any("error", err))
+		logging.Logger.Error("failed to send start chain", zap.Error(err))
 		return nil, err
 	}
 
 	mb := mc.GetMagicBlock(int64(r))
 	if mb == nil || !mb.Miners.HasNode(nodeID) {
-		logging.Logger.Error("failed to send start chain", zap.Any("id", nodeID))
+		logging.Logger.Error("failed to send start chain", zap.String("id", nodeID))
 		return nil, common.NewError("failed to send start chain", "miner is not in active set")
 	}
 
 	if mc.GetCurrentRound() != int64(r) {
-		logging.Logger.Error("failed to send start chain -- different rounds", zap.Any("current_round", mc.GetCurrentRound()), zap.Any("requested_round", r))
+		logging.Logger.Error("failed to send start chain -- different rounds", zap.Int64("current_round", mc.GetCurrentRound()), zap.Int("requested_round", r))
 		return nil, common.NewError("failed to send start chain", fmt.Sprintf("differt_rounds -- current_round: %v, requested_round: %v", mc.GetCurrentRound(), r))
 	}
 	message := datastore.GetEntityMetadata("start_chain").Instance().(*StartChain)

--- a/code/go/0chain.net/miner/m_handler.go
+++ b/code/go/0chain.net/miner/m_handler.go
@@ -462,7 +462,7 @@ func notarizedBlockHandler(ctx context.Context, entity datastore.Entity) (
 	//reject cur_round -2 is a locked round, there can't be new notarization important for us
 	if nb.Round < mc.GetCurrentRound()-1 {
 		logging.Logger.Debug("notarized block handler (round older than the current round)",
-			zap.String("block", nb.Hash), zap.Any("round", nb.Round))
+			zap.String("block", nb.Hash), zap.Int64("round", nb.Round))
 		return
 	}
 

--- a/code/go/0chain.net/miner/miner/handler.go
+++ b/code/go/0chain.net/miner/miner/handler.go
@@ -38,7 +38,7 @@ func ConfigUpdateHandler(w http.ResponseWriter, r *http.Request) {
 func ConfigUpdateAllHandler(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseForm()
 	if err != nil {
-		logging.Logger.Error("failed to parse update config form", zap.Any("error", err))
+		logging.Logger.Error("failed to parse update config form", zap.Error(err))
 		return
 	}
 	mb := chain.GetServerChain().GetCurrentMagicBlock()
@@ -48,7 +48,7 @@ func ConfigUpdateAllHandler(w http.ResponseWriter, r *http.Request) {
 			go func(miner *node.Node) {
 				resp, err := http.PostForm(miner.GetN2NURLBase()+updateConfigURL, r.Form)
 				if err != nil {
-					logging.Logger.Error("failed to update other miner's config", zap.Any("miner", miner.GetKey()), zap.Any("response", resp), zap.Any("error", err))
+					logging.Logger.Error("failed to update other miner's config", zap.String("miner", miner.GetKey()), zap.Any("response", resp), zap.Error(err))
 					return
 				}
 				defer resp.Body.Close()

--- a/code/go/0chain.net/miner/miner/miner.go
+++ b/code/go/0chain.net/miner/miner/miner.go
@@ -166,7 +166,7 @@ func main() {
 		}
 
 		logging.Logger.Info("Inside nonGenesis", zap.String("host_name", hostName),
-			zap.Any("n2n_host_name", n2nHostName), zap.Int("port_num", portNum), zap.String("path", path), zap.String("description", description))
+			zap.String("n2n_host_name", n2nHostName), zap.Int("port_num", portNum), zap.String("path", path), zap.String("description", description))
 
 		node.Self.Underlying().Host = hostName
 		node.Self.Underlying().N2NHost = n2nHostName
@@ -175,7 +175,7 @@ func main() {
 		node.Self.Underlying().Description = description
 	} else {
 		if initStateErr != nil {
-			logging.Logger.Panic("Failed to read initialStates", zap.Any("Error", initStateErr))
+			logging.Logger.Panic("Failed to read initialStates", zap.Error(initStateErr))
 		}
 	}
 
@@ -206,7 +206,7 @@ func main() {
 
 	logging.Logger.Info("Starting miner", zap.String("build_tag", build.BuildTag), zap.String("go_version", runtime.Version()), zap.Int("available_cpus", runtime.NumCPU()), zap.String("port", address))
 	logging.Logger.Info("Chain info", zap.String("chain_id", config.GetServerChainID()), zap.String("mode", mode))
-	logging.Logger.Info("Self identity", zap.Any("set_index", node.Self.Underlying().SetIndex), zap.Any("id", node.Self.Underlying().GetKey()))
+	logging.Logger.Info("Self identity", zap.Int("set_index", node.Self.Underlying().SetIndex), zap.String("id", node.Self.Underlying().GetKey()))
 
 	registerInConductor(node.Self.Underlying().GetKey())
 
@@ -306,7 +306,7 @@ func main() {
 
 		if err = dkgShare.Verify(bls.ComputeIDdkg(node.Self.Underlying().GetKey()), mpks); err != nil {
 			if mc.ChainConfig.IsViewChangeEnabled() {
-				logging.Logger.Error("Failed to verify genesis dkg", zap.Any("error", err))
+				logging.Logger.Error("Failed to verify genesis dkg", zap.Error(err))
 			} else {
 				logging.Logger.Panic(fmt.Sprintf("Failed to verify genesis dkg: ERROR: %v", err.Error()))
 			}

--- a/code/go/0chain.net/miner/miner/miner.go
+++ b/code/go/0chain.net/miner/miner/miner.go
@@ -230,7 +230,7 @@ func main() {
 			initProfHandlers(pprofMux)
 			go func() {
 				err2 := profServer.ListenAndServe()
-				logging.Logger.Info("Http server shut down", zap.Error(err2))
+				logging.Logger.Error("Http server shut down", zap.Error(err2))
 			}()
 		}
 

--- a/code/go/0chain.net/miner/miner/worker.go
+++ b/code/go/0chain.net/miner/miner/worker.go
@@ -144,14 +144,14 @@ func TransactionGenerator(c *chain.Chain, workdir string) {
 						if r < 25 {
 							txn, err = createSendTransaction(c, prng)
 							if err != nil {
-								logging.Logger.Info("transaction generator", zap.Error(err))
+								logging.Logger.Error("transaction generator", zap.Error(err))
 							}
 						} else {
 							txn = createDataTransaction(prng)
 						}
 						_, err = transaction.PutTransactionWithoutVerifySig(ctx, txn)
 						if err != nil {
-							logging.Logger.Info("transaction generator", zap.Error(err))
+							logging.Logger.Error("transaction generator", zap.Error(err))
 						}
 					}
 					wg.Done()
@@ -259,16 +259,16 @@ func GenerateClients(c *chain.Chain, numClients int, workdir string) {
 		//generous airdrop in dev/test mode :)
 		fee, err := currency.Int64ToCoin(prng.Int63n(10) + 1)
 		if err != nil {
-			logging.Logger.Info("client generator", zap.Error(err))
+			logging.Logger.Error("client generator", zap.Error(err))
 		}
 		val, err := currency.Int64ToCoin(prng.Int63n(100) * 10000000000)
 		if err != nil {
-			logging.Logger.Info("client generator", zap.Error(err))
+			logging.Logger.Error("client generator", zap.Error(err))
 		}
 		txn := ownerWallet.CreateSendTransaction(w.ClientID, val, "generous air drop! :)", fee)
 		_, err = transaction.PutTransactionWithoutVerifySig(tctx, txn)
 		if err != nil {
-			logging.Logger.Info("client generator", zap.Error(err))
+			logging.Logger.Error("client generator", zap.Error(err))
 		}
 	}
 	if c.ChainConfig.IsFaucetEnabled() {
@@ -277,7 +277,7 @@ func GenerateClients(c *chain.Chain, numClients int, workdir string) {
 			`{"name":"refill","input":{}}`, 0)
 		_, err := transaction.PutTransactionWithoutVerifySig(tctx, txn)
 		if err != nil {
-			logging.Logger.Info("client generator - faucet refill", zap.Error(err))
+			logging.Logger.Error("client generator - faucet refill", zap.Error(err))
 		}
 	}
 	logging.Logger.Info("generation of wallets complete", zap.Int("wallets", len(wallets)))

--- a/code/go/0chain.net/miner/miner/worker.go
+++ b/code/go/0chain.net/miner/miner/worker.go
@@ -117,13 +117,13 @@ func TransactionGenerator(c *chain.Chain, workdir string) {
 		}
 		select {
 		case <-ctx.Done():
-			logging.Logger.Info("transaction generation", zap.Any("timer_count", timerCount))
+			logging.Logger.Info("transaction generation", zap.Int64("timer_count", timerCount))
 			return
 		case <-timer.C:
 			timerCount++
 			txnCount := int32(txnMetadataProvider.GetStore().GetCollectionSize(ctx, txnMetadataProvider, collectionName))
 			if timerCount%300 == 0 {
-				logging.Logger.Info("transaction generation", zap.Any("txn_count", txnCount), zap.Any("blocks_per_miner", blocksPerMiner), zap.Any("num_txns", numTxns))
+				logging.Logger.Info("transaction generation", zap.Int32("txn_count", txnCount), zap.Float64("blocks_per_miner", blocksPerMiner), zap.Int32("num_txns", numTxns))
 			}
 			if float64(txnCount) >= blocksPerMiner*float64(8*numTxns) {
 				continue
@@ -144,14 +144,14 @@ func TransactionGenerator(c *chain.Chain, workdir string) {
 						if r < 25 {
 							txn, err = createSendTransaction(c, prng)
 							if err != nil {
-								logging.Logger.Info("transaction generator", zap.Any("error", err))
+								logging.Logger.Info("transaction generator", zap.Error(err))
 							}
 						} else {
 							txn = createDataTransaction(prng)
 						}
 						_, err = transaction.PutTransactionWithoutVerifySig(ctx, txn)
 						if err != nil {
-							logging.Logger.Info("transaction generator", zap.Any("error", err))
+							logging.Logger.Info("transaction generator", zap.Error(err))
 						}
 					}
 					wg.Done()
@@ -259,16 +259,16 @@ func GenerateClients(c *chain.Chain, numClients int, workdir string) {
 		//generous airdrop in dev/test mode :)
 		fee, err := currency.Int64ToCoin(prng.Int63n(10) + 1)
 		if err != nil {
-			logging.Logger.Info("client generator", zap.Any("error", err))
+			logging.Logger.Info("client generator", zap.Error(err))
 		}
 		val, err := currency.Int64ToCoin(prng.Int63n(100) * 10000000000)
 		if err != nil {
-			logging.Logger.Info("client generator", zap.Any("error", err))
+			logging.Logger.Info("client generator", zap.Error(err))
 		}
 		txn := ownerWallet.CreateSendTransaction(w.ClientID, val, "generous air drop! :)", fee)
 		_, err = transaction.PutTransactionWithoutVerifySig(tctx, txn)
 		if err != nil {
-			logging.Logger.Info("client generator", zap.Any("error", err))
+			logging.Logger.Info("client generator", zap.Error(err))
 		}
 	}
 	if c.ChainConfig.IsFaucetEnabled() {
@@ -277,7 +277,7 @@ func GenerateClients(c *chain.Chain, numClients int, workdir string) {
 			`{"name":"refill","input":{}}`, 0)
 		_, err := transaction.PutTransactionWithoutVerifySig(tctx, txn)
 		if err != nil {
-			logging.Logger.Info("client generator - faucet refill", zap.Any("error", err))
+			logging.Logger.Info("client generator - faucet refill", zap.Error(err))
 		}
 	}
 	logging.Logger.Info("generation of wallets complete", zap.Int("wallets", len(wallets)))

--- a/code/go/0chain.net/miner/protocol_block.go
+++ b/code/go/0chain.net/miner/protocol_block.go
@@ -184,7 +184,7 @@ func (mc *Chain) verifySmartContracts(ctx context.Context, b *block.Block) error
 		if txn.TransactionType == transaction.TxnTypeSmartContract {
 			err := txn.VerifyOutputHash(ctx)
 			if err != nil {
-				logging.Logger.Error("Smart contract output verification failed", zap.Any("error", err), zap.Any("output", txn.TransactionOutput))
+				logging.Logger.Error("Smart contract output verification failed", zap.Error(err), zap.String("output", txn.TransactionOutput))
 				return common.NewError("txn_output_verification_failed", "Transaction output hash verification failed")
 			}
 		}
@@ -400,9 +400,9 @@ func (mc *Chain) VerifyBlock(ctx context.Context, b *block.Block) (
 	bpTimer.UpdateSince(start)
 	logging.Logger.Debug("SignBlock finished", zap.String("block", b.Hash), zap.Duration("spent", time.Since(cur)))
 
-	logging.Logger.Info("verify block successful", zap.Any("round", b.Round),
-		zap.Int("block_size", len(b.Txns)), zap.Any("time", time.Since(start)),
-		zap.Any("block", b.Hash), zap.String("prev_block", b.PrevHash),
+	logging.Logger.Info("verify block successful", zap.Int64("round", b.Round),
+		zap.Int("block_size", len(b.Txns)), zap.Duration("time", time.Since(start)),
+		zap.String("block", b.Hash), zap.String("prev_block", b.PrevHash),
 		zap.String("state_hash", util.ToHex(b.ClientStateHash)),
 		zap.Int8("state_status", b.GetStateStatus()))
 
@@ -505,13 +505,13 @@ func (mc *Chain) ValidateTransactions(ctx context.Context, b *block.Block) error
 				}
 				if txn.OutputHash == "" {
 					cancel = true
-					logging.Logger.Error("validate transactions - no output hash", zap.Any("round", b.Round), zap.Any("block", b.Hash), zap.String("txn", datastore.ToJSON(txn).String()))
+					logging.Logger.Error("validate transactions - no output hash", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.String("txn", datastore.ToJSON(txn).String()))
 					return
 				}
 				err := txn.ValidateWrtTimeForBlock(ctx, b.CreationDate, !aggregate)
 				if err != nil {
 					cancel = true
-					logging.Logger.Error("validate transactions", zap.Any("round", b.Round), zap.Any("block", b.Hash), zap.String("txn", datastore.ToJSON(txn).String()), zap.Error(err))
+					logging.Logger.Error("validate transactions", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.String("txn", datastore.ToJSON(txn).String()), zap.Error(err))
 					return
 				}
 
@@ -554,7 +554,7 @@ func (mc *Chain) ValidateTransactions(ctx context.Context, b *block.Block) error
 				return ctx.Err()
 			case result := <-validChannel:
 				if roundMismatch {
-					logging.Logger.Info("validate transactions (round mismatch)", zap.Any("round", b.Round), zap.Any("block", b.Hash), zap.Any("current_round", mc.GetCurrentRound()))
+					logging.Logger.Info("validate transactions (round mismatch)", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Int64("current_round", mc.GetCurrentRound()))
 					return ErrRoundMismatch
 				}
 				if !result {
@@ -999,7 +999,7 @@ func (mc *Chain) generateBlock(ctx context.Context, b *block.Block,
 		for _, txn := range iterInfo.pastTxns {
 			keys = append(keys, txn.GetKey())
 		}
-		logging.Logger.Info("generate block (found txns very old)", zap.Any("round", b.Round),
+		logging.Logger.Info("generate block (found txns very old)", zap.Int64("round", b.Round),
 			zap.Int("num_invalid_txns", len(iterInfo.invalidTxns)), zap.Strings("txn_hashes", keys))
 		go func() {
 			if err := mc.deleteTxns(iterInfo.invalidTxns); err != nil {
@@ -1012,19 +1012,19 @@ func (mc *Chain) generateBlock(ctx context.Context, b *block.Block,
 		for _, txn := range iterInfo.pastTxns {
 			keys = append(keys, txn.GetKey())
 		}
-		logging.Logger.Info("generate block (found pastTxns transactions)", zap.Any("round", b.Round), zap.Int("txn num", len(keys)))
+		logging.Logger.Info("generate block (found pastTxns transactions)", zap.Int64("round", b.Round), zap.Int("txn num", len(keys)))
 	}
 	if iterInfo.roundMismatch {
-		logging.Logger.Debug("generate block (round mismatch)", zap.Any("round", b.Round), zap.Any("current_round", mc.GetCurrentRound()))
+		logging.Logger.Debug("generate block (round mismatch)", zap.Int64("round", b.Round), zap.Int64("current_round", mc.GetCurrentRound()))
 		return ErrRoundMismatch
 	}
 	if iterInfo.roundTimeout {
-		logging.Logger.Debug("generate block (round timeout)", zap.Any("round", b.Round), zap.Any("current_round", mc.GetCurrentRound()))
+		logging.Logger.Debug("generate block (round timeout)", zap.Int64("round", b.Round), zap.Int64("current_round", mc.GetCurrentRound()))
 		return ErrRoundTimeout
 	}
 	if iterInfo.reInclusionErr != nil {
 		logging.Logger.Error("generate block (txn reinclusion check)",
-			zap.Any("round", b.Round), zap.Error(iterInfo.reInclusionErr))
+			zap.Int64("round", b.Round), zap.Error(iterInfo.reInclusionErr))
 	}
 
 	switch err {

--- a/code/go/0chain.net/miner/protocol_bls.go
+++ b/code/go/0chain.net/miner/protocol_bls.go
@@ -181,7 +181,7 @@ func (mc *Chain) GetBlsMessageForRound(r *round.Round) (string, error) {
 		zap.Int("round_timeout", r.GetTimeoutCount()),
 		zap.Int64("prev_rseed", pr.GetRandomSeed()),
 		zap.String("prev round vrf random seed", prrs),
-		zap.Any("bls_msg", blsMsg))
+		zap.String("bls_msg", blsMsg))
 
 	return blsMsg, nil
 }
@@ -289,7 +289,7 @@ func (mc *Chain) AddVRFShare(ctx context.Context, mr *Round, vrfs *round.VRFShar
 		// cache the vrf share if the previous round is not ready yet
 		mr.vrfSharesCache.add(vrfs)
 
-		Logger.Warn("failed to get bls message", zap.Any("vrfs_share", vrfs.Share), zap.Any("round", mr.Round))
+		Logger.Warn("failed to get bls message", zap.String("vrfs_share", vrfs.Share), zap.Any("round", mr.Round))
 		return false
 	}
 
@@ -318,8 +318,8 @@ func verifyVRFShare(r *Round, vrfs *round.VRFShare, blsMsg string, dkg *bls.DKG)
 
 	if err := share.SetHexString(vrfs.Share); err != nil {
 		Logger.Error("failed to decode share hex string",
-			zap.Any("vrfs_share", vrfs.Share),
-			zap.Any("message", blsMsg))
+			zap.String("vrfs_share", vrfs.Share),
+			zap.String("message", blsMsg))
 		return false
 	}
 
@@ -327,10 +327,10 @@ func verifyVRFShare(r *Round, vrfs *round.VRFShare, blsMsg string, dkg *bls.DKG)
 		stringID := (&partyID).GetHexString()
 		pi := dkg.GetPublicKeyByID(partyID)
 		Logger.Error("failed to verify share",
-			zap.Any("share", share.GetHexString()),
-			zap.Any("message", blsMsg),
-			zap.Any("from", stringID),
-			zap.Any("pi", pi.GetHexString()),
+			zap.String("share", share.GetHexString()),
+			zap.String("message", blsMsg),
+			zap.String("from", stringID),
+			zap.String("pi", pi.GetHexString()),
 			zap.String("node_id", vrfs.GetParty().GetKey()),
 			zap.Int64("round", vrfs.Round),
 			zap.Int64("dkg_starting_round", dkg.StartingRound),
@@ -343,9 +343,9 @@ func verifyVRFShare(r *Round, vrfs *round.VRFShare, blsMsg string, dkg *bls.DKG)
 	Logger.Info("verified vrf",
 		zap.Int64("round", vrfs.Round),
 		zap.String("node_id", vrfs.GetParty().GetKey()),
-		zap.Any("share", share.GetHexString()),
-		zap.Any("from", (&partyID).GetHexString()),
-		zap.Any("message", blsMsg))
+		zap.String("share", share.GetHexString()),
+		zap.String("from", (&partyID).GetHexString()),
+		zap.String("message", blsMsg))
 	return true
 }
 
@@ -436,7 +436,7 @@ func (mc *Chain) ThresholdNumBLSSigReceived(ctx context.Context, mr *Round, blsT
 	var rbOutput = encryption.Hash(groupSignature.GetHexString())
 	Logger.Info("receive bls sign",
 		zap.Int64("round", mr.GetRoundNumber()),
-		zap.Any("group_signature", groupSignature.GetHexString()),
+		zap.String("group_signature", groupSignature.GetHexString()),
 		zap.String("rboOutput", rbOutput))
 
 	//mc.computeRBO(ctx, mr, rbOutput)

--- a/code/go/0chain.net/miner/protocol_receive.go
+++ b/code/go/0chain.net/miner/protocol_receive.go
@@ -122,7 +122,7 @@ func (mc *Chain) BlockVerifyWorkers(ctx context.Context) {
 						logging.Logger.Error("process verify block failed",
 							zap.Int64("round", b.Round),
 							zap.String("block", b.Hash),
-							zap.Any("duration", time.Since(ts)),
+							zap.Duration("duration", time.Since(ts)),
 							zap.Error(err))
 						continue
 					}
@@ -369,7 +369,7 @@ func (mc *Chain) NotarizationProcessWorker(ctx context.Context) {
 					logging.Logger.Info("process notarization success",
 						zap.Int64("round", not.Round),
 						zap.String("block", not.BlockID),
-						zap.Any("duration", time.Since(ts)))
+						zap.Duration("duration", time.Since(ts)))
 				case <-cctx.Done():
 					logging.Logger.Error("process notarization timeout",
 						zap.Int64("round", not.Round),
@@ -518,7 +518,7 @@ func (mc *Chain) handleNotarizedBlockMessage(ctx context.Context,
 	var mr = mc.getOrCreateRound(ctx, nb.Round)
 	if mr == nil {
 		logging.Logger.Debug("can't create round",
-			zap.String("block", nb.Hash), zap.Any("round", nb.Round),
+			zap.String("block", nb.Hash), zap.Int64("round", nb.Round),
 			zap.Bool("has_pr", mc.GetMinerRound(nb.Round-1) != nil))
 		return // can't handle yet
 	}

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -53,7 +53,7 @@ func (mc *Chain) addMyVRFShare(ctx context.Context, pr *Round, r *Round) {
 	var dkg = mc.GetDKG(rn)
 	if dkg == nil {
 		logging.Logger.Error("add_my_vrf_share -- DKG is nil, my VRF share is not added",
-			zap.Any("round", rn))
+			zap.Int64("round", rn))
 		return
 	}
 
@@ -65,8 +65,8 @@ func (mc *Chain) addMyVRFShare(ctx context.Context, pr *Round, r *Round) {
 	vrfs.RoundTimeoutCount = r.GetTimeoutCount()
 
 	if vrfs.Share, err = mc.GetBlsShare(ctx, r.Round); err != nil {
-		logging.Logger.Error("add_my_vrf_share", zap.Any("round", vrfs.Round),
-			zap.Any("round_timeout", vrfs.RoundTimeoutCount),
+		logging.Logger.Error("add_my_vrf_share", zap.Int64("round", vrfs.Round),
+			zap.Int("round_timeout", vrfs.RoundTimeoutCount),
 			zap.Int64("dkg_starting_round", dkg.StartingRound),
 			zap.Int64("dkg_mb_number", dkg.MagicBlockNumber),
 			zap.Int64("pr_seed", pr.GetRandomSeed()),
@@ -75,8 +75,8 @@ func (mc *Chain) addMyVRFShare(ctx context.Context, pr *Round, r *Round) {
 		return
 	}
 
-	logging.Logger.Info("add_my_vrf_share", zap.Any("round", vrfs.Round),
-		zap.Any("round_timeout", vrfs.RoundTimeoutCount),
+	logging.Logger.Info("add_my_vrf_share", zap.Int64("round", vrfs.Round),
+		zap.Int("round_timeout", vrfs.RoundTimeoutCount),
 		zap.Int64("dkg_starting_round", dkg.StartingRound),
 		zap.Int64("dkg_mb_number", dkg.MagicBlockNumber),
 		zap.Int64("pr_seed", pr.GetRandomSeed()),
@@ -286,7 +286,7 @@ func (mc *Chain) TryProposeBlock(ctx context.Context, mr *Round) {
 			zap.Int("index", self.SetIndex),
 			zap.Int("rank", rank),
 			zap.Int("timeout_count", mr.GetTimeoutCount()),
-			zap.Any("random_seed", mr.GetRandomSeed()))
+			zap.Int64("random_seed", mr.GetRandomSeed()))
 		// TODO: remove this debug
 		go func(r int64) {
 			// check if this round has got a block in 3 seconds, report if not
@@ -303,7 +303,7 @@ func (mc *Chain) TryProposeBlock(ctx context.Context, mr *Round) {
 	logging.Logger.Info("*** TOC_FIX starting round block generation ***",
 		zap.Int64("round", rn), zap.Int("index", self.SetIndex),
 		zap.Int("rank", rank), zap.Int("timeout_count", mr.GetTimeoutCount()),
-		zap.Any("random_seed", mr.GetRandomSeed()),
+		zap.Int64("random_seed", mr.GetRandomSeed()),
 		zap.Int64("lf_round", mc.GetLatestFinalizedBlock().Round))
 
 	// NOTE: If there are not enough txns, this will not advance further even
@@ -360,8 +360,8 @@ func (mc *Chain) getBlockToExtend(ctx context.Context, r round.RoundI) (
 				zap.Error(err))
 			if state.DebugBlock() {
 				logging.Logger.Error("get block to extend - best nb compute state",
-					zap.Any("round", r.GetRoundNumber()),
-					zap.Any("block", bnb.Hash), zap.Error(err))
+					zap.Int64("round", r.GetRoundNumber()),
+					zap.String("block", bnb.Hash), zap.Error(err))
 				return nil
 			}
 		}
@@ -378,19 +378,19 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 	roundNumber := r.GetRoundNumber()
 	pround := mc.GetRound(roundNumber - 1)
 	if pround == nil {
-		logging.Logger.Error("generate round block - no prior round", zap.Any("round", roundNumber-1))
+		logging.Logger.Error("generate round block - no prior round", zap.Int64("round", roundNumber-1))
 		return nil, common.NewError("invalid_round,", "Round not available")
 	}
 
 	pb := mc.GetBlockToExtend(ctx, pround)
 	if pb == nil {
-		logging.Logger.Error("generate round block - no block to extend", zap.Any("round", roundNumber))
+		logging.Logger.Error("generate round block - no block to extend", zap.Int64("round", roundNumber))
 		return nil, common.NewError("block_gen_no_block_to_extend", "Do not have the block to extend this round")
 	}
 
 	if !pb.IsStateComputed() {
 		logging.Logger.Debug("GenerateRoundBlock, state of prior round block not computed",
-			zap.Any("state status", pb.GetStateStatus()))
+			zap.Int8("state status", pb.GetStateStatus()))
 	}
 	withCancel, cancelFunc := context.WithCancel(common.GetRootContext())
 	r.SetGenerationCancelf(cancelFunc)
@@ -458,8 +458,8 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 	for {
 		if mc.GetCurrentRound() > b.Round {
 			logging.Logger.Error("generate block - round mismatch",
-				zap.Any("round", roundNumber),
-				zap.Any("current_round", mc.GetCurrentRound()))
+				zap.Int64("round", roundNumber),
+				zap.Int64("current_round", mc.GetCurrentRound()))
 			return nil, ErrRoundMismatch
 		}
 
@@ -469,7 +469,7 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 			logging.Logger.Debug("GenerateRoundBlock, previous block state is not computed",
 				zap.Int64("round", b.Round),
 				zap.Int64("pre round", pb.Round),
-				zap.Any("prior_block_state", pb.GetStateStatus()))
+				zap.Int8("prior_block_state", pb.GetStateStatus()))
 		}
 
 		//b.SetStateDB(pb, mc.GetStateDB())
@@ -487,16 +487,16 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 						if startLogging.IsZero() || time.Since(startLogging) > time.Second {
 							startLogging = time.Now()
 							logging.Logger.Info("generate block",
-								zap.Any("round", roundNumber),
-								zap.Any("delay", delay),
-								zap.Any("txn_count", txnCount),
-								zap.Any("t.txn_count", transaction.GetTransactionCount()),
+								zap.Int64("round", roundNumber),
+								zap.Int("delay", delay),
+								zap.Uint64("txn_count", txnCount),
+								zap.Uint64("t.txn_count", transaction.GetTransactionCount()),
 								zap.Any("error", cerr))
 						}
 						if mc.GetCurrentRound() > b.Round {
 							logging.Logger.Error("generate block - round mismatch",
-								zap.Any("round", roundNumber),
-								zap.Any("current_round", mc.GetCurrentRound()))
+								zap.Int64("round", roundNumber),
+								zap.Int64("current_round", mc.GetCurrentRound()))
 							return nil, ErrRoundMismatch
 						}
 						if txnCount != transaction.GetTransactionCount() || time.Since(start) > generationTimeout {
@@ -516,10 +516,10 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 				}
 			}
 			if startLogging.IsZero() || time.Since(startLogging) > time.Second {
-				logging.Logger.Info("generate block", zap.Any("round", roundNumber),
-					zap.Any("txn_count", txnCount),
-					zap.Any("t.txn_count", transaction.GetTransactionCount()),
-					zap.Any("error", err))
+				logging.Logger.Info("generate block", zap.Int64("round", roundNumber),
+					zap.Uint64("txn_count", txnCount),
+					zap.Uint64("t.txn_count", transaction.GetTransactionCount()),
+					zap.Error(err))
 			}
 			return nil, err
 		}
@@ -543,8 +543,8 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 
 	if r.IsVerificationComplete() {
 		logging.Logger.Warn("generate block - verification complete, we are late, cancel block generation",
-			zap.Any("round", roundNumber),
-			zap.Any("notarized", len(r.GetNotarizedBlocks())))
+			zap.Int64("round", roundNumber),
+			zap.Int("notarized", len(r.GetNotarizedBlocks())))
 		return nil, nil
 	}
 
@@ -736,7 +736,7 @@ func (mc *Chain) updatePreviousBlockNotarization(ctx context.Context, b *block.B
 		ctx = context.Background()
 		if err := mc.VerifyNotarization(ctx, b.PrevHash, b.GetPrevBlockVerificationTickets(), b.Round-1); err != nil {
 			logging.Logger.Error("update prev block notarization failed",
-				zap.Int64("round", pr.Number), zap.Any("miner_id", b.MinerID),
+				zap.Int64("round", pr.Number), zap.String("miner_id", b.MinerID),
 				zap.String("block", b.PrevHash),
 				zap.Int("v_tickets", b.PrevBlockVerificationTicketsSize()),
 				zap.Error(err))
@@ -821,13 +821,13 @@ func (mc *Chain) computeBlockProposalDynamicWaitTime(r round.RoundI) time.Durati
 /*CollectBlocksForVerification - keep collecting the blocks till timeout and then start verifying */
 func (mc *Chain) CollectBlocksForVerification(ctx context.Context, r *Round) {
 	verifyAndSend := func(ctx context.Context, r *Round, b *block.Block) bool {
-		logging.Logger.Debug("verifyAndSend - started", zap.Any("block", b.Hash))
+		logging.Logger.Debug("verifyAndSend - started", zap.String("block", b.Hash))
 		b.SetBlockState(block.StateVerificationAccepted)
 		miner := mc.GetMiners(r.GetRoundNumber()).GetNode(b.MinerID)
 		if miner == nil || miner.ProtocolStats == nil {
 			logging.Logger.Error("verifyAndSend -- failed miner",
-				zap.Any("round", r.Number), zap.Any("block", b.Hash),
-				zap.Any("miner", b.MinerID))
+				zap.Int64("round", r.Number), zap.String("block", b.Hash),
+				zap.String("miner", b.MinerID))
 			b.SetBlockState(block.StateVerificationFailed)
 			return false
 		}
@@ -857,17 +857,17 @@ func (mc *Chain) CollectBlocksForVerification(ctx context.Context, r *Round) {
 				if !r.isVerificationComplete() {
 					b.SetBlockState(block.StateVerificationFailed)
 					logging.Logger.Warn("verifyAndSend failed, verification cancelled (round mismatch)",
-						zap.Any("round", r.Number),
-						zap.Any("block", b.Hash),
-						zap.Any("current_round", mc.GetCurrentRound()))
+						zap.Int64("round", r.Number),
+						zap.String("block", b.Hash),
+						zap.Int64("current_round", mc.GetCurrentRound()))
 				}
 				return false
 			default:
 				b.SetBlockState(block.StateVerificationFailed)
 				minerStats.VerificationFailures++
 				logging.Logger.Error("verifyAndSend failed",
-					zap.Any("round", r.Number),
-					zap.Any("block", b.Hash),
+					zap.Int64("round", r.Number),
+					zap.String("block", b.Hash),
 					zap.Error(err))
 			}
 			return false
@@ -1085,7 +1085,7 @@ func (mc *Chain) checkBlockNotarization(ctx context.Context, r *Round, b *block.
 	if !b.IsBlockNotarized() {
 		logging.Logger.Info("checkBlockNotarization -- block is not Notarized. Returning",
 			zap.Int64("round", b.Round),
-			zap.Any("block hash", b.Hash))
+			zap.String("block hash", b.Hash))
 		return false
 	}
 	if !mc.AddNotarizedBlock(r, b) {
@@ -1413,13 +1413,13 @@ func (mc *Chain) handleNoProgress(ctx context.Context, rn int64) {
 			}
 			if lfmbr.Hash != b.LatestFinalizedMagicBlockHash {
 				logging.Logger.Error("handleNoProgress mismatch latest finalized magic block",
-					zap.Any("lfmbr hash", lfmbr.Hash),
-					zap.Any("block lfmbr hash", b.LatestFinalizedMagicBlockHash),
+					zap.String("lfmbr hash", lfmbr.Hash),
+					zap.String("block lfmbr hash", b.LatestFinalizedMagicBlockHash),
 					zap.Int64("lfmbr starting round", lfmbr.Round),
 					zap.Int64("block lfmbr starting round", b.LatestFinalizedMagicBlockRound))
 			} else {
 				logging.Logger.Debug("handleNoProgress match latest finalized magic block",
-					zap.Any("lfmbr hash", lfmbr.Hash),
+					zap.String("lfmbr hash", lfmbr.Hash),
 					zap.Int64("lfmbr round", lfmbr.Round))
 			}
 			logging.Logger.Info("Sent proposal in handle NoProgress")
@@ -1447,14 +1447,14 @@ func (mc *Chain) handleNoProgress(ctx context.Context, rn int64) {
 	switch crt := mc.GetRoundTimeoutCount(); {
 	case crt < 10:
 		logging.Logger.Info("handleNoProgress",
-			zap.Any("round", mc.GetCurrentRound()),
+			zap.Int64("round", mc.GetCurrentRound()),
 			zap.Int64("count_round_timeout", crt),
-			zap.Any("num_vrf_share", len(r.GetVRFShares())))
+			zap.Int("num_vrf_share", len(r.GetVRFShares())))
 	case crt == 10:
 		logging.Logger.Error("handleNoProgress (no further timeout messages will be displayed)",
-			zap.Any("round", mc.GetCurrentRound()),
+			zap.Int64("round", mc.GetCurrentRound()),
 			zap.Int64("count_round_timeout", crt),
-			zap.Any("num_vrf_share", len(r.GetVRFShares())))
+			zap.Int("num_vrf_share", len(r.GetVRFShares())))
 		//TODO: should have a means to send an email/SMS to someone or something like that
 	}
 
@@ -1477,7 +1477,7 @@ func (mc *Chain) kickFinalization(ctx context.Context) {
 		var mr = mc.GetMinerRound(i)
 		if mr == nil || mr.IsFinalized() {
 			logging.Logger.Info("restartRound->kickFinalization continued",
-				zap.Any("miner round", mr),
+				zap.Int64("miner round", mr.Number),
 				zap.Bool("miner is finalized", mr != nil && mr.IsFinalized()))
 			i++
 			count++
@@ -1563,16 +1563,16 @@ func (mc *Chain) restartRound(ctx context.Context, rn int64) {
 	switch crt := mc.GetRoundTimeoutCount(); {
 	case crt < 10:
 		logging.Logger.Error("restartRound - round timeout occurred",
-			zap.Any("round", rn), zap.Int64("count", crt),
-			zap.Any("num_vrf_share", len(r.GetVRFShares())),
+			zap.Int64("round", rn), zap.Int64("count", crt),
+			zap.Int("num_vrf_share", len(r.GetVRFShares())),
 			zap.String("current_phase", round.GetPhaseName(r.GetPhase())),
 			zap.Bool("is_finalized", r.IsFinalized()))
 
 	case crt == 10:
 		logging.Logger.Error("restartRound - round timeout occurred (no further"+
 			" timeout messages will be displayed)",
-			zap.Any("round", rn), zap.Int64("count", crt),
-			zap.Any("num_vrf_share", len(r.GetVRFShares())),
+			zap.Int64("round", rn), zap.Int64("count", crt),
+			zap.Int("num_vrf_share", len(r.GetVRFShares())),
 			zap.String("current_phase", round.GetPhaseName(r.GetPhase())),
 			zap.Bool("is_finalized", r.IsFinalized()))
 
@@ -2007,7 +2007,7 @@ func (mc *Chain) WaitForActiveSharders(ctx context.Context) error {
 	logging.Logger.Debug("waiting for sharders",
 		zap.Int64("latest_magic_block_round", lmb.StartingRound),
 		zap.Int64("latest_magic_block_number", lmb.MagicBlockNumber),
-		zap.Any("sharders", waitingSharders))
+		zap.Strings("sharders", waitingSharders))
 
 	var ticker = time.NewTicker(5 * chain.DELTA)
 	defer ticker.Stop()
@@ -2021,7 +2021,7 @@ func (mc *Chain) WaitForActiveSharders(ctx context.Context) error {
 				return nil
 			}
 			logging.Logger.Info("Waiting for Sharders.", zap.Time("ts", ts),
-				zap.Any("sharders", waitingSharders))
+				zap.Strings("sharders", waitingSharders))
 			lmb.Sharders.OneTimeStatusMonitor(ctx, lmb.StartingRound) // just mark 'em active
 		}
 	}

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -1476,9 +1476,13 @@ func (mc *Chain) kickFinalization(ctx context.Context) {
 	for i < e && count < 5 {
 		var mr = mc.GetMinerRound(i)
 		if mr == nil || mr.IsFinalized() {
-			logging.Logger.Info("restartRound->kickFinalization continued",
-				zap.Int64("miner round", mr.Number),
-				zap.Bool("miner is finalized", mr != nil && mr.IsFinalized()))
+			if mr != nil {
+				logging.Logger.Info("restartRound->kickFinalization continued",
+					zap.Int64("miner round", mr.Number),
+					zap.Bool("miner is finalized", mr.IsFinalized()))
+			} else {
+				logging.Logger.Info("restartRound->kickFinalization continued. Miner Round is nil")
+			}
 			i++
 			count++
 			continue // skip finalized blocks, skip nil miner rounds

--- a/code/go/0chain.net/miner/protocol_view_chainge_main.go
+++ b/code/go/0chain.net/miner/protocol_view_chainge_main.go
@@ -72,8 +72,8 @@ func (mc *Chain) sendDKGShare(ctx context.Context, to string) (err error) {
 		ok, err = signatureScheme.Verify(share.Sign, share.Message)
 		if !ok || err != nil {
 			logging.Logger.Error("invalid share or sign",
-				zap.Error(err), zap.Any("minersc/dkg.gosign_status", ok),
-				zap.Any("message", share.Message), zap.Any("sign", share.Sign))
+				zap.Error(err), zap.Bool("minersc/dkg.gosign_status", ok),
+				zap.String("message", share.Message), zap.String("sign", share.Sign))
 			return
 		}
 		shareOrSignSuccess[n.ID] = share
@@ -168,7 +168,7 @@ func (mc *Chain) PublishShareOrSigns(ctx context.Context, lfb *block.Block,
 	for id := range dmn.SimpleNodes {
 		var nodeSend = node.GetNode(id)
 		if nodeSend == nil {
-			logging.Logger.Warn("failed to get node", zap.Any("id", id))
+			logging.Logger.Warn("failed to get node", zap.String("id", id))
 			continue
 		}
 		minerUrls = append(minerUrls, nodeSend.GetN2NURLBase())
@@ -188,7 +188,7 @@ func (mc *Chain) ContributeMpk(ctx context.Context, lfb *block.Block,
 
 	var dmn *minersc.DKGMinerNodes
 	if dmn, err = mc.getDKGMiners(ctx, lfb, mb, active); err != nil {
-		logging.Logger.Error("can't contribute", zap.Any("error", err))
+		logging.Logger.Error("can't contribute", zap.Error(err))
 		return
 	}
 

--- a/code/go/0chain.net/miner/protocol_view_change.go
+++ b/code/go/0chain.net/miner/protocol_view_change.go
@@ -215,7 +215,7 @@ func (mc *Chain) DKGProcess(ctx context.Context) {
 		logging.Logger.Debug("dkg process: move phase",
 			zap.String("current_phase", mc.CurrentPhase().String()),
 			zap.Any("next_phase", pn),
-			zap.String("txn", txn.Hash))
+			zap.Any("txn", txn))
 
 		if txn == nil || (txn != nil && mc.ConfirmTransaction(ctx, txn, 0)) {
 			prevPhase := mc.CurrentPhase()

--- a/code/go/0chain.net/miner/worker.go
+++ b/code/go/0chain.net/miner/worker.go
@@ -52,8 +52,8 @@ func (mc *Chain) BlockWorker(ctx context.Context) {
 				if bmsg.Sender != nil {
 					logging.Logger.Debug("message",
 						zap.Any("msg", GetMessageLookup(bmsg.Type)),
-						zap.Any("sender_index", bmsg.Sender.SetIndex),
-						zap.Any("id", bmsg.Sender.GetKey()))
+						zap.Int("sender_index", bmsg.Sender.SetIndex),
+						zap.String("id", bmsg.Sender.GetKey()))
 				} else {
 					logging.Logger.Debug("message", zap.Any("msg", GetMessageLookup(bmsg.Type)))
 				}
@@ -72,13 +72,13 @@ func (mc *Chain) BlockWorker(ctx context.Context) {
 				if bmsg.Sender != nil {
 					logging.Logger.Debug("message (done)",
 						zap.Any("msg", GetMessageLookup(bmsg.Type)),
-						zap.Any("sender_index", bmsg.Sender.SetIndex),
-						zap.Any("id", bmsg.Sender.GetKey()),
-						zap.Any("duration", time.Since(ts)))
+						zap.Int("sender_index", bmsg.Sender.SetIndex),
+						zap.String("id", bmsg.Sender.GetKey()),
+						zap.Duration("duration", time.Since(ts)))
 				} else {
 					logging.Logger.Debug("message (done)",
 						zap.Any("msg", GetMessageLookup(bmsg.Type)),
-						zap.Any("duration", time.Since(ts)))
+						zap.Duration("duration", time.Since(ts)))
 				}
 			}(msg)
 		}
@@ -104,7 +104,7 @@ func roundTimeoutProcess(ctx context.Context, proto Protocol, rn int64) {
 	case <-rc:
 		logging.Logger.Info("protocol.HandleRoundTimeout finished",
 			zap.Int64("round", rn),
-			zap.Any("duration", time.Since(ts)))
+			zap.Duration("duration", time.Since(ts)))
 	}
 }
 
@@ -138,8 +138,8 @@ func (mc *Chain) RoundWorker(ctx context.Context) {
 						}
 					} else {
 						logging.Logger.Info("round timeout",
-							zap.Any("round", r.Number),
-							zap.Any("current round", cround),
+							zap.Int64("round", r.Number),
+							zap.Int64("current round", cround),
 							zap.Int("VRF_shares", len(r.GetVRFShares())),
 							zap.Int("proposedBlocks", len(r.GetProposedBlocks())),
 							zap.Int("verificationTickets", len(r.verificationTickets)),

--- a/code/go/0chain.net/sharder/block.go
+++ b/code/go/0chain.net/sharder/block.go
@@ -52,7 +52,7 @@ func SetupBlockSummaries() {
 /*GetBlockBySummary - get a block */
 func (sc *Chain) GetBlockBySummary(ctx context.Context, bs *block.BlockSummary) (*block.Block, error) {
 	if len(bs.Hash) < 64 {
-		Logger.Error("Hash from block summary is less than 64", zap.Any("block_summary", bs))
+		Logger.Error("Hash from block summary is less than 64", zap.String("block_summary", bs.Hash))
 	}
 	//Try to get the block from the cache
 	b, err := sc.GetBlock(ctx, bs.Hash)
@@ -86,7 +86,7 @@ func (sc *Chain) GetBlockSummary(ctx context.Context, hash string) (*block.Block
 		return nil, err
 	}
 	if len(blockSummary.Hash) < 64 {
-		Logger.Error("Reading block summary - hash of block in summary is less than 64", zap.Any("block_summary", blockSummary))
+		Logger.Error("Reading block summary - hash of block in summary is less than 64", zap.String("block_summary", blockSummary.Hash))
 	}
 	return blockSummary, nil
 }
@@ -110,7 +110,7 @@ func (sc *Chain) StoreBlockSummaryFromBlock(b *block.Block) error {
 	bctx := ememorystore.WithEntityConnection(common.GetRootContext(), bSummaryEntityMetadata)
 	defer ememorystore.Close(bctx)
 	if len(bs.Hash) < 64 {
-		Logger.Error("Writing block summary - block hash less than 64", zap.Any("hash", bs.Hash))
+		Logger.Error("Writing block summary - block hash less than 64", zap.String("hash", bs.Hash))
 	}
 	err := bs.Write(bctx)
 	if err != nil {
@@ -126,7 +126,7 @@ func (sc *Chain) StoreBlockSummary(ctx context.Context, bs *block.BlockSummary) 
 	bctx := ememorystore.WithEntityConnection(ctx, bSummaryEntityMetadata)
 	defer ememorystore.Close(bctx)
 	if len(bs.Hash) < 64 {
-		Logger.Error("Writing block summary - block hash less than 64", zap.Any("hash", bs.Hash))
+		Logger.Error("Writing block summary - block hash less than 64", zap.String("hash", bs.Hash))
 	}
 	err := bs.Write(bctx)
 	if err != nil {
@@ -146,7 +146,7 @@ func (sc *Chain) StoreMagicBlockMapFromBlock(mbm *block.MagicBlockMap) error {
 	mctx := persistencestore.WithEntityConnection(common.GetRootContext(), mbMapEntityMetadata)
 	defer persistencestore.Close(mctx)
 	if len(mbm.Hash) < 64 {
-		Logger.Error("Writing block summary - block hash less than 64", zap.Any("hash", mbm.Hash), zap.Any("magic_block_number", mbm.ID))
+		Logger.Error("Writing block summary - block hash less than 64", zap.String("hash", mbm.Hash), zap.String("magic_block_number", mbm.ID))
 	}
 	return mbMapEntityMetadata.GetStore().Write(mctx, mbm)
 }

--- a/code/go/0chain.net/sharder/blockstore/fs_store.go
+++ b/code/go/0chain.net/sharder/blockstore/fs_store.go
@@ -258,9 +258,9 @@ func (fbs *FSBlockStore) UploadToCloud(hash string, round int64) error {
 	if fbs.Minio.DeleteLocal() {
 		err = os.Remove(filePath)
 		if err != nil {
-			Logger.Error("Failed to delete block which is moved to cloud", zap.Any("round", round), zap.Any("path", filePath))
+			Logger.Error("Failed to delete block which is moved to cloud", zap.Int64("round", round), zap.String("path", filePath))
 		}
-		Logger.Info("Local block successfully deleted, moved to cloud", zap.Any("round", round), zap.Any("path", filePath))
+		Logger.Info("Local block successfully deleted, moved to cloud", zap.Int64("round", round), zap.String("path", filePath))
 	}
 	return nil
 }

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -194,7 +194,7 @@ func (sc *Chain) setupLatestBlocks(ctx context.Context, bl *blocksLoaded) (
 	bl.lfb.SetStateStatus(block.StateSuccessful)
 	if err = sc.InitBlockState(bl.lfb); err != nil {
 		bl.lfb.SetStateStatus(0)
-		logging.Logger.Info("load_lfb -- can't initialize stored block state",
+		logging.Logger.Error("load_lfb -- can't initialize stored block state",
 			zap.Error(err))
 		// return common.NewErrorf("load_lfb",
 		//	"can't init block state: %v", err) // fatal

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -111,7 +111,7 @@ func (sc *Chain) SetupGenesisBlock(hash string, magicBlock *block.MagicBlock, in
 		err = sc.StoreMagicBlockMapFromBlock(bs.GetMagicBlockMap())
 		for err != nil {
 			tries++
-			logging.Logger.Error("setup genesis block -- failed to store magic block map", zap.Any("error", err), zap.Any("tries", tries))
+			logging.Logger.Error("setup genesis block -- failed to store magic block map", zap.Error(err), zap.Int64("tries", tries))
 			time.Sleep(time.Millisecond * 100)
 			err = sc.StoreMagicBlockMapFromBlock(bs.GetMagicBlockMap())
 		}

--- a/code/go/0chain.net/sharder/protocol_round.go
+++ b/code/go/0chain.net/sharder/protocol_round.go
@@ -31,8 +31,8 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 		nb := r.GetNotarizedBlocks()
 		if len(nb) > 0 {
 			Logger.Error("*** different blocks for the same round ***",
-				zap.Any("round", b.Round), zap.Any("block", b.Hash),
-				zap.Any("existing_block", nb[0].Hash))
+				zap.Int64("round", b.Round), zap.String("block", b.Hash),
+				zap.String("existing_block", nb[0].Hash))
 		}
 	}
 
@@ -78,7 +78,7 @@ func (sc *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI,
 
 	select {
 	case <-doneC:
-		Logger.Debug("AddNotarizedBlock compute state successfully", zap.Any("duration", time.Since(t)))
+		Logger.Debug("AddNotarizedBlock compute state successfully", zap.Duration("duration", time.Since(t)))
 	case err := <-errC:
 		Logger.Error("AddNotarizedBlock failed to compute state",
 			zap.Int64("round", b.Round),

--- a/code/go/0chain.net/sharder/sharder/sharder.go
+++ b/code/go/0chain.net/sharder/sharder/sharder.go
@@ -191,7 +191,7 @@ func main() {
 	initStates := state.NewInitStates()
 	initStateErr := initStates.Read(*initialStatesFile)
 	if initStateErr != nil {
-		Logger.Panic("Failed to read initialStates", zap.Any("Error", initStateErr))
+		Logger.Panic("Failed to read initialStates", zap.Error(initStateErr))
 		return
 	}
 
@@ -228,6 +228,7 @@ func main() {
 		sc.SetupGenesisBlock(viper.GetString("server_chain.genesis_block.id"),
 			magicBlock, initStates)
 	}
+	// Leaving this huge log bcz it's useful to show the initialized node and it's only logged once for every node
 	Logger.Info("sharder node", zap.Any("node", node.Self))
 
 	var selfNode = node.Self.Underlying()
@@ -250,7 +251,7 @@ func main() {
 		selfNode.Description = description
 	} else {
 		if initStateErr != nil {
-			Logger.Panic("Failed to read initialStates", zap.Any("Error", initStateErr))
+			Logger.Panic("Failed to read initialStates", zap.Error(initStateErr))
 		}
 	}
 	if selfNode.Type != node.NodeTypeSharder {
@@ -272,8 +273,8 @@ func main() {
 		zap.String("port", address))
 	Logger.Info("Chain info", zap.String("chain_id", config.GetServerChainID()),
 		zap.String("mode", mode))
-	Logger.Info("Self identity", zap.Any("set_index", selfNode.SetIndex),
-		zap.Any("id", selfNode.GetKey()))
+	Logger.Info("Self identity", zap.Int("set_index", selfNode.SetIndex),
+		zap.String("id", selfNode.GetKey()))
 
 	registerInConductor(node.Self.Underlying().GetKey())
 
@@ -511,9 +512,9 @@ func setupBlockStorageProvider(mConf blockstore.MinioConfiguration, workdir stri
 			Logger.Error("Error with make bucket, Will check if bucket exists", zap.Error(err))
 			exists, errBucketExists := mClient.BucketExists(mConf.BucketName)
 			if errBucketExists == nil && exists {
-				Logger.Info("We already own ", zap.Any("bucket_name", mConf.BucketName))
+				Logger.Info("We already own ", zap.String("bucket_name", mConf.BucketName))
 			} else {
-				Logger.Error("Minio bucket error", zap.Error(errBucketExists), zap.Any("bucket_name", mConf.BucketName))
+				Logger.Error("Minio bucket error", zap.Error(errBucketExists), zap.String("bucket_name", mConf.BucketName))
 				panic(err)
 			}
 		} else {

--- a/code/go/0chain.net/sharder/transaction.go
+++ b/code/go/0chain.net/sharder/transaction.go
@@ -172,7 +172,7 @@ func (sc *Chain) getTxnCountForRound(ctx context.Context, r int64) (int, error) 
 		if err == nil {
 			txnSummaryMV = true
 		} else {
-			logging.Logger.Info("create mv", zap.Error(err))
+			logging.Logger.Error("create mv", zap.Error(err))
 			txnSummaryMV = true
 			return 0, err
 		}

--- a/code/go/0chain.net/sharder/transaction.go
+++ b/code/go/0chain.net/sharder/transaction.go
@@ -119,13 +119,13 @@ func (sc *Chain) StoreTransactions(b *block.Block) error {
 		err := sc.storeTransactions(sTxns)
 		if err != nil {
 			delay = 2 * delay
-			logging.Logger.Error("save transactions error", zap.Any("round", b.Round), zap.String("block", b.Hash), zap.Int("retry", tries), zap.Duration("delay", delay), zap.Error(err))
+			logging.Logger.Error("save transactions error", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Int("retry", tries), zap.Duration("delay", delay), zap.Error(err))
 			time.Sleep(delay)
 			continue
 		}
 
 		success = true
-		logging.Logger.Debug("transactions saved successfully", zap.Any("round", b.Round), zap.Any("block", b.Hash), zap.Int("block_size", len(b.Txns)))
+		logging.Logger.Debug("transactions saved successfully", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Int("block_size", len(b.Txns)))
 		break
 	}
 
@@ -137,7 +137,7 @@ func (sc *Chain) StoreTransactions(b *block.Block) error {
 	txnSaveTimer.UpdateSince(ts)
 	p95 := txnSaveTimer.Percentile(.95)
 	if txnSaveTimer.Count() > 100 && 2*p95 < float64(duration) {
-		logging.Logger.Info("save transactions - slow", zap.Any("round", b.Round), zap.String("block", b.Hash), zap.Duration("duration", duration), zap.Duration("p95", time.Duration(math.Round(p95/1000000))*time.Millisecond))
+		logging.Logger.Info("save transactions - slow", zap.Int64("round", b.Round), zap.String("block", b.Hash), zap.Duration("duration", duration), zap.Duration("p95", time.Duration(math.Round(p95/1000000))*time.Millisecond))
 	}
 	return nil
 }

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -362,7 +362,7 @@ func (sc *Chain) RegisterSharderKeepWorker(ctx context.Context) {
 
 		if !sc.ConfirmTransaction(ctx, txn, 0) {
 			logging.Logger.Debug("register_sharder_keep_worker -- failed "+
-				"to confirm transaction", zap.String("txn", txn.Hash))
+				"to confirm transaction", zap.Any("txn", txn))
 			continue
 		}
 

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -362,7 +362,7 @@ func (sc *Chain) RegisterSharderKeepWorker(ctx context.Context) {
 
 		if !sc.ConfirmTransaction(ctx, txn, 0) {
 			logging.Logger.Debug("register_sharder_keep_worker -- failed "+
-				"to confirm transaction", zap.Any("txn", txn))
+				"to confirm transaction", zap.String("txn", txn.Hash))
 			continue
 		}
 
@@ -403,12 +403,12 @@ func (sc *Chain) MinioWorker(ctx context.Context) {
 			for roundToProcess > 0 {
 				hash, err := sc.GetBlockHash(ctx, roundToProcess)
 				if err != nil {
-					logging.Logger.Error("Unable to get block hash from round number", zap.Any("round", roundToProcess))
+					logging.Logger.Error("Unable to get block hash from round number", zap.Int64("round", roundToProcess))
 					roundToProcess--
 					continue
 				}
 				if fs.CloudObjectExists(hash) {
-					logging.Logger.Info("The data is already present on cloud, Terminating the worker...", zap.Any("round", roundToProcess))
+					logging.Logger.Info("The data is already present on cloud, Terminating the worker...", zap.Int64("round", roundToProcess))
 					break
 				} else {
 					swg.Add()
@@ -425,9 +425,9 @@ func (sc *Chain) MinioWorker(ctx context.Context) {
 func (sc *Chain) moveBlockToCloud(ctx context.Context, round int64, hash string, fs blockstore.BlockStore, swg *sizedwaitgroup.SizedWaitGroup) {
 	err := fs.UploadToCloud(hash, round)
 	if err != nil {
-		logging.Logger.Error("Error in uploading to cloud, The data is also missing from cloud", zap.Error(err), zap.Any("round", round))
+		logging.Logger.Error("Error in uploading to cloud, The data is also missing from cloud", zap.Error(err), zap.Int64("round", round))
 	} else {
-		logging.Logger.Info("Block successfully uploaded to cloud", zap.Any("round", round))
+		logging.Logger.Info("Block successfully uploaded to cloud", zap.Int64("round", round))
 		sc.TieringStats.TotalBlocksUploaded++
 		sc.TieringStats.LastRoundUploaded = round
 		sc.TieringStats.LastUploadTime = time.Now()

--- a/code/go/0chain.net/smartcontract/dbs/event/allocation.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/allocation.go
@@ -168,7 +168,7 @@ func (edb *EventDb) updateAllocationStakes(allocs []Allocation) error {
 		du := time.Since(ts)
 		if du.Milliseconds() > 50 {
 			logging.Logger.Debug("event db - update allocation stakes slow",
-				zap.Any("duration", du),
+				zap.Duration("duration", du),
 				zap.Int("num", len(allocs)))
 		}
 	}()

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -264,7 +264,7 @@ func (edb *EventDb) addOrOverwriteBlobber(blobbers []Blobber) error {
 		for _, b := range blobbers {
 			bids = append(bids, b.ID)
 		}
-		logging.Logger.Debug("add or overwrite blobbers failed", zap.Any("ids", bids))
+		logging.Logger.Debug("add or overwrite blobbers failed", zap.Strings("ids", bids))
 	}
 	return err
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -56,8 +56,8 @@ func (edb *EventDb) ProcessEvents(
 		du := time.Since(ts)
 		if du.Milliseconds() > 200 {
 			logging.Logger.Warn("process events slow",
-				zap.Any("duration", du),
-				zap.Any("merge events duration", pdu),
+				zap.Duration("duration", du),
+				zap.Duration("merge events duration", pdu),
 				zap.Int64("round", round),
 				zap.String("block", block),
 				zap.Int("block size", blockSize))
@@ -66,7 +66,7 @@ func (edb *EventDb) ProcessEvents(
 		du := time.Since(ts)
 		logging.Logger.Warn("process events - context done",
 			zap.Error(ctx.Err()),
-			zap.Any("duration", du),
+			zap.Duration("duration", du),
 			zap.Int64("round", round),
 			zap.String("block", block),
 			zap.Int("block size", blockSize))
@@ -218,7 +218,7 @@ func (edb *EventDb) addEventsWorker(ctx context.Context) {
 
 		due := time.Since(tse)
 		logging.Logger.Debug("event db process",
-			zap.Any("duration", due),
+			zap.Duration("duration", due),
 			zap.Int("events number", len(es.events)),
 			zap.Strings("tags", tags),
 			zap.Int64("round", es.round),
@@ -227,7 +227,7 @@ func (edb *EventDb) addEventsWorker(ctx context.Context) {
 
 		if due.Milliseconds() > 200 {
 			logging.Logger.Warn("event db work slow",
-				zap.Any("duration", due),
+				zap.Duration("duration", due),
 				zap.Int("events number", len(es.events)),
 				zap.Strings("tags", tags),
 				zap.Int64("round", es.round),
@@ -287,7 +287,7 @@ func (edb *EventDb) processEvent(event Event, tags []string, round int64, block 
 		du := time.Since(ts)
 		if du.Milliseconds() > 50 {
 			logging.Logger.Warn("event db save slow - addStat",
-				zap.Any("duration", du),
+				zap.Duration("duration", du),
 				zap.String("event tag", event.Tag.String()),
 				zap.Int64("round", round),
 				zap.String("block", block),
@@ -301,7 +301,7 @@ func (edb *EventDb) processEvent(event Event, tags []string, round int64, block 
 		du := time.Since(ts)
 		if du.Milliseconds() > 50 {
 			logging.Logger.Warn("event db save slow - addchain",
-				zap.Any("duration", du),
+				zap.Duration("duration", du),
 				zap.String("event tag", event.Tag.String()),
 				zap.Int64("round", round),
 				zap.String("block", block),

--- a/code/go/0chain.net/smartcontract/dbs/event/provider.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/provider.go
@@ -8,8 +8,6 @@ import (
 	"0chain.net/core/common"
 	"0chain.net/smartcontract/dbs"
 	"github.com/0chain/common/core/currency"
-	"github.com/0chain/common/core/logging"
-	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 

--- a/code/go/0chain.net/smartcontract/dbs/event/provider.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/provider.go
@@ -94,7 +94,6 @@ func (edb *EventDb) updateProvidersTotalUnStakes(providers []Provider, tablename
 
 func (edb *EventDb) updateProvidersHealthCheck(updates []dbs.DbHealthCheck, tableName ProviderTable) error {
 	table := string(tableName)
-	logging.Logger.Info("Running update provider health check with data: ", zap.Any("updates", updates), zap.String("tableName", table))
 
 	var ids []string
 	var lastHealthCheck []int64

--- a/code/go/0chain.net/smartcontract/dbs/event/snapshot.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/snapshot.go
@@ -96,7 +96,6 @@ type globalSnapshot struct {
 }
 
 func (edb *EventDb) addSnapshot(s Snapshot) error {
-	logging.Logger.Info("add_snapshot", zap.Any("snapshot", s))
 	return edb.Store.Get().Create(&s).Error
 }
 
@@ -138,7 +137,7 @@ func (gs *globalSnapshot) update(e []Event) {
 			gs.TotalMint += int64(m.Amount)
 			gs.ZCNSupply += int64(m.Amount)
 			logging.Logger.Info("snapshot update TagAddMint",
-				zap.Any("total mint and zcn mint", gs))
+				zap.Int64("total_mint", gs.TotalMint), zap.Int64("zcn_supply", gs.ZCNSupply))
 		case TagBurn:
 			m, ok := fromEvent[state.Burn](event.Data)
 			if !ok {
@@ -148,7 +147,7 @@ func (gs *globalSnapshot) update(e []Event) {
 			}
 			gs.ZCNSupply -= int64(m.Amount)
 			logging.Logger.Info("snapshot update TagBurn",
-				zap.Any("zcn burn", gs))
+				zap.Int64("zcn_supply", gs.ZCNSupply))
 		case TagLockStakePool:
 			d, ok := fromEvent[DelegatePoolLock](event.Data)
 			if !ok {

--- a/code/go/0chain.net/smartcontract/dbs/event/stakepool.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/stakepool.go
@@ -123,7 +123,7 @@ func (edb *EventDb) rewardUpdate(spus []dbs.StakePoolReward, round int64) error 
 		if du > 50*time.Millisecond {
 			logging.Logger.Debug("event db - update reward slow",
 				zap.Int64("round", round),
-				zap.Any("duration", du),
+				zap.Duration("duration", du),
 				zap.Int("total update items", n),
 				zap.Int("rewards num", len(rewards.rewards)),
 				zap.Int("delegate pools num", len(rewards.delegatePools)),
@@ -140,7 +140,7 @@ func (edb *EventDb) rewardUpdate(spus []dbs.StakePoolReward, round int64) error 
 	rpdu := time.Since(ts)
 	if rpdu.Milliseconds() > 50 {
 		logging.Logger.Debug("event db - reward providers slow",
-			zap.Any("duration", rpdu),
+			zap.Duration("duration", rpdu),
 			zap.Int64("round", round))
 	}
 

--- a/code/go/0chain.net/smartcontract/dbs/event/user.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/user.go
@@ -39,7 +39,7 @@ func (edb *EventDb) GetUser(userID string) (*User, error) {
 func (edb *EventDb) addOrUpdateUsers(users []User) error {
 	ts := time.Now()
 	defer func() {
-		logging.Logger.Debug("event db - upsert users ", zap.Any("duration", time.Since(ts)),
+		logging.Logger.Debug("event db - upsert users ", zap.Duration("duration", time.Since(ts)),
 			zap.Int("num", len(users)))
 	}()
 	return edb.Store.Get().Clauses(clause.OnConflict{

--- a/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
@@ -117,7 +117,7 @@ func (edb *EventDb) addWriteMarkers(wms []WriteMarker) error {
 		du := time.Since(ts)
 		if du.Milliseconds() > 50 {
 			logging.Logger.Debug("event db - add write markers slow",
-				zap.Any("duration", du),
+				zap.Duration("duration", du),
 				zap.Int("num", len(wms)))
 		}
 	}()

--- a/code/go/0chain.net/smartcontract/minersc/dkg.go
+++ b/code/go/0chain.net/smartcontract/minersc/dkg.go
@@ -248,17 +248,17 @@ func (msc *MinerSmartContract) setPhaseNode(balances cstate.StateContextI,
 			}
 
 			Logger.Error("failed to move phase, restartDKG",
-				zap.Any("phase", pn.Phase),
+				zap.String("phase", pn.Phase.String()),
 				zap.Int64("phase start round", pn.StartRound),
 				zap.Int64("phase current round", pn.CurrentRound),
-				zap.Any("move_func", getFunctionName(currentMoveFunc)),
+				zap.String("move_func", getFunctionName(currentMoveFunc)),
 				zap.Error(err))
 			if err := msc.RestartDKG(pn, balances); err != nil {
 				Logger.Error("setPhaseNode restart DKG failed",
 					zap.Error(err),
 					zap.Int64("phase start round", pn.StartRound),
 					zap.Int64("phase current round", pn.CurrentRound),
-					zap.Any("move_func", getFunctionName(currentMoveFunc)))
+					zap.String("move_func", getFunctionName(currentMoveFunc)))
 				return err
 			}
 		} else {
@@ -282,8 +282,8 @@ func (msc *MinerSmartContract) setPhaseNode(balances cstate.StateContextI,
 					}
 
 					Logger.Error("setPhaseNode failed to set phase node - restarting DKG",
-						zap.Any("error", err),
-						zap.Any("phase", pn.Phase))
+						zap.Error(err),
+						zap.String("phase", pn.Phase.String()))
 
 					if err := msc.RestartDKG(pn, balances); err != nil {
 						Logger.Debug("setPhaseNode move phase failed",
@@ -309,7 +309,7 @@ func (msc *MinerSmartContract) setPhaseNode(balances cstate.StateContextI,
 	_, err := balances.InsertTrieNode(pn.GetKey(), pn)
 	if err != nil && err != util.ErrValueNotPresent {
 		Logger.Error("failed to set phase node -- insert failed",
-			zap.Any("error", err))
+			zap.Error(err))
 		return err
 	}
 
@@ -322,7 +322,7 @@ func (msc *MinerSmartContract) createDKGMinersForContribute(
 	allMinersList, err := msc.getMinersList(balances)
 	if err != nil {
 		Logger.Error("createDKGMinersForContribute -- failed to get miner list",
-			zap.Any("error", err))
+			zap.Error(err))
 		return err
 	}
 
@@ -371,7 +371,7 @@ func (msc *MinerSmartContract) widdleDKGMinersForShare(
 	dkgMiners, err := getDKGMinersList(balances)
 	if err != nil {
 		Logger.Error("widdle dkg miners -- failed to get dkgMiners",
-			zap.Any("error", err))
+			zap.Error(err))
 		return err
 	}
 
@@ -381,7 +381,7 @@ func (msc *MinerSmartContract) widdleDKGMinersForShare(
 	mpks, err := getMinersMPKs(balances)
 	if err != nil {
 		Logger.Error("widdle dkg miners -- failed to get miners mpks",
-			zap.Any("error", err))
+			zap.Error(err))
 		return err
 	}
 
@@ -398,7 +398,7 @@ func (msc *MinerSmartContract) widdleDKGMinersForShare(
 
 	if err := updateDKGMinersList(balances, dkgMiners); err != nil {
 		Logger.Error("widdle dkg miners -- failed to insert dkg miners",
-			zap.Any("error", err))
+			zap.Error(err))
 		return err
 	}
 	return nil
@@ -572,7 +572,7 @@ func (msc *MinerSmartContract) createMagicBlockForWait(
 
 	err = updateMagicBlock(balances, magicBlock)
 	if err != nil {
-		Logger.Error("failed to insert magic block", zap.Any("error", err))
+		Logger.Error("failed to insert magic block", zap.Error(err))
 		return err
 	}
 	// dkgMinersList = NewDKGMinerNodes()
@@ -869,7 +869,7 @@ func (msc *MinerSmartContract) RestartDKG(pn *PhaseNode,
 	defer msc.mutexMinerMPK.Unlock()
 	mpks := block.NewMpks()
 	if err := updateMinersMPKs(balances, mpks); err != nil {
-		Logger.Error("failed to restart dkg", zap.Any("error", err))
+		Logger.Error("failed to restart dkg", zap.Error(err))
 		return err
 	}
 
@@ -877,19 +877,19 @@ func (msc *MinerSmartContract) RestartDKG(pn *PhaseNode,
 
 	gsos := block.NewGroupSharesOrSigns()
 	if err := updateGroupShareOrSigns(balances, gsos); err != nil {
-		Logger.Error("failed to restart dkg", zap.Any("error", err))
+		Logger.Error("failed to restart dkg", zap.Error(err))
 		return err
 	}
 	dkgMinersList := NewDKGMinerNodes()
 	dkgMinersList.StartRound = pn.CurrentRound
 	if err := updateDKGMinersList(balances, dkgMinersList); err != nil {
-		Logger.Error("failed to restart dkg", zap.Any("error", err))
+		Logger.Error("failed to restart dkg", zap.Error(err))
 		return err
 	}
 
 	sharderKeepList := new(MinerNodes)
 	if err := updateShardersKeepList(balances, sharderKeepList); err != nil {
-		Logger.Error("failed to restart dkg", zap.Any("error", err))
+		Logger.Error("failed to restart dkg", zap.Error(err))
 		return err
 	}
 	pn.Phase = Start

--- a/code/go/0chain.net/smartcontract/minersc/fees.go
+++ b/code/go/0chain.net/smartcontract/minersc/fees.go
@@ -197,7 +197,7 @@ func (msc *MinerSmartContract) adjustViewChange(gn *GlobalNode,
 			waited, dmn.K)
 	}
 	if err != nil {
-		logging.Logger.Info("adjust_view_change", zap.Error(err))
+		logging.Logger.Error("adjust_view_change", zap.Error(err))
 		// don't do this view change, save the gn later
 		// reset the ViewChange to previous one (for miners)
 		var prev = gn.prevMagicBlock(balances)

--- a/code/go/0chain.net/smartcontract/minersc/miner.go
+++ b/code/go/0chain.net/smartcontract/minersc/miner.go
@@ -62,8 +62,6 @@ func (msc *MinerSmartContract) AddMiner(t *transaction.Transaction,
 			"failed to add new miner: Not in magic block")
 	}
 
-	logging.Logger.Info("add_miner: try to add miner", zap.Any("txn", t))
-
 	allMiners, err := getMinersList(balances)
 	if err != nil {
 		logging.Logger.Error("add_miner: Error in getting list from the DB",
@@ -85,14 +83,13 @@ func (msc *MinerSmartContract) AddMiner(t *transaction.Transaction,
 		zap.String("base URL", newMiner.N2NHost),
 		zap.String("ID", newMiner.ID),
 		zap.String("pkey", newMiner.PublicKey),
-		zap.Any("mscID", msc.ID),
+		zap.String("mscID", msc.ID),
 		zap.String("delegate_wallet", newMiner.Settings.DelegateWallet),
 		zap.Float64("service_charge", newMiner.Settings.ServiceChargeRatio),
 		zap.Int("num_delegates", newMiner.Settings.MaxNumDelegates),
 		zap.Int64("min_stake", int64(newMiner.Settings.MinStake)),
 		zap.Int64("max_stake", int64(newMiner.Settings.MaxStake)),
 	)
-	logging.Logger.Info("add_miner: MinerNode", zap.Any("node", newMiner))
 
 	if newMiner.PublicKey == "" || newMiner.ID == "" {
 		logging.Logger.Error("public key or ID is empty")

--- a/code/go/0chain.net/smartcontract/minersc/sharder.go
+++ b/code/go/0chain.net/smartcontract/minersc/sharder.go
@@ -70,8 +70,6 @@ func (msc *MinerSmartContract) AddSharder(
 	balances cstate.StateContextI,
 ) (resp string, err error) {
 
-	logging.Logger.Info("add_sharder", zap.Any("txn", t))
-
 	var newSharder = NewMinerNode()
 	if err = newSharder.Decode(input); err != nil {
 		logging.Logger.Error("Error in decoding the input", zap.Error(err))
@@ -107,14 +105,13 @@ func (msc *MinerSmartContract) AddSharder(
 		zap.String("base URL", newSharder.N2NHost),
 		zap.String("ID", newSharder.ID),
 		zap.String("pkey", newSharder.PublicKey),
-		zap.Any("mscID", msc.ID),
+		zap.String("mscID", msc.ID),
 		zap.String("delegate_wallet", newSharder.Settings.DelegateWallet),
 		zap.Float64("service_charge", newSharder.Settings.ServiceChargeRatio),
 		zap.Int("number_of_delegates", newSharder.Settings.MaxNumDelegates),
 		zap.Int64("min_stake", int64(newSharder.Settings.MinStake)),
 		zap.Int64("max_stake", int64(newSharder.Settings.MaxStake)))
 
-	logging.Logger.Info("SharderNode", zap.Any("node", newSharder))
 
 	if newSharder.PublicKey == "" || newSharder.ID == "" {
 		logging.Logger.Error("public key or ID is empty")
@@ -343,11 +340,10 @@ func (msc *MinerSmartContract) sharderKeep(_ *transaction.Transaction,
 		zap.String("base URL", newSharder.N2NHost),
 		zap.String("ID", newSharder.ID),
 		zap.String("pkey", newSharder.PublicKey),
-		zap.Any("mscID", msc.ID),
+		zap.String("mscID", msc.ID),
 		zap.Int64("pn_start_round", pn.StartRound),
 		zap.String("phase", pn.Phase.String()))
 
-	logging.Logger.Info("SharderNode", zap.Any("node", newSharder))
 	if newSharder.PublicKey == "" || newSharder.ID == "" {
 		logging.Logger.Error("public key or ID is empty")
 		return "", errors.New("PublicKey or the ID is empty. Cannot proceed")

--- a/code/go/0chain.net/smartcontract/multisigsc/test/blockchainclient.go
+++ b/code/go/0chain.net/smartcontract/multisigsc/test/blockchainclient.go
@@ -81,7 +81,7 @@ func discoverPoolMembers(discoveryFile string) {
 		} else {
 			if !isSliceEq(pm.Miners, members.Miners) || !isSliceEq(pm.Sharders, members.Sharders) {
 				Logger.Fatal("The members are different from", zap.String("URL", ip),
-					zap.Any("Miners", members.Miners), zap.Any("Sharders", pm.Sharders))
+					zap.Strings("Miners", members.Miners), zap.Strings("Sharders", pm.Sharders))
 			}
 		}
 	}
@@ -90,7 +90,7 @@ func discoverPoolMembers(discoveryFile string) {
 		Logger.Fatal("Could not discover blockchain")
 	}
 
-	Logger.Info("Discovered pool members", zap.Any("Miners", pm.Miners), zap.Any("Sharders", pm.Sharders))
+	Logger.Info("Discovered pool members", zap.Strings("Miners", pm.Miners), zap.Strings("Sharders", pm.Sharders))
 }
 
 func extractDiscoverIps(discFile string) []string {
@@ -171,7 +171,7 @@ func getOwnerWallet(signatureScheme, ownerKeysFile string) mptwallet.Wallet {
 
 // Register a client on the blockchain's MPT.
 func registerMPTWallet(w mptwallet.Wallet) {
-	Logger.Info("Registering MPT wallet", zap.Any("ClientID", w.ClientID))
+	Logger.Info("Registering MPT wallet", zap.String("ClientID", w.ClientID))
 
 	data, err := json.Marshal(w)
 	if err != nil {
@@ -181,7 +181,7 @@ func registerMPTWallet(w mptwallet.Wallet) {
 	for _, ip := range members.Miners {
 		body, err := httpclientutil.SendPostRequest(ip+httpclientutil.RegisterClient, data, "", "", nil)
 		if err != nil {
-			Logger.Fatal("HTTP POST error", zap.Error(err), zap.Any("body", body))
+			Logger.Fatal("HTTP POST error", zap.Error(err), zap.ByteString("body", body))
 		}
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1334,9 +1334,9 @@ func (sc *StorageSmartContract) finalizedPassRates(alloc *StorageAllocation) ([]
 
 		if ba.Stats.TotalChallenges == 0 {
 			logging.Logger.Warn("empty total challenges on finalizedPassRates",
-				zap.Any("OpenChallenges", ba.Stats.OpenChallenges),
-				zap.Any("FailedChallenges", ba.Stats.FailedChallenges),
-				zap.Any("SuccessChallenges", ba.Stats.SuccessChallenges))
+				zap.Int64("OpenChallenges", ba.Stats.OpenChallenges),
+				zap.Int64("FailedChallenges", ba.Stats.FailedChallenges),
+				zap.Int64("SuccessChallenges", ba.Stats.SuccessChallenges))
 			return nil, errors.New("empty total challenges")
 		}
 

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -740,7 +740,7 @@ func (sc *StorageSmartContract) challengeFailed(
 		return "", common.NewError("challenge_penalty_error", err.Error())
 	}
 
-	logging.Logger.Info("Challenge failed", zap.Any("challenge", challResp.ID))
+	logging.Logger.Info("Challenge failed", zap.String("challenge", challResp.ID))
 
 	err := sc.blobberPenalty(t, alloc, latestCompletedChallTime, allocChallenges, blobAlloc,
 		validators, balances)
@@ -772,7 +772,7 @@ func (sc *StorageSmartContract) getAllocationForChallenge(
 	case nil:
 	case util.ErrValueNotPresent:
 		logging.Logger.Error("client state has invalid allocations",
-			zap.Any("selected_allocation", allocID))
+			zap.String("selected_allocation", allocID))
 		return nil, common.NewErrorf("invalid_allocation",
 			"client state has invalid allocations")
 	default:

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -60,7 +60,7 @@ func (ipsc *StorageSmartContract) GetCost(t *transaction.Transaction, funcName s
 	}
 	cost, ok := conf.Cost[funcName]
 	if !ok {
-		logging.Logger.Error("no cost given", zap.Any("funcName", funcName))
+		logging.Logger.Error("no cost given", zap.String("funcName", funcName))
 		return math.MaxInt32, errors.New("no cost given for " + funcName)
 	}
 	return cost, nil


### PR DESCRIPTION
## Fixes
I'm following these rules - as much as possible, may have some exceptions. 
1. Use `zap.<Type>` instead of `zap.Any` whenever the type is supported by zap.
2. Remove any unneeded/debugging `zap.Any` from the logs.
3. Log IDs/Hashes/Rounds instead of the full objects esp. for `Node`s, `Block`s and `Transaction`s
4. Leave `zap.Any` if it's
    1. Used with a simple custom type e.g. `currency.Coin` 
    2. Logs a **single, not so big** object from a complex type
    3. Logs once or a limited number of times during the nodes lifetime.
5. Use `Logger.Error` whenever an error is logged.
6. Use `zap.Error(err)` instead of `zap.Any("error", err)`
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
