### PR TITLE
HotFix Benchmark panic. Add finalised allocation at index 2

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
@@ -28,7 +28,10 @@ import (
 	"0chain.net/core/common"
 )
 
-const mockMinLockDemand = 1
+const (
+	mockMinLockDemand            = 1
+	mockFinalizedAllocationIndex = 2
+)
 
 func AddMockAllocations(
 	clients, publicKeys []string,
@@ -83,9 +86,8 @@ func addMockAllocation(
 			FailedChallenges:          1,
 			LastestClosedChallengeTxn: "latest closed challenge transaction:" + id,
 		},
-		TimeUnit: 1 * time.Hour,
-		// make last allocation finalised
-		Finalized: i == viper.GetInt(sc.NumAllocations)-1,
+		TimeUnit:  1 * time.Hour,
+		Finalized: i == mockFinalizedAllocationIndex,
 		WritePool: mockWriePoolSize,
 	}
 	for j := 0; j < viper.GetInt(sc.NumCurators); j++ {

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
@@ -231,7 +231,7 @@ func BenchmarkTests(
 					Expiration:      common.Timestamp(50 * 60 * 60),
 					RemoveBlobberId: getMockBlobberId(0),
 					AddBlobberId:    getMockBlobberId(viper.GetInt(bk.NumBlobbers) - 1),
-					FileOptions: 	 63,
+					FileOptions:     63,
 				}
 				bytes, _ := json.Marshal(&uar)
 				return bytes
@@ -244,9 +244,8 @@ func BenchmarkTests(
 				HashIDField: datastore.HashIDField{
 					Hash: encryption.Hash("mock transaction hash"),
 				},
-				//CreationDate: common.Timestamp(viper.GetDuration(bk.StorageMinAllocDuration).Seconds()) + now,
 				CreationDate: creationTime + benchAllocationExpire(creationTime) + 1,
-				ClientID:     data.Clients[0],
+				ClientID:     data.Clients[getMockOwnerFromAllocationIndex(0, viper.GetInt(bk.NumActiveClients))],
 				ToClientID:   ADDRESS,
 			},
 			input: func() []byte {
@@ -599,12 +598,12 @@ func BenchmarkTests(
 				},
 				Value: rpMinLock,
 				ClientID: data.Clients[getMockOwnerFromAllocationIndex(
-					viper.GetInt(bk.NumAllocations)-1, viper.GetInt(bk.NumActiveClients))],
+					mockFinalizedAllocationIndex, viper.GetInt(bk.NumActiveClients))],
 				ToClientID: ADDRESS,
 			},
 			input: func() []byte {
 				bytes, _ := json.Marshal(&unlockRequest{
-					AllocationID: getMockAllocationId(viper.GetInt(bk.NumAllocations) - 1),
+					AllocationID: getMockAllocationId(mockFinalizedAllocationIndex),
 				})
 				return bytes
 			}(),


### PR DESCRIPTION
## Fixes
Fix panic in the benchmark for large numbers of allocations. Set allocation with index two as a finalised allocation.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
