### PR TITLE
Use allocation id to make readmarker key

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -1571,15 +1571,17 @@ func (srh *StorageRestHandler) getReadMarkers(w http.ResponseWriter, r *http.Req
 //	500:
 func (srh *StorageRestHandler) getLatestReadMarker(w http.ResponseWriter, r *http.Request) {
 	var (
-		clientID  = r.URL.Query().Get("client")
-		blobberID = r.URL.Query().Get("blobber")
+		clientID     = r.URL.Query().Get("client")
+		blobberID    = r.URL.Query().Get("blobber")
+		allocationID = r.URL.Query().Get("allocation")
 
 		commitRead = &ReadConnection{}
 	)
 
 	commitRead.ReadMarker = &ReadMarker{
-		BlobberID: blobberID,
-		ClientID:  clientID,
+		BlobberID:    blobberID,
+		ClientID:     clientID,
+		AllocationID: allocationID,
 	}
 
 	err := srh.GetQueryStateContext().GetTrieNode(commitRead.GetKey(ADDRESS), commitRead)
@@ -2182,7 +2184,7 @@ func blobberTableToStorageNode(blobber event.Blobber) storageNodeResponse {
 		UncollectedServiceCharge: blobber.Rewards.Rewards,
 		IsKilled:                 blobber.IsKilled,
 		IsShutdown:               blobber.IsShutdown,
-		SavedData: 			  	  blobber.SavedData,
+		SavedData:                blobber.SavedData,
 	}
 }
 

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -742,7 +742,7 @@ func (sa *StorageAllocation) addToWritePool(
 				sa.WritePool = writePool
 			}
 		}
-	
+
 	}
 
 	i, err := txn.Value.Int64()
@@ -1480,7 +1480,7 @@ type ReadConnection struct {
 
 func (rc *ReadConnection) GetKey(globalKey string) datastore.Key {
 	return datastore.Key(globalKey +
-		encryption.Hash(rc.ReadMarker.BlobberID+":"+rc.ReadMarker.ClientID))
+		encryption.Hash(rc.ReadMarker.BlobberID+rc.ReadMarker.ClientID+rc.ReadMarker.AllocationID))
 }
 
 func (rc *ReadConnection) Decode(input []byte) error {


### PR DESCRIPTION
## Fixes
Use allocation id to generate key for client readmarkers. The issue was if client issues two different readmarkers for different allocations which reside in same blobber then function,
```
func (rc *ReadConnection) GetKey(globalKey string) datastore.Key {
	return datastore.Key(globalKey +
		encryption.Hash(rc.ReadMarker.BlobberID + ":" + rc.ReadMarker.ClientID)
}
```
would return same latest Redeemed readmarker object for both allocations which is erroneous because allocations will have different read price and also the readcounter record will get affected.
To fix this issue I've simply modified this function to,
```
func (rc *ReadConnection) GetKey(globalKey string) datastore.Key {
	return datastore.Key(globalKey +
		encryption.Hash(rc.ReadMarker.BlobberID+rc.ReadMarker.ClientID+rc.ReadMarker.AllocationID))
}
``` 
Here I've also removed ":" inclusion.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber: https://github.com/0chain/blobber/pull/1019
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
