### PR TITLE
refactor: use general methods for stake pooling

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/config.go
+++ b/code/go/0chain.net/smartcontract/storagesc/config.go
@@ -363,6 +363,10 @@ func (conf *Config) validateStakeRange(min, max currency.Coin) (err error) {
 	return
 }
 
+func (conf *Config) ValidateStakeRange(min, max currency.Coin) (err error) {
+	return conf.validateStakeRange(min, max)
+}
+
 func (conf *Config) Encode() (b []byte) {
 	var err error
 	if b, err = json.Marshal(conf); err != nil {


### PR DESCRIPTION
Signed-off-by: Kushal Kumar <kushalkumargupta4@gmail.com>

## Fixes #1862 

## Changes
- Use general stake pooling methods

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
