### PR TITLE
add isActive parameter to validators endpoint

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -1320,7 +1320,17 @@ func (srh *StorageRestHandler) validators(w http.ResponseWriter, r *http.Request
 		common.Respond(w, r, nil, common.NewErrInternal("no db connection"))
 		return
 	}
-	validators, err := edb.GetValidators(pagination)
+
+	values := r.URL.Query()
+	active := values.Get("active")
+
+	var validators []event.Validator
+	if active == "true" {
+		validators, err = edb.GetActiveValidators(pagination)
+	} else {
+		validators, err = edb.GetValidators(pagination)
+	}
+
 	if err != nil {
 		err := common.NewErrInternal("cannot get validator list" + err.Error())
 		common.Respond(w, r, nil, err)


### PR DESCRIPTION
## Fixes

## Changes
add a new query parameter `active=true` for /validators endpoint

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
