### PR TITLE
Chaning generate_mocks.sh to support BASEDIR with spaces

### DIFF
--- a/generate_mocks.sh
+++ b/generate_mocks.sh
@@ -9,37 +9,37 @@ generate_mock() {
 	mockery --case underscore --output=$OUTPUT --all
 }
 
-cd $BASEDIR/code/go/0chain.net/core || exit
+cd "${BASEDIR}/code/go/0chain.net/core" || exit
 rm -rf ../core/mocks
 generate_mock "../core/mocks"
 
-cd $BASEDIR/code/go/0chain.net/miner || exit
+cd "${BASEDIR}/code/go/0chain.net/miner" || exit
 rm -rf ../miner/mocks
 generate_mock "../miner/mocks"
 
-cd $BASEDIR/code/go/0chain.net/chaincore || exit
+cd "${BASEDIR}/code/go/0chain.net/chaincore" || exit
 rm -rf ../chaincore/mocks
 generate_mock "../chaincore/mocks"
 
-cd $BASEDIR/code/go/0chain.net/chaincore/chain/state || exit
+cd "${BASEDIR}/code/go/0chain.net/chaincore/chain/state" || exit
 rm -rf ../state/mocks
 generate_mock "../state/mocks"
 
-cd $BASEDIR/code/go/0chain.net/conductor || exit
+cd "${BASEDIR}/code/go/0chain.net/conductor" || exit
 rm -rf ../conductor/mocks
 generate_mock "../conductor/mocks"
 
-cd $BASEDIR/code/go/0chain.net/sharder || exit
+cd "${BASEDIR}/code/go/0chain.net/sharder" || exit
 rm -rf ../sharder/mocks
 generate_mock "../sharder/mocks"
 
-cd $BASEDIR/code/go/0chain.net/smartcontract || exit
+cd "${BASEDIR}/code/go/0chain.net/smartcontract" || exit
 rm -rf ../smartcontract/mocks
 generate_mock "../smartcontract/mocks"
 
-cd $BASEDIR/code/go/0chain.net/smartcontract/benchmark || exit
+cd "${BASEDIR}/code/go/0chain.net/smartcontract/benchmark" || exit
 rm -rf ../benchmark/mocks
 generate_mock "../benchmark/mocks"
 
-cd $BASEDIR/code/go/0chain.net || exit
+cd "${BASEDIR}/code/go/0chain.net" || exit
 go generate -run="mockery" ./...


### PR DESCRIPTION
## Fixes 
#2119 

## Changes
including quotation marks in generate_mocks.sh file 

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
