### PR TITLE
Fix testNodeStat

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -73,11 +73,12 @@ func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool,
 	}
 	m = minerDps[0].Miner
 
-	if "" == minerDps[0].ProviderRewards.ProviderID {
-		return m, nil, fmt.Errorf("cannot find provider rewards table for miner %v. rewards %v",
-			id, minerDps[0].ProviderRewards)
-	}
+	//if "" == minerDps[0].ProviderRewards.ProviderID {
+	//	return m, nil, fmt.Errorf("cannot find provider rewards table for miner %v. rewards %v",
+	//		id, minerDps[0].ProviderRewards)
+	//} todo remove
 	m.Rewards = minerDps[0].ProviderRewards
+	m.Rewards.ProviderID = id
 	if len(minerDps) == 1 && minerDps[0].DelegatePool.ProviderID == "" {
 		return m, nil, nil
 	}

--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -81,7 +81,8 @@ func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool,
 	//} todo
 	for i := 0; i < len(minerDps); i++ {
 		logging.Logger.Info("GetMinerWithDelegatePools Results",
-			zap.Any("delegate pool", minerDps[i].ProviderRewards),
+			zap.Int("index", i),
+			zap.Any("provider_rewards", minerDps[i].ProviderRewards),
 			zap.Any("miner", minerDps[i].Miner),
 			zap.Any("delegate pool", minerDps[i].DelegatePool),
 		)

--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/0chain/common/core/currency"
-	"github.com/0chain/common/core/logging"
-	"go.uber.org/zap"
 	"gorm.io/gorm/clause"
 
 	"0chain.net/smartcontract/dbs"
@@ -74,15 +72,6 @@ func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool,
 		return m, nil, fmt.Errorf("mismatched miner; want id %s but have id %s", id, minerDps[0].Miner.ID)
 	}
 	m = minerDps[0].Miner
-
-	for i := 0; i < len(minerDps); i++ {
-		logging.Logger.Info("GetMinerWithDelegatePools Results",
-			zap.Int("index", i),
-			zap.Any("provider_rewards", minerDps[i].ProviderRewards),
-			zap.Any("miner", minerDps[i].Miner),
-			zap.Any("delegate pool", minerDps[i].DelegatePool),
-		)
-	}
 
 	m.Rewards = minerDps[0].ProviderRewards
 	m.Rewards.ProviderID = id

--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -75,10 +75,6 @@ func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool,
 	}
 	m = minerDps[0].Miner
 
-	//if "" == minerDps[0].ProviderRewards.ProviderID {
-	//	return m, nil, fmt.Errorf("cannot find provider rewards table for miner %v. rewards %v",
-	//		id, minerDps[0].ProviderRewards)
-	//} todo
 	for i := 0; i < len(minerDps); i++ {
 		logging.Logger.Info("GetMinerWithDelegatePools Results",
 			zap.Int("index", i),
@@ -90,7 +86,7 @@ func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool,
 
 	m.Rewards = minerDps[0].ProviderRewards
 	m.Rewards.ProviderID = id
-	if len(minerDps) == 1 && minerDps[0].DelegatePool.ProviderID == "" {
+	if len(minerDps) == 1 && minerDps[0].DelegatePool.PoolID == "" {
 		// The miner has no delegate pools
 		return m, nil, nil
 	}

--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -72,11 +72,12 @@ func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool,
 		return m, nil, fmt.Errorf("mismatched miner; want id %s but have id %s", id, minerDps[0].Miner.ID)
 	}
 	m = minerDps[0].Miner
-	if id != minerDps[0].ProviderRewards.ProviderID {
-		return m, nil, fmt.Errorf("mismatched miner; want id %s but have id%s in provider rewrards",
-			id, minerDps[0].Miner.ID)
-	}
+
 	m.Rewards = minerDps[0].ProviderRewards
+	m.Rewards.ProviderID = id
+	if len(minerDps) == 1 && minerDps[0].DelegatePool.ProviderID == "" {
+		return m, nil, nil
+	}
 	for i := range minerDps {
 		dps = append(dps, minerDps[i].DelegatePool)
 		if id != minerDps[i].DelegatePool.ProviderID {

--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -79,8 +79,14 @@ func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool,
 	//	return m, nil, fmt.Errorf("cannot find provider rewards table for miner %v. rewards %v",
 	//		id, minerDps[0].ProviderRewards)
 	//} todo
-	logging.Logger.Info("GetMinerWithDelegatePools Results",
-		zap.Any("results", minerDps))
+	for i := 0; i < len(minerDps); i++ {
+		logging.Logger.Info("GetMinerWithDelegatePools Results",
+			zap.Any("delegate pool", minerDps[i].ProviderRewards),
+			zap.Any("miner", minerDps[i].Miner),
+			zap.Any("delegate pool", minerDps[i].DelegatePool),
+		)
+	}
+
 	m.Rewards = minerDps[0].ProviderRewards
 	m.Rewards.ProviderID = id
 	if len(minerDps) == 1 && minerDps[0].DelegatePool.ProviderID == "" {

--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -73,8 +73,11 @@ func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool,
 	}
 	m = minerDps[0].Miner
 
+	if "" == minerDps[0].ProviderRewards.ProviderID {
+		return m, nil, fmt.Errorf("cannot find provider rewards table for miner %v. rewards %v",
+			id, minerDps[0].ProviderRewards)
+	}
 	m.Rewards = minerDps[0].ProviderRewards
-	m.Rewards.ProviderID = id
 	if len(minerDps) == 1 && minerDps[0].DelegatePool.ProviderID == "" {
 		return m, nil, nil
 	}

--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -78,12 +78,13 @@ func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool,
 	//if "" == minerDps[0].ProviderRewards.ProviderID {
 	//	return m, nil, fmt.Errorf("cannot find provider rewards table for miner %v. rewards %v",
 	//		id, minerDps[0].ProviderRewards)
-	//}
+	//} todo
 	logging.Logger.Info("GetMinerWithDelegatePools Results",
 		zap.Any("results", minerDps))
 	m.Rewards = minerDps[0].ProviderRewards
 	m.Rewards.ProviderID = id
 	if len(minerDps) == 1 && minerDps[0].DelegatePool.ProviderID == "" {
+		// The miner has no delegate pools
 		return m, nil, nil
 	}
 	for i := range minerDps {

--- a/code/go/0chain.net/smartcontract/dbs/event/miner_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner_test.go
@@ -75,7 +75,7 @@ func TestGetMinerWithDelegatePoolsNoPools(t *testing.T) {
 
 	s, dps, err := edb.GetMinerWithDelegatePools(minerIds[1])
 
-	require.NoError(t, err, "Error while getting sharder with delegate pools")
+	require.NoError(t, err, "Error while getting miner with delegate pools")
 	require.Nil(t, dps, "there should be no delegate pools")
 	require.Equal(t, s.ID, minerIds[1])
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/miner_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner_test.go
@@ -53,9 +53,6 @@ func TestGetMinerWithDelegatePools(t *testing.T) {
 	})
 	require.NoError(t, err, "Error while inserting DelegatePool to event Database")
 
-	miners, err := edb.GetMiners()
-	miners = miners
-
 	p, err := edb.GetDelegatePool("pool_id", minerIds[1])
 	require.NoError(t, err, "Error while retrieving DelegatePool from event Database")
 	require.Equal(t, p.PoolID, "pool_id")
@@ -68,6 +65,19 @@ func TestGetMinerWithDelegatePools(t *testing.T) {
 	require.Equal(t, s.ID, minerIds[1])
 	require.Equal(t, 2, len(dps))
 	require.Equal(t, minerIds[1], dps[0].ProviderID)
+}
+
+func TestGetMinerWithDelegatePoolsNoPools(t *testing.T) {
+	edb, clean := GetTestEventDB(t)
+	defer clean()
+
+	minerIds := createMiners(t, edb, 2)
+
+	s, dps, err := edb.GetMinerWithDelegatePools(minerIds[1])
+
+	require.NoError(t, err, "Error while getting sharder with delegate pools")
+	require.Nil(t, dps, "there should be no delegate pools")
+	require.Equal(t, s.ID, minerIds[1])
 }
 
 func TestMinersBatchUpdate(t *testing.T) {

--- a/code/go/0chain.net/smartcontract/dbs/event/sharder.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/sharder.go
@@ -110,11 +110,13 @@ func (edb *EventDb) GetSharderWithDelegatePools(id string) (Sharder, []DelegateP
 		return s, nil, fmt.Errorf("mismatched sharder; want id %s but have id %s", id, sharderDps[0].Sharder.ID)
 	}
 	s = sharderDps[0].Sharder
-	if id != sharderDps[0].ProviderRewards.ProviderID {
-		return s, nil, fmt.Errorf("mismatched sharder; want id %s but have id %s in provider rewrards",
-			id, sharderDps[0].Sharder.ID)
-	}
+
 	s.Rewards = sharderDps[0].ProviderRewards
+	s.Rewards.ProviderID = id
+	if len(sharderDps) == 1 && sharderDps[0].DelegatePool.PoolID == "" {
+		// The sharder has no delegate pools
+		return s, nil, nil
+	}
 	for i := range sharderDps {
 		dps = append(dps, sharderDps[i].DelegatePool)
 		if id != sharderDps[i].DelegatePool.ProviderID {

--- a/code/go/0chain.net/smartcontract/dbs/event/sharder_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/sharder_test.go
@@ -67,6 +67,19 @@ func TestGetSharderWithDelegatePools(t *testing.T) {
 	require.Equal(t, "1", dps[0].ProviderID) // failed, the provider id is ""
 }
 
+func TestGetSharderWithDelegatePoolsNoPools(t *testing.T) {
+	edb, clean := GetTestEventDB(t)
+	defer clean()
+
+	createSharders(t, edb, 2)
+
+	s, dps, err := edb.GetSharderWithDelegatePools("1")
+
+	require.NoError(t, err, "Error while getting sharder with delegate pools")
+	require.Nil(t, dps, "there should be no delegate pools")
+	require.Equal(t, s.ID, "1")
+}
+
 func TestSharders(t *testing.T) {
 	t.Skip("only for local debugging, requires local postgresql")
 


### PR DESCRIPTION
## Fixes
Fix testNodeStat.
* Change to support miners and sharders with no stake pools. SQL + gorm returns an empty delegate pool object when the object has no stake pools. So we now test for this.
* Improve error message to show the errors from event database API.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
