### PR TITLE
script to generate timestamped migration files with boilerplate

### DIFF
--- a/generate_migration.sh
+++ b/generate_migration.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+ts=$(date +%s)
+fname=$1
+
+if [ -z "$fname" ]; then
+    echo "Usage: $0 <filename>"
+    exit 1
+fi
+
+
+# Write boilerplate of the migration file
+echo "-- +goose Up
+-- +goose StatementBegin
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- +goose StatementEnd" > "code/go/0chain.net/smartcontract/dbs/goose/migrations/""$ts""_$fname.sql"


### PR DESCRIPTION
## Fixes
Added script to generate migration files, prefixed with current unix timestamp at UTC+00 with goose migration boilerplate.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
