### PR TITLE
Fix "allocated" field of the blobber is increased even before it's added to the allocation

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -985,7 +985,21 @@ func (sa *StorageAllocation) changeBlobbers(
 	if err != nil {
 		return nil, err
 	}
-	addedBlobber.Allocated += sa.bSize()
+
+	var sp *stakePool
+	if sp, err = ssc.getStakePool(spenum.Blobber, addedBlobber.ID, balances); err != nil {
+		return nil, fmt.Errorf("can't get blobber's stake pool: %v", err)
+	}
+	staked, err := sp.stake()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := sa.isActive(addedBlobber, staked, sp.TotalOffers, conf, now); err != nil {
+		return nil, err
+	}
+
+	addedBlobber.Allocated += sa.bSize() // Why increase allocation then check if the free capacity is enough?
 	balances.EmitEvent(event.TypeStats, event.TagAllocBlobberValueChange, addedBlobber.ID, event.AllocationBlobberValueChanged{
 		FieldType:    event.Allocated,
 		AllocationId: sa.ID,
@@ -1007,24 +1021,12 @@ func (sa *StorageAllocation) changeBlobbers(
 		return nil, fmt.Errorf("failed to add allocation to blobber: %v", err)
 	}
 
-	var sp *stakePool
-	if sp, err = ssc.getStakePool(spenum.Blobber, addedBlobber.ID, balances); err != nil {
-		return nil, fmt.Errorf("can't get blobber's stake pool: %v", err)
-	}
-	staked, err := sp.stake()
-	if err != nil {
-		return nil, err
-	}
 
 	if err := sp.addOffer(ba.Offer()); err != nil {
 		return nil, fmt.Errorf("failed to add offter: %v", err)
 	}
 
 	if err := sp.Save(spenum.Blobber, addId, balances); err != nil {
-		return nil, err
-	}
-
-	if err := sa.isActive(addedBlobber, staked, sp.TotalOffers, conf, now); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Fixes
- To reproduce:
1. Adjust the capacity of a blobber to like 1.9 GB
2. Try to add it to an allocation of size 1 GB
3. Will receive an error saying "Insufficient free capacity" although the blobber capacity > allocation size.

- Reason
[Here](https://github.com/0chain/0chain/blob/837ce18d5518469383993bacae455fbe5143e50d/code/go/0chain.net/smartcontract/storagesc/models.go#L988) allocated field of the blobber is increased with the size of the allocation, but only [here](https://github.com/0chain/0chain/blob/837ce18d5518469383993bacae455fbe5143e50d/code/go/0chain.net/smartcontract/storagesc/models.go#L1027) (after the increase) it's tested if it has free capacity or not. 

## Changes
- Fix this behavior i.e. test before incrementing.
## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
