### PR TITLE
Optimize cancel_allocation SC

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1660,12 +1660,12 @@ func (sc *StorageSmartContract) finishAllocation(
 	}
 	fmt.Println("distribute rewards", time.Since(st))
 
-	st = time.Now()
-	var blobbers []*StorageNode
-	if blobbers, err = sc.getAllocationBlobbers(alloc, balances); err != nil {
-		return fmt.Errorf("could not get alloc blobbers: %v", err)
-	}
-	fmt.Println("get allocation blobbers", time.Since(st))
+	//st = time.Now()
+	//var blobbers []*StorageNode
+	//if blobbers, err = sc.getAllocationBlobbers(alloc, balances); err != nil {
+	//	return fmt.Errorf("could not get alloc blobbers: %v", err)
+	//}
+	//fmt.Println("get allocation blobbers", time.Since(st))
 
 	var cp *challengePool
 	if cp, err = sc.getChallengePool(alloc.ID, balances); err != nil {
@@ -1680,10 +1680,10 @@ func (sc *StorageSmartContract) finishAllocation(
 
 	var passPayments currency.Coin
 	for i, d := range alloc.BlobberAllocs {
-		var b = blobbers[i]
-		if b.ID != d.BlobberID {
-			return fmt.Errorf("blobber %s and %s don't match", b.ID, d.BlobberID)
-		}
+		//var b = blobbers[i]
+		//if b.ID != d.BlobberID {
+		//	return fmt.Errorf("blobber %s and %s don't match", b.ID, d.BlobberID)
+		//}
 
 		ts := time.Now()
 		if alloc.UsedSize > 0 && cp.Balance > 0 && passRates[i] > 0 && d.Stats != nil {
@@ -1698,9 +1698,9 @@ func (sc *StorageSmartContract) finishAllocation(
 				return err
 			}
 
-			err = sps[i].DistributeRewards(reward, b.ID, spenum.Blobber, spenum.ChallengePassReward, balances)
+			err = sps[i].DistributeRewards(reward, d.BlobberID, spenum.Blobber, spenum.ChallengePassReward, balances)
 			if err != nil {
-				return fmt.Errorf("failed to distribute rewards blobber: %s, err: %v", b.ID, err)
+				return fmt.Errorf("failed to distribute rewards blobber: %s, err: %v", d.BlobberID, err)
 			}
 
 			d.Spent, err = currency.AddCoin(d.Spent, reward)
@@ -1740,24 +1740,7 @@ func (sc *StorageSmartContract) finishAllocation(
 				Delta:        int64((stake - before[i]) / d.Terms.WritePrice),
 			})
 		}
-
-		//ts = time.Now()
-		// update the blobber
-		//if _, err = balances.InsertTrieNode(b.GetKey(), b); err != nil {
-		//	return fmt.Errorf("failed to save blobber: %s, err: %v", d.BlobberID, err)
-		//}
-
-		//blobSave += time.Since(ts)
-
-		emitUpdateBlobber(b, balances)
-		// TODO: move to populate challenge
-		//ts = time.Now()
-		//err = removeAllocationFromBlobber(balances, d)
-		//if err != nil {
-		//	return err
-		//}
-		//
-		//removeAlloc += time.Since(ts)
+		//emitUpdateBlobber(b, balances)
 	}
 
 	fmt.Println("stake save:", stakeSave)

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1622,7 +1622,6 @@ func (sc *StorageSmartContract) finishAllocation(
 ) (err error) {
 	before := make([]currency.Coin, len(sps))
 
-	st := time.Now()
 	// we can use the i for the blobbers list above because of algorithm
 	// of the getAllocationBlobbers method; also, we can use the i in the
 	// passRates list above because of algorithm of the adjustChallenges
@@ -1658,34 +1657,14 @@ func (sc *StorageSmartContract) finishAllocation(
 			}
 		}
 	}
-	fmt.Println("distribute rewards", time.Since(st))
-
-	//st = time.Now()
-	//var blobbers []*StorageNode
-	//if blobbers, err = sc.getAllocationBlobbers(alloc, balances); err != nil {
-	//	return fmt.Errorf("could not get alloc blobbers: %v", err)
-	//}
-	//fmt.Println("get allocation blobbers", time.Since(st))
 
 	var cp *challengePool
 	if cp, err = sc.getChallengePool(alloc.ID, balances); err != nil {
 		return fmt.Errorf("could not get challenge pool of alloc: %s, err: %v", alloc.ID, err)
 	}
 
-	st = time.Now()
-	var (
-		stakeSave time.Duration
-		//blobSave  time.Duration
-	)
-
 	var passPayments currency.Coin
 	for i, d := range alloc.BlobberAllocs {
-		//var b = blobbers[i]
-		//if b.ID != d.BlobberID {
-		//	return fmt.Errorf("blobber %s and %s don't match", b.ID, d.BlobberID)
-		//}
-
-		ts := time.Now()
 		if alloc.UsedSize > 0 && cp.Balance > 0 && passRates[i] > 0 && d.Stats != nil {
 			ratio := float64(d.Stats.UsedSize) / float64(alloc.UsedSize)
 			cpBalance, err := cp.Balance.Float64()
@@ -1712,41 +1691,8 @@ func (sc *StorageSmartContract) finishAllocation(
 				return fmt.Errorf("pass payments: %v", err)
 			}
 		}
-
-		ts = time.Now()
-		if err = sps[i].Save(spenum.Blobber, d.BlobberID, balances); err != nil {
-			return fmt.Errorf("failed to save stake pool: %s, err: %v", d.BlobberID, err)
-		}
-		fmt.Println("save stake pool", time.Since(ts))
-
-		staked, err := sps[i].stake()
-		if err != nil {
-			return err
-		}
-
-		stakeSave += time.Since(ts)
-
-		tag, data := event.NewUpdateBlobberTotalStakeEvent(d.BlobberID, staked)
-		balances.EmitEvent(event.TypeStats, tag, d.BlobberID, data)
-		if d.Terms.WritePrice > 0 {
-			stake, err := sps[i].stake()
-			if err != nil {
-				return err
-			}
-			balances.EmitEvent(event.TypeStats, event.TagAllocBlobberValueChange, d.BlobberID, event.AllocationBlobberValueChanged{
-				FieldType:    event.Staked,
-				AllocationId: "",
-				BlobberId:    d.BlobberID,
-				Delta:        int64((stake - before[i]) / d.Terms.WritePrice),
-			})
-		}
-		//emitUpdateBlobber(b, balances)
 	}
 
-	fmt.Println("stake save:", stakeSave)
-	//fmt.Println("blob save:", blobSave)
-
-	fmt.Println("blobber alloc actions", time.Since(st))
 	prevBal := cp.Balance
 	cp.Balance, err = currency.MinusCoin(cp.Balance, passPayments)
 	if err != nil {
@@ -1789,6 +1735,27 @@ func (sc *StorageSmartContract) finishAllocation(
 		err = sps[i].DistributeRewards(reward, ba.BlobberID, spenum.Blobber, spenum.CancellationChargeReward, balances)
 		if err != nil {
 			return fmt.Errorf("failed to distribute rewards, blobber: %s, err: %v", ba.BlobberID, err)
+		}
+
+		if err = sps[i].Save(spenum.Blobber, ba.BlobberID, balances); err != nil {
+			return fmt.Errorf("failed to save stake pool: %s, err: %v", ba.BlobberID, err)
+		}
+
+		staked, err := sps[i].stake()
+		if err != nil {
+			return err
+		}
+
+		tag, data := event.NewUpdateBlobberTotalStakeEvent(ba.BlobberID, staked)
+		balances.EmitEvent(event.TypeStats, tag, ba.BlobberID, data)
+		if ba.Terms.WritePrice > 0 {
+			balances.EmitEvent(event.TypeStats, event.TagAllocBlobberValueChange,
+				ba.BlobberID, event.AllocationBlobberValueChanged{
+					FieldType:    event.Staked,
+					AllocationId: "",
+					BlobberId:    ba.BlobberID,
+					Delta:        int64((staked - before[i]) / ba.Terms.WritePrice),
+				})
 		}
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1674,9 +1674,8 @@ func (sc *StorageSmartContract) finishAllocation(
 
 	st = time.Now()
 	var (
-		stakeSave   time.Duration
-		blobSave    time.Duration
-		removeAlloc time.Duration
+		stakeSave time.Duration
+		//blobSave  time.Duration
 	)
 
 	var passPayments currency.Coin
@@ -1714,9 +1713,11 @@ func (sc *StorageSmartContract) finishAllocation(
 			}
 		}
 
+		ts = time.Now()
 		if err = sps[i].Save(spenum.Blobber, d.BlobberID, balances); err != nil {
 			return fmt.Errorf("failed to save stake pool: %s, err: %v", d.BlobberID, err)
 		}
+		fmt.Println("save stake pool", time.Since(ts))
 
 		staked, err := sps[i].stake()
 		if err != nil {
@@ -1740,13 +1741,13 @@ func (sc *StorageSmartContract) finishAllocation(
 			})
 		}
 
-		ts = time.Now()
+		//ts = time.Now()
 		// update the blobber
-		if _, err = balances.InsertTrieNode(b.GetKey(), b); err != nil {
-			return fmt.Errorf("failed to save blobber: %s, err: %v", d.BlobberID, err)
-		}
+		//if _, err = balances.InsertTrieNode(b.GetKey(), b); err != nil {
+		//	return fmt.Errorf("failed to save blobber: %s, err: %v", d.BlobberID, err)
+		//}
 
-		blobSave += time.Since(ts)
+		//blobSave += time.Since(ts)
 
 		emitUpdateBlobber(b, balances)
 		// TODO: move to populate challenge
@@ -1760,8 +1761,7 @@ func (sc *StorageSmartContract) finishAllocation(
 	}
 
 	fmt.Println("stake save:", stakeSave)
-	fmt.Println("blob save:", blobSave)
-	fmt.Println("remove allocation:", removeAlloc)
+	//fmt.Println("blob save:", blobSave)
 
 	fmt.Println("blobber alloc actions", time.Since(st))
 	prevBal := cp.Balance

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -2286,22 +2286,6 @@ func Test_finalize_allocation(t *testing.T) {
 	assert.True(t,
 		alloc.BlobberAllocs[0].MinLockDemand <= alloc.BlobberAllocs[0].Spent,
 		"should receive min_lock_demand")
-
-	// assert that allocation is removed from all the blobber
-	for _, b := range blobs {
-		p, err := partitionsBlobberAllocations(b.id, balances)
-		require.NoError(t, err)
-		var baNode BlobberAllocationNode
-		err = p.Get(balances, allocID, &baNode)
-		require.True(t, partitions.ErrItemNotFound(err))
-
-	}
-	// assert blobber challenge ready partition is removed
-	challengeParts, err := partitionsChallengeReadyBlobbers(balances)
-	require.NoError(t, err)
-	var crbNode ChallengeReadyBlobber
-	err = challengeParts.Get(balances, b1.id, &crbNode)
-	require.True(t, partitions.ErrItemNotFound(err))
 }
 
 func Test_finalize_allocation_do_not_remove_challenge_ready(t *testing.T) {
@@ -2459,19 +2443,4 @@ func Test_finalize_allocation_do_not_remove_challenge_ready(t *testing.T) {
 	assert.True(t,
 		alloc.BlobberAllocs[0].MinLockDemand <= alloc.BlobberAllocs[0].Spent,
 		"should receive min_lock_demand")
-
-	// assert that allocation is removed from blobber
-	p, err := partitionsBlobberAllocations(b1.id, balances)
-	require.NoError(t, err)
-	var baNode BlobberAllocationNode
-	err = p.Get(balances, allocID, &baNode)
-	require.True(t, partitions.ErrItemNotFound(err))
-
-	// assert blobber challenge ready partition is not removed as we still have one allocation is bound
-	challengeParts, err := partitionsChallengeReadyBlobbers(balances)
-	require.NoError(t, err)
-	var crbNode ChallengeReadyBlobber
-	err = challengeParts.Get(balances, b1.id, &crbNode)
-	require.NoError(t, err)
-	require.Equal(t, b1.id, crbNode.BlobberID)
 }

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
@@ -110,6 +110,17 @@ func addMockAllocation(
 			AllocationRoot: encryption.Hash("allocation root"),
 		}
 		sa.BlobberAllocs = append(sa.BlobberAllocs, &ba)
+
+		blobAllocPart, err := partitionsBlobberAllocations(bId, balances)
+		if err != nil {
+			log.Fatal("add blob alloc partition", err)
+		}
+		if err := blobAllocPart.Add(balances, &BlobberAllocationNode{ID: sa.ID}); err != nil {
+			log.Fatal("add blob alloc node", err)
+		}
+		if err := blobAllocPart.Save(balances); err != nil {
+			log.Fatal("save blob alloc part", err)
+		}
 	}
 
 	if _, err := balances.InsertTrieNode(sa.GetKey(ADDRESS), sa); err != nil {
@@ -225,29 +236,6 @@ func AddMockChallenges(
 				blobAlloc[oc.BlobberID] = make(map[string]*AllocOpenChallenge)
 			}
 			blobAlloc[oc.BlobberID][ch.AllocationID] = oc
-		}
-	}
-
-	// adding blobber challenge allocation partition
-	for blobberID, val := range blobAlloc {
-
-		aPart, err := partitionsBlobberAllocations(blobberID, balances)
-		if err != nil {
-			panic(err)
-		}
-		for allocID := range val {
-
-			err = aPart.Add(balances, &BlobberAllocationNode{
-				ID: allocID,
-			})
-			if err != nil {
-				panic(err)
-			}
-		}
-		err = aPart.Save(balances)
-
-		if err != nil {
-			panic(err)
 		}
 	}
 }


### PR DESCRIPTION
## Fixes
- closes #572
## Changes
- Optimize cancel_allocation SC from around `14ms` to about `3.8ms`. Alloc blobbers' stake pools save process is still slow, so the more blobbers an alloc has, the slower the cancel_allocation SC would be. The benchmark test seems only has 4 blobbers each alloc. So it could be slower if an allocation has 12 blobbers. One way to improve it is do not save rewards to all blobbers' stake pools at once. Instead, we can save the rewards into an `alloc_blobber_rewards` partition, and distribute the rewards to one blobber each round in `payFees` txn.  In this way, no matter how many blobbers each alloc has, the cancel_allocation SC execution time would be the same all the time. 
- Removed unnecessary blobber storage node loading and saving
- Fixed a mistake on saving stake pools. Rewards didn't saved correctly, there were coins distributing to pools after saving. 

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
