### PR TITLE
Fix wrong validator health check cost config

### DIFF
--- a/docker.local/config/sc.yaml
+++ b/docker.local/config/sc.yaml
@@ -68,8 +68,6 @@ smart_contracts:
       delete_sharder: 100
       miner_health_check: 100
       sharder_health_check: 100
-      blobber_health_check: 100
-      validator_health_check: 100
       contributeMpk: 100
       shareSignsOrShares: 100
       wait: 100
@@ -215,6 +213,7 @@ smart_contracts:
       free_allocation_request: 1500
       free_update_allocation: 2500
       blobber_health_check: 100
+      validator_health_check: 100
       update_blobber_settings: 100
       update_validator_settings: 100
       pay_blobber_block_rewards: 100


### PR DESCRIPTION
## Fixes
```sh
2023-04-13 14:53:21 | 2023-04-13T04:46:43.978Z	ERROR	storagesc/sc.go:63	no cost given	{"funcName": "validator_health_check"} 
2023-04-13 14:53:21 | 2023-04-13T04:46:43.979Z	ERROR	storagesc/sc.go:63	no cost given	{"funcName": "validator_health_check"} 
2023-04-13 14:53:22 | 2023-04-13T04:42:28.837Z	ERROR	storagesc/challenge.go:1102	generate_challenge	{"error": "validators number does not meet minimum challenge requirement", "validator num": 0, "minimum required": 2}

```

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
