### PR TITLE
Any action by third party (non owner) on an allocation should return an error except for expansion when third_party_extendable = true

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1149,9 +1149,11 @@ func (sc *StorageSmartContract) updateAllocationRequestInternal(
 		return "", err
 	}
 
-	if (t.ClientID != alloc.Owner || request.OwnerID != alloc.Owner) && !alloc.ThirdPartyExtendable {
-		return "", common.NewError("allocation_updating_failed",
-			"only owner can update the allocation")
+	if (t.ClientID != alloc.Owner || request.OwnerID != alloc.Owner) {
+		if !alloc.ThirdPartyExtendable || (request.Size == 0 && request.Expiration == 0) {
+			return "", common.NewError("allocation_updating_failed",
+				"only owner can update the allocation")
+		}
 	}
 
 	if err = request.validate(conf, alloc); err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1150,7 +1150,7 @@ func (sc *StorageSmartContract) updateAllocationRequestInternal(
 	}
 
 	if (t.ClientID != alloc.Owner || request.OwnerID != alloc.Owner) {
-		if !alloc.ThirdPartyExtendable || (request.Size == 0 && request.Expiration == 0) {
+		if !alloc.ThirdPartyExtendable || (request.Size <= 0 && request.Expiration <= 0) {
 			return "", common.NewError("allocation_updating_failed",
 				"only owner can update the allocation")
 		}

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -1919,7 +1919,7 @@ func TestStorageSmartContract_updateAllocationRequest(t *testing.T) {
 	assert.Equal(t, expectedSize, alloc.Size)
 	assert.Equal(t, expectedExpiration, alloc.Expiration)
 
-	// Other cannot perform any other action than extending. No error returned but the value is unchanged.
+	// Other cannot perform any other action than extending.
 	req = updateAllocationRequest{
 		ID:          alloc.ID,
 		FileOptions: 61,
@@ -1928,7 +1928,7 @@ func TestStorageSmartContract_updateAllocationRequest(t *testing.T) {
 	tp += 100
 	expectedFileOptions := alloc.FileOptions
 	resp, err = req.callUpdateAllocReq(t, otherClient.id, 20*x10, tp, ssc, balances)
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	alloc, err = ssc.getAllocation(allocID, balances)
 	require.NoError(t, err)


### PR DESCRIPTION
## Fixes
- Any action by third party (non owner) on an allocation should return an error except for expansion when `third_party_extendable = true` 
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
