### PR TITLE
use ActiveBlobbersTimeLimit for /alloc_blobbers endpoint

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -240,7 +240,7 @@ func (edb *EventDb) GetBlobbersFromParams(allocation AllocationQuery, limit comm
 	dbStore = dbStore.Where("write_price between ? and ?", allocation.WritePriceRange.Min, allocation.WritePriceRange.Max)
 	dbStore = dbStore.Where("max_offer_duration >= ?", allocation.MaxOfferDuration.Nanoseconds())
 	dbStore = dbStore.Where("capacity - allocated >= ?", allocation.AllocationSize)
-	dbStore = dbStore.Where("last_health_check > ?", common.ToTime(now).Add(-time.Hour).Unix())
+	dbStore = dbStore.Where("last_health_check > ?", common.ToTime(now).Add(-ActiveBlobbersTimeLimit).Unix())
 	dbStore = dbStore.Where("(total_stake - offers_total) > ? * write_price", allocation.AllocationSizeInGB)
 	dbStore = dbStore.Limit(limit.Limit).Offset(limit.Offset).Order(clause.OrderByColumn{
 		Column: clause.Column{Name: "capacity"},


### PR DESCRIPTION
## Fixes  https://github.com/0chain/gosdk/issues/724

## Changes

to check for active blobbers `/getblobbers?active=true` we use `ActiveBlobbersTimeLimit` variable. Use the same variable for `/alloc_blobbers` blobbers. 

the endpoint `/alloc_blobbers` is called before creating an allocation to check to get active blobbers to include in the allocation. 

We in both the APIs we should use the same variable `ActiveBlobbersTimeLimit` 

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
