### PR TITLE
Assert client balances after transfer and mint

### DIFF
--- a/code/go/0chain.net/chaincore/chain/state.go
+++ b/code/go/0chain.net/chaincore/chain/state.go
@@ -500,11 +500,11 @@ func (c *Chain) updateState(ctx context.Context, b *block.Block, bState util.Mer
 
 func sumOfFromToBalance(sctx bcstate.StateContextI, from, to string) (currency.Coin, error) {
 	ofb, err := sctx.GetClientBalance(from)
-	if err != nil {
+	if err != nil && err != util.ErrValueNotPresent {
 		return 0, err
 	}
 	otb, err := sctx.GetClientBalance(to)
-	if err != nil {
+	if err != nil && err != util.ErrValueNotPresent {
 		return 0, err
 	}
 
@@ -636,7 +636,7 @@ func (c *Chain) transferAmount(sctx bcstate.StateContextI, fromClient, toClient 
 
 func (c *Chain) mintAmountWithAssert(sctx bcstate.StateContextI, toClient datastore.Key, amount currency.Coin) (eu *event.User, err error) {
 	originBalance, err := sctx.GetClientBalance(toClient)
-	if err != nil {
+	if err != nil && err != util.ErrValueNotPresent {
 		return nil, err
 	}
 

--- a/code/go/0chain.net/chaincore/state/state.go
+++ b/code/go/0chain.net/chaincore/state/state.go
@@ -40,6 +40,19 @@ func (s *State) GetHashBytes() []byte {
 	return encryption.RawHash(s.Encode())
 }
 
+func (s *State) Clone() *State {
+	ns := &State{
+		TxnHash:      s.TxnHash,
+		TxnHashBytes: make([]byte, len(s.TxnHashBytes)),
+		Round:        s.Round,
+		Balance:      s.Balance,
+		Nonce:        s.Nonce,
+	}
+
+	copy(ns.TxnHashBytes, s.TxnHashBytes)
+	return ns
+}
+
 /*Encode - implement SecureSerializableValueI interface */
 func (s *State) Encode() []byte {
 	buf := bytes.NewBuffer(nil)

--- a/code/go/0chain.net/smartcontract/stakepool/stakepool.go
+++ b/code/go/0chain.net/smartcontract/stakepool/stakepool.go
@@ -515,6 +515,21 @@ func (sp *StakePool) DistributeRewards(
 	}
 	var spUpdate = NewStakePoolReward(providerId, providerType, rewardType)
 
+	defer func() {
+		if err != nil {
+			return
+		}
+
+		totalRewards := spUpdate.Reward
+		for _, p := range spUpdate.DelegateRewards {
+			totalRewards += p
+		}
+
+		if totalRewards != value {
+			logging.Logger.Panic(fmt.Sprintf("distribute rewards error: total rewards %d != value %d", totalRewards, value))
+		}
+	}()
+
 	// if no stake pools pay all rewards to the provider
 	if len(sp.Pools) == 0 {
 		sp.Reward, err = currency.AddCoin(sp.Reward, value)

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -868,7 +868,10 @@ func (sa *StorageAllocation) cost() (currency.Coin, error) {
 		if err != nil {
 			return 0, err
 		}
-		cost += c
+		cost, err = currency.AddCoin(cost, c)
+		if err != nil {
+			return 0, err
+		}
 	}
 	return cost, nil
 }
@@ -1020,7 +1023,6 @@ func (sa *StorageAllocation) changeBlobbers(
 	if err != nil {
 		return nil, fmt.Errorf("failed to add allocation to blobber: %v", err)
 	}
-
 
 	if err := sp.addOffer(ba.Offer()); err != nil {
 		return nil, fmt.Errorf("failed to add offter: %v", err)


### PR DESCRIPTION
## Fixes
- Partial fixes for #1270

## Changes
- Added state context cach for clients, so when client state is loaded/inserted to MPT, the client state will be set to the cahce. Adding this is to avoid duplicate MPT reading when checking the clients balances.
- The zcnsc.Burn transaction would be processed in the `transfer` case

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
