### PR TITLE
fix conditional checks for readpool token movement

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber2_test.go
@@ -33,7 +33,6 @@ const (
 	errPreviousMarker    = "validations with previous marker failed"
 	errEarlyAllocation   = "early reading, allocation not started yet"
 	errExpiredAllocation = "late reading, allocation expired"
-	errNoTokensReadPool  = "no tokens"
 	errNotEnoughTokens   = "not enough tokens"
 )
 
@@ -174,16 +173,6 @@ func TestCommitBlobberRead(t *testing.T) {
 		require.Error(t, err)
 		require.True(t, strings.Contains(err.Error(), errCommitBlobber))
 		require.True(t, strings.Contains(err.Error(), errExpiredAllocation))
-	})
-
-	t.Run(errNoTokensReadPool+" expired blobbers", func(t *testing.T) {
-		var expiredReadPools = mockReadPool{}
-		var err = testCommitBlobberRead(
-			t, blobberYaml, lastRead, read, allocation, stakes, expiredReadPools,
-		)
-		require.Error(t, err)
-		require.True(t, strings.Contains(err.Error(), errCommitBlobber))
-		require.True(t, strings.Contains(err.Error(), errNoTokensReadPool))
 	})
 
 	t.Run(errNotEnoughTokens+" expired blobbers", func(t *testing.T) {

--- a/code/go/0chain.net/smartcontract/storagesc/readpool.go
+++ b/code/go/0chain.net/smartcontract/storagesc/readpool.go
@@ -110,11 +110,7 @@ func (rp *readPool) moveToBlobber(allocID, blobID string,
 	var moved currency.Coin
 	currentBalance := rp.Balance
 
-	if currentBalance == 0 {
-		return "", fmt.Errorf("no tokens in read pool for allocation: %s,"+
-			" blobber: %s", allocID, blobID)
-	}
-	if value >= currentBalance {
+	if value > currentBalance {
 		return "", fmt.Errorf("not enough tokens in read pool for "+
 			"allocation: %s, blobber: %s", allocID, blobID)
 	} else {


### PR DESCRIPTION
## Fixes
- Removes explicit check for 0 balance, it is unnecessary
- Fixes >= to >, no reason to throw an error if readpool has exactly the amount that is needed
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
