### PR TITLE
Add `no-mocks` flag to build and test scripts

### DIFF
--- a/docker.local/bin/build.miners.sh
+++ b/docker.local/bin/build.miners.sh
@@ -9,8 +9,21 @@ DOCKER_DIR="$ROOT/docker.local/build.miner"
 DOCKER_FILE="$DOCKER_DIR/Dockerfile"
 DOCKERCOMPOSE="$DOCKER_DIR/docker-compose.yml"
 
+generate_mocks=1
+for arg in "$@"
+do
+    case $arg in
+        --no-mocks)
+            generate_mocks=0
+        shift
+        ;;
+    esac
+done
+
 # generate mocks
-make build-mocks
+if (( generate_mocks == 1 )); then
+    make build-mocks
+fi
 
 cmd="build"
 

--- a/docker.local/bin/build.sharders.sh
+++ b/docker.local/bin/build.sharders.sh
@@ -4,8 +4,21 @@ set -e
 GIT_COMMIT=$(git rev-list -1 HEAD)
 echo "$GIT_COMMIT"
 
+generate_mocks=1
+for arg in "$@"
+do
+    case $arg in
+        --no-mocks)
+            generate_mocks=0
+        shift
+        ;;
+    esac
+done
+
 # generate mocks
-make build-mocks
+if (( generate_mocks == 1 )); then
+    make build-mocks
+fi
 
 cmd="build"
 

--- a/docker.local/bin/unit_test.sh
+++ b/docker.local/bin/unit_test.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 set -e
 
-# generate mocks
-make build-mocks
-
 cmd="build"
 dockerfile="docker.local/build.unit_test/Dockerfile"
 platform=""
+generate_mocks=1
 
 for arg in "$@"
 do
@@ -18,8 +16,17 @@ do
         platform="--platform=linux/amd64"
         shift
         ;;
+        --no-mocks)
+            generate_mocks=0
+        shift
+        ;;
     esac
 done
+
+# generate mocks
+if (( generate_mocks == 1 )); then
+    make build-mocks
+fi
 
 # Allocate interactive TTY to allow Ctrl-C.
 INTERACTIVE="-it"


### PR DESCRIPTION
## Fixes
Generating mocks take so long time every time we run `build.miner.sh`, `build.sharder.sh` and `unit_test.sh` while not being required everytime. This PR adds a flag to run the mentioned scripts skipping mock generation.

## Changes
- Added `no-mocks` flag to the mentioned scripts

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
