### PR TITLE
Fix blobber penalty calculation

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -431,10 +431,12 @@ func (edb *EventDb) blobberSpecificRevenue(spus []dbs.StakePoolReward) error {
 		totalChanges = 0
 	)
 
-	for i, spu := range spus {
+	blobberIdx := -1
+	for _, spu := range spus {
 		if spu.Type != spenum.Blobber {
 			continue
 		}
+		blobberIdx++
 		ids = append(ids, spu.ProviderID.ID)
 		totalBlockRewards = append(totalBlockRewards, 0)
 		totalStorageIncome = append(totalStorageIncome, 0)
@@ -444,17 +446,17 @@ func (edb *EventDb) blobberSpecificRevenue(spus []dbs.StakePoolReward) error {
 		switch (spu.RewardType) {
 			case spenum.BlockRewardBlobber:
 				totalChanges++
-				totalBlockRewards[i] = int64(spu.Reward)
+				totalBlockRewards[blobberIdx] = int64(spu.Reward)
 			case spenum.ChallengePassReward:
 				totalChanges++
-				totalStorageIncome[i] = int64(spu.Reward)
+				totalStorageIncome[blobberIdx] = int64(spu.Reward)
 			case spenum.FileDownloadReward:
 				totalChanges++
-				totalReadIncome[i] = int64(spu.Reward)
+				totalReadIncome[blobberIdx] = int64(spu.Reward)
 			case spenum.ChallengeSlashPenalty:
 				totalChanges++
 				for _, penalty := range spu.DelegatePenalties {
-					totalSlashedStake[i] = int64(penalty)
+					totalSlashedStake[blobberIdx] += int64(penalty)
 				}
 		}
 	}

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -447,7 +447,9 @@ func (edb *EventDb) blobberSpecificRevenue(spus []dbs.StakePoolReward) error {
 				totalReadIncome[i] = int64(spu.Reward)
 			case spenum.ChallengeSlashPenalty:
 				totalChanges++
-				totalSlashedStake[i] = int64(spu.Reward)
+				for _, penalty := range spu.DelegatePenalties {
+					totalSlashedStake[i] = int64(penalty)
+				}
 		}
 	}
 

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -52,7 +52,7 @@ type Blobber struct {
 	ChallengesCompleted uint64  `json:"challenges_completed"`
 	OpenChallenges      uint64  `json:"open_challenges"`
 	RankMetric          float64 `json:"rank_metric" gorm:"index"` // currently ChallengesPassed / ChallengesCompleted
-	TotalBlockReward	currency.Coin   `json:"total_block_reward"`
+	TotalBlockRewards	currency.Coin   `json:"total_block_rewards"`
 	TotalStorageIncome 	currency.Coin   `json:"total_storage_income"`
 	TotalReadIncome 	currency.Coin   `json:"total_read_income"`
 	TotalSlashedStake 	currency.Coin   `json:"total_slashed_stake"`
@@ -424,7 +424,7 @@ func (edb *EventDb) updateBlobberChallenges(deltas []ChallengeStatsDeltas) error
 func (edb *EventDb) blobberSpecificRevenue(spus []dbs.StakePoolReward) error {
 	var (
 		ids []string
-		totalBlockReward []int64
+		totalBlockRewards []int64
 		totalStorageIncome []int64
 		totalReadIncome []int64
 		totalSlashedStake []int64
@@ -436,7 +436,7 @@ func (edb *EventDb) blobberSpecificRevenue(spus []dbs.StakePoolReward) error {
 			continue
 		}
 		ids = append(ids, spu.ProviderID.ID)
-		totalBlockReward = append(totalBlockReward, 0)
+		totalBlockRewards = append(totalBlockRewards, 0)
 		totalStorageIncome = append(totalStorageIncome, 0)
 		totalReadIncome = append(totalReadIncome, 0)
 		totalSlashedStake = append(totalSlashedStake, 0)
@@ -444,7 +444,7 @@ func (edb *EventDb) blobberSpecificRevenue(spus []dbs.StakePoolReward) error {
 		switch (spu.RewardType) {
 			case spenum.BlockRewardBlobber:
 				totalChanges++
-				totalBlockReward[i] = int64(spu.Reward)
+				totalBlockRewards[i] = int64(spu.Reward)
 			case spenum.ChallengePassReward:
 				totalChanges++
 				totalStorageIncome[i] = int64(spu.Reward)
@@ -464,7 +464,7 @@ func (edb *EventDb) blobberSpecificRevenue(spus []dbs.StakePoolReward) error {
 	}
 
 	return CreateBuilder("blobbers", "id", ids).
-		AddUpdate("total_block_reward", totalBlockReward, "blobbers.total_block_reward + t.total_block_reward").
+		AddUpdate("total_block_rewards", totalBlockRewards, "blobbers.total_block_rewards + t.total_block_rewards").
 		AddUpdate("total_storage_income", totalStorageIncome, "blobbers.total_storage_income + t.total_storage_income").
 		AddUpdate("total_read_income", totalReadIncome, "blobbers.total_read_income + t.total_read_income").
 		AddUpdate("total_slashed_stake", totalSlashedStake, "blobbers.total_slashed_stake + t.total_slashed_stake").

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate.go
@@ -25,6 +25,7 @@ type BlobberAggregate struct {
 	TotalStake          currency.Coin `json:"total_stake"`
 	TotalServiceCharge  currency.Coin `json:"total_service_charge"`
 	TotalRewards        currency.Coin `json:"total_rewards"`
+	TotalBlockReward	currency.Coin `json:"total_block_reward"`
 	TotalStorageIncome  currency.Coin `json:"total_storage_income"`
 	TotalReadIncome	 	currency.Coin `json:"total_read_income"`
 	TotalSlashedStake	currency.Coin `json:"total_slashed_stake"`
@@ -152,6 +153,7 @@ func (edb *EventDb) calculateBlobberAggregate(gs *Snapshot, round, limit, offset
 		aggregate.OffersTotal = (old.OffersTotal + current.OffersTotal) / 2
 		aggregate.UnstakeTotal = (old.UnstakeTotal + current.UnstakeTotal) / 2
 		aggregate.OpenChallenges = (old.OpenChallenges + current.OpenChallenges) / 2
+		aggregate.TotalBlockReward = (old.TotalBlockReward + current.TotalBlockReward) / 2
 		aggregate.TotalStorageIncome = (old.TotalStorageIncome + current.TotalStorageIncome) / 2
 		aggregate.TotalReadIncome = (old.TotalReadIncome + current.TotalReadIncome) / 2
 		aggregate.TotalSlashedStake = (old.TotalSlashedStake + current.TotalSlashedStake) / 2

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate.go
@@ -25,7 +25,7 @@ type BlobberAggregate struct {
 	TotalStake          currency.Coin `json:"total_stake"`
 	TotalServiceCharge  currency.Coin `json:"total_service_charge"`
 	TotalRewards        currency.Coin `json:"total_rewards"`
-	TotalBlockReward	currency.Coin `json:"total_block_reward"`
+	TotalBlockRewards	currency.Coin `json:"total_block_rewards"`
 	TotalStorageIncome  currency.Coin `json:"total_storage_income"`
 	TotalReadIncome	 	currency.Coin `json:"total_read_income"`
 	TotalSlashedStake	currency.Coin `json:"total_slashed_stake"`
@@ -153,7 +153,7 @@ func (edb *EventDb) calculateBlobberAggregate(gs *Snapshot, round, limit, offset
 		aggregate.OffersTotal = (old.OffersTotal + current.OffersTotal) / 2
 		aggregate.UnstakeTotal = (old.UnstakeTotal + current.UnstakeTotal) / 2
 		aggregate.OpenChallenges = (old.OpenChallenges + current.OpenChallenges) / 2
-		aggregate.TotalBlockReward = (old.TotalBlockReward + current.TotalBlockReward) / 2
+		aggregate.TotalBlockRewards = (old.TotalBlockRewards + current.TotalBlockRewards) / 2
 		aggregate.TotalStorageIncome = (old.TotalStorageIncome + current.TotalStorageIncome) / 2
 		aggregate.TotalReadIncome = (old.TotalReadIncome + current.TotalReadIncome) / 2
 		aggregate.TotalSlashedStake = (old.TotalSlashedStake + current.TotalSlashedStake) / 2

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate_test.go
@@ -173,6 +173,7 @@ func TestBlobberAggregateAndSnapshot(t *testing.T) {
 			"rank_metric":          gorm.Expr("rank_metric * ?", 2),
 			"challenges_passed":    gorm.Expr("challenges_passed * ?", 2),
 			"challenges_completed": gorm.Expr("challenges_completed * ?", 2),
+			"total_block_reward":   gorm.Expr("total_block_reward * ?", 2),
 			"total_storage_income": gorm.Expr("total_storage_income * ?", 2),
 			"total_read_income":	gorm.Expr("total_read_income * ?", 2),
 			"total_slashed_stake":  gorm.Expr("total_slashed_stake * ?", 2),
@@ -233,6 +234,7 @@ func TestBlobberAggregateAndSnapshot(t *testing.T) {
 		require.Equal(t, oldBlobber.ReadData*2, curBlobber.ReadData)
 		require.Equal(t, oldBlobber.OffersTotal*2, curBlobber.OffersTotal)
 		require.Equal(t, oldBlobber.OpenChallenges*2, curBlobber.OpenChallenges)
+		require.Equal(t, oldBlobber.TotalBlockReward*2, curBlobber.TotalBlockReward)
 		require.Equal(t, oldBlobber.TotalStorageIncome*2, curBlobber.TotalStorageIncome)
 		require.Equal(t, oldBlobber.TotalReadIncome*2, curBlobber.TotalReadIncome)
 		require.Equal(t, oldBlobber.TotalSlashedStake*2, curBlobber.TotalSlashedStake)
@@ -320,6 +322,7 @@ func blobberToSnapshot(blobber *Blobber) BlobberSnapshot {
 		TotalRewards:        blobber.Rewards.TotalRewards,
 		TotalStake:          blobber.TotalStake,
 		OpenChallenges:      blobber.OpenChallenges,
+		TotalBlockReward:    blobber.TotalBlockReward,
 		TotalStorageIncome:  blobber.TotalStorageIncome,
 		TotalReadIncome:     blobber.TotalReadIncome,
 		TotalSlashedStake:   blobber.TotalSlashedStake,
@@ -376,6 +379,7 @@ func calculateBlobberAggregate(round int64, current *Blobber, old *BlobberSnapsh
 	aggregate.OffersTotal = (old.OffersTotal + current.OffersTotal) / 2
 	aggregate.UnstakeTotal = (old.UnstakeTotal + current.UnstakeTotal) / 2
 	aggregate.OpenChallenges = (old.OpenChallenges + current.OpenChallenges) / 2
+	aggregate.TotalBlockReward = (old.TotalBlockReward + current.TotalBlockReward) / 2
 	aggregate.TotalStorageIncome = (old.TotalStorageIncome + current.TotalStorageIncome) / 2
 	aggregate.TotalReadIncome = (old.TotalReadIncome + current.TotalReadIncome) / 2
 	aggregate.TotalSlashedStake = (old.TotalSlashedStake + current.TotalSlashedStake) / 2
@@ -438,6 +442,7 @@ func assertBlobberAggregate(t *testing.T, expected, actual *BlobberAggregate) {
 	require.Equal(t, expected.OpenChallenges, actual.OpenChallenges)
 	require.Equal(t, expected.ChallengesPassed, actual.ChallengesPassed)
 	require.Equal(t, expected.ChallengesCompleted, actual.ChallengesCompleted)
+	require.Equal(t, expected.TotalBlockReward, actual.TotalBlockReward)
 	require.Equal(t, expected.TotalStorageIncome, actual.TotalStorageIncome)
 	require.Equal(t, expected.TotalReadIncome, actual.TotalReadIncome)
 	require.Equal(t, expected.TotalSlashedStake, actual.TotalSlashedStake)
@@ -458,6 +463,7 @@ func assertBlobberSnapshot(t *testing.T, expected, actual *BlobberSnapshot) {
 	require.Equal(t, expected.OffersTotal, actual.OffersTotal)
 	require.Equal(t, expected.UnstakeTotal, actual.UnstakeTotal)
 	require.Equal(t, expected.TotalRewards, actual.TotalRewards)
+	require.Equal(t, expected.TotalBlockReward, actual.TotalBlockReward)
 	require.Equal(t, expected.TotalStorageIncome, actual.TotalStorageIncome)
 	require.Equal(t, expected.TotalReadIncome, actual.TotalReadIncome)
 	require.Equal(t, expected.TotalSlashedStake, actual.TotalSlashedStake)

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate_test.go
@@ -173,7 +173,7 @@ func TestBlobberAggregateAndSnapshot(t *testing.T) {
 			"rank_metric":          gorm.Expr("rank_metric * ?", 2),
 			"challenges_passed":    gorm.Expr("challenges_passed * ?", 2),
 			"challenges_completed": gorm.Expr("challenges_completed * ?", 2),
-			"total_block_reward":   gorm.Expr("total_block_reward * ?", 2),
+			"total_block_rewards":   gorm.Expr("total_block_rewards * ?", 2),
 			"total_storage_income": gorm.Expr("total_storage_income * ?", 2),
 			"total_read_income":	gorm.Expr("total_read_income * ?", 2),
 			"total_slashed_stake":  gorm.Expr("total_slashed_stake * ?", 2),
@@ -234,7 +234,7 @@ func TestBlobberAggregateAndSnapshot(t *testing.T) {
 		require.Equal(t, oldBlobber.ReadData*2, curBlobber.ReadData)
 		require.Equal(t, oldBlobber.OffersTotal*2, curBlobber.OffersTotal)
 		require.Equal(t, oldBlobber.OpenChallenges*2, curBlobber.OpenChallenges)
-		require.Equal(t, oldBlobber.TotalBlockReward*2, curBlobber.TotalBlockReward)
+		require.Equal(t, oldBlobber.TotalBlockRewards*2, curBlobber.TotalBlockRewards)
 		require.Equal(t, oldBlobber.TotalStorageIncome*2, curBlobber.TotalStorageIncome)
 		require.Equal(t, oldBlobber.TotalReadIncome*2, curBlobber.TotalReadIncome)
 		require.Equal(t, oldBlobber.TotalSlashedStake*2, curBlobber.TotalSlashedStake)
@@ -322,7 +322,7 @@ func blobberToSnapshot(blobber *Blobber) BlobberSnapshot {
 		TotalRewards:        blobber.Rewards.TotalRewards,
 		TotalStake:          blobber.TotalStake,
 		OpenChallenges:      blobber.OpenChallenges,
-		TotalBlockReward:    blobber.TotalBlockReward,
+		TotalBlockRewards:    blobber.TotalBlockRewards,
 		TotalStorageIncome:  blobber.TotalStorageIncome,
 		TotalReadIncome:     blobber.TotalReadIncome,
 		TotalSlashedStake:   blobber.TotalSlashedStake,
@@ -379,7 +379,7 @@ func calculateBlobberAggregate(round int64, current *Blobber, old *BlobberSnapsh
 	aggregate.OffersTotal = (old.OffersTotal + current.OffersTotal) / 2
 	aggregate.UnstakeTotal = (old.UnstakeTotal + current.UnstakeTotal) / 2
 	aggregate.OpenChallenges = (old.OpenChallenges + current.OpenChallenges) / 2
-	aggregate.TotalBlockReward = (old.TotalBlockReward + current.TotalBlockReward) / 2
+	aggregate.TotalBlockRewards = (old.TotalBlockRewards + current.TotalBlockRewards) / 2
 	aggregate.TotalStorageIncome = (old.TotalStorageIncome + current.TotalStorageIncome) / 2
 	aggregate.TotalReadIncome = (old.TotalReadIncome + current.TotalReadIncome) / 2
 	aggregate.TotalSlashedStake = (old.TotalSlashedStake + current.TotalSlashedStake) / 2
@@ -442,7 +442,7 @@ func assertBlobberAggregate(t *testing.T, expected, actual *BlobberAggregate) {
 	require.Equal(t, expected.OpenChallenges, actual.OpenChallenges)
 	require.Equal(t, expected.ChallengesPassed, actual.ChallengesPassed)
 	require.Equal(t, expected.ChallengesCompleted, actual.ChallengesCompleted)
-	require.Equal(t, expected.TotalBlockReward, actual.TotalBlockReward)
+	require.Equal(t, expected.TotalBlockRewards, actual.TotalBlockRewards)
 	require.Equal(t, expected.TotalStorageIncome, actual.TotalStorageIncome)
 	require.Equal(t, expected.TotalReadIncome, actual.TotalReadIncome)
 	require.Equal(t, expected.TotalSlashedStake, actual.TotalSlashedStake)
@@ -463,7 +463,7 @@ func assertBlobberSnapshot(t *testing.T, expected, actual *BlobberSnapshot) {
 	require.Equal(t, expected.OffersTotal, actual.OffersTotal)
 	require.Equal(t, expected.UnstakeTotal, actual.UnstakeTotal)
 	require.Equal(t, expected.TotalRewards, actual.TotalRewards)
-	require.Equal(t, expected.TotalBlockReward, actual.TotalBlockReward)
+	require.Equal(t, expected.TotalBlockRewards, actual.TotalBlockRewards)
 	require.Equal(t, expected.TotalStorageIncome, actual.TotalStorageIncome)
 	require.Equal(t, expected.TotalReadIncome, actual.TotalReadIncome)
 	require.Equal(t, expected.TotalSlashedStake, actual.TotalSlashedStake)

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_snapshot.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_snapshot.go
@@ -20,6 +20,7 @@ type BlobberSnapshot struct {
 	TotalServiceCharge  currency.Coin `json:"total_service_charge"`
 	TotalRewards		currency.Coin `json:"total_rewards"`
 	TotalStake          currency.Coin `json:"total_stake"`
+	TotalBlockReward	currency.Coin `json:"total_block_reward"`
 	TotalStorageIncome  currency.Coin `json:"total_storage_income"`
 	TotalReadIncome		currency.Coin `json:"total_read_income"`
 	TotalSlashedStake	currency.Coin `json:"total_slashed_stake"`
@@ -66,6 +67,7 @@ func (edb *EventDb) addBlobberSnapshot(blobbers []Blobber) error {
 			OffersTotal:  blobber.OffersTotal,
 			UnstakeTotal: blobber.UnstakeTotal,
 			TotalRewards: blobber.Rewards.TotalRewards,
+			TotalBlockReward: blobber.TotalBlockReward,
 			TotalStorageIncome: blobber.TotalStorageIncome,
 			TotalReadIncome: blobber.TotalReadIncome,
 			TotalSlashedStake: blobber.TotalSlashedStake,

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_snapshot.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_snapshot.go
@@ -20,7 +20,7 @@ type BlobberSnapshot struct {
 	TotalServiceCharge  currency.Coin `json:"total_service_charge"`
 	TotalRewards		currency.Coin `json:"total_rewards"`
 	TotalStake          currency.Coin `json:"total_stake"`
-	TotalBlockReward	currency.Coin `json:"total_block_reward"`
+	TotalBlockRewards	currency.Coin `json:"total_block_rewards"`
 	TotalStorageIncome  currency.Coin `json:"total_storage_income"`
 	TotalReadIncome		currency.Coin `json:"total_read_income"`
 	TotalSlashedStake	currency.Coin `json:"total_slashed_stake"`
@@ -67,7 +67,7 @@ func (edb *EventDb) addBlobberSnapshot(blobbers []Blobber) error {
 			OffersTotal:  blobber.OffersTotal,
 			UnstakeTotal: blobber.UnstakeTotal,
 			TotalRewards: blobber.Rewards.TotalRewards,
-			TotalBlockReward: blobber.TotalBlockReward,
+			TotalBlockRewards: blobber.TotalBlockRewards,
 			TotalStorageIncome: blobber.TotalStorageIncome,
 			TotalReadIncome: blobber.TotalReadIncome,
 			TotalSlashedStake: blobber.TotalSlashedStake,

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_test.go
@@ -66,7 +66,7 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 				ID:                "B000",
 			},
 			BaseURL: "https://blobber.zero",
-			TotalBlockReward: 0,
+			TotalBlockRewards: 0,
 			TotalStorageIncome: 0,
 			TotalReadIncome:   0,
 			TotalSlashedStake: 0,
@@ -76,7 +76,7 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 				ID:                "B001",
 			},
 			BaseURL: "https://blobber.one",
-			TotalBlockReward: 0,
+			TotalBlockRewards: 0,
 			TotalStorageIncome: 0,
 			TotalReadIncome:   0,
 			TotalSlashedStake: 0,
@@ -86,7 +86,7 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 				ID:                "B002",
 			},
 			BaseURL: "https://blobber.two",
-			TotalBlockReward: 0,
+			TotalBlockRewards: 0,
 			TotalStorageIncome: 0,
 			TotalReadIncome:   0,
 			TotalSlashedStake: 0,
@@ -96,7 +96,7 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 				ID:                "B003",
 			},
 			BaseURL: "https://blobber.three",
-			TotalBlockReward: 0,
+			TotalBlockRewards: 0,
 			TotalStorageIncome: 0,
 			TotalReadIncome:   0,
 			TotalSlashedStake: 0,
@@ -166,22 +166,22 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 	err = edb.Store.Get().Model(&Blobber{}).Omit(clause.Associations).Order("id ASC").Find(&blobbersAfter).Error
 	require.NoError(t, err)
 
-	assert.Equal(t, blobbersBefore[0].TotalBlockReward + 10, blobbersAfter[0].TotalBlockReward)
+	assert.Equal(t, blobbersBefore[0].TotalBlockRewards + 10, blobbersAfter[0].TotalBlockRewards)
 	assert.Equal(t, blobbersBefore[0].TotalStorageIncome, blobbersAfter[0].TotalStorageIncome)
 	assert.Equal(t, blobbersBefore[0].TotalReadIncome, blobbersAfter[0].TotalReadIncome)
 	assert.Equal(t, blobbersBefore[0].TotalSlashedStake, blobbersAfter[0].TotalSlashedStake)
 
-	assert.Equal(t, blobbersBefore[1].TotalBlockReward, blobbersAfter[1].TotalBlockReward)	
+	assert.Equal(t, blobbersBefore[1].TotalBlockRewards, blobbersAfter[1].TotalBlockRewards)	
 	assert.Equal(t, blobbersBefore[1].TotalStorageIncome + 20, blobbersAfter[1].TotalStorageIncome)
 	assert.Equal(t, blobbersBefore[1].TotalReadIncome, blobbersAfter[1].TotalReadIncome)
 	assert.Equal(t, blobbersBefore[1].TotalSlashedStake, blobbersAfter[1].TotalSlashedStake)
 
-	assert.Equal(t, blobbersBefore[2].TotalBlockReward, blobbersAfter[2].TotalBlockReward)
+	assert.Equal(t, blobbersBefore[2].TotalBlockRewards, blobbersAfter[2].TotalBlockRewards)
 	assert.Equal(t, blobbersBefore[2].TotalStorageIncome, blobbersAfter[2].TotalStorageIncome)
 	assert.Equal(t, blobbersBefore[2].TotalReadIncome + 30, blobbersAfter[2].TotalReadIncome)
 	assert.Equal(t, blobbersBefore[2].TotalSlashedStake, blobbersAfter[2].TotalSlashedStake)
 
-	assert.Equal(t, blobbersBefore[3].TotalBlockReward, blobbersAfter[3].TotalBlockReward)
+	assert.Equal(t, blobbersBefore[3].TotalBlockRewards, blobbersAfter[3].TotalBlockRewards)
 	assert.Equal(t, blobbersBefore[3].TotalStorageIncome, blobbersAfter[3].TotalStorageIncome)
 	assert.Equal(t, blobbersBefore[3].TotalReadIncome, blobbersAfter[3].TotalReadIncome)
 	assert.Equal(t, blobbersBefore[3].TotalSlashedStake + 40, blobbersAfter[3].TotalSlashedStake)

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/0chain/common/core/currency"
 	"github.com/0chain/common/core/logging"
 
 	"github.com/stretchr/testify/assert"
@@ -142,13 +143,18 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 			RewardType: spenum.FileDownloadReward,
 		},
 		{
-			// Slashed stake : blobber three
+			// Slashed stake : blobber three slashed stake should increase by 60
 			ProviderID: dbs.ProviderID{
 				ID: "B003",
 				Type: spenum.Blobber,
 			},
 			Reward: 40,
 			RewardType: spenum.ChallengeSlashPenalty,
+			DelegatePenalties: map[string]currency.Coin{
+				"delegate1": 10,
+				"delegate2": 20,
+				"delegate3": 30,
+			},
 		},
 	}
 
@@ -184,7 +190,7 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 	assert.Equal(t, blobbersBefore[3].TotalBlockRewards, blobbersAfter[3].TotalBlockRewards)
 	assert.Equal(t, blobbersBefore[3].TotalStorageIncome, blobbersAfter[3].TotalStorageIncome)
 	assert.Equal(t, blobbersBefore[3].TotalReadIncome, blobbersAfter[3].TotalReadIncome)
-	assert.Equal(t, blobbersBefore[3].TotalSlashedStake + 40, blobbersAfter[3].TotalSlashedStake)
+	assert.Equal(t, blobbersBefore[3].TotalSlashedStake + 60, blobbersAfter[3].TotalSlashedStake)
 }
 
 func compareBlobbers(t *testing.T, b1, b2 Blobber) {

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_test.go
@@ -66,6 +66,7 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 				ID:                "B000",
 			},
 			BaseURL: "https://blobber.zero",
+			TotalBlockReward: 0,
 			TotalStorageIncome: 0,
 			TotalReadIncome:   0,
 			TotalSlashedStake: 0,
@@ -75,6 +76,7 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 				ID:                "B001",
 			},
 			BaseURL: "https://blobber.one",
+			TotalBlockReward: 0,
 			TotalStorageIncome: 0,
 			TotalReadIncome:   0,
 			TotalSlashedStake: 0,
@@ -84,6 +86,7 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 				ID:                "B002",
 			},
 			BaseURL: "https://blobber.two",
+			TotalBlockReward: 0,
 			TotalStorageIncome: 0,
 			TotalReadIncome:   0,
 			TotalSlashedStake: 0,
@@ -93,6 +96,7 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 				ID:                "B003",
 			},
 			BaseURL: "https://blobber.three",
+			TotalBlockReward: 0,
 			TotalStorageIncome: 0,
 			TotalReadIncome:   0,
 			TotalSlashedStake: 0,
@@ -103,6 +107,15 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 	spus := []dbs.StakePoolReward{
 		{
 			// Shouldn't affect anybody
+			ProviderID: dbs.ProviderID{
+				ID: "M000",
+				Type: spenum.Miner,
+			},
+			Reward: 10,
+			RewardType: spenum.BlockRewardMiner,
+		},
+		{
+			// Block Reward: blobber zero
 			ProviderID: dbs.ProviderID{
 				ID: "B000",
 				Type: spenum.Blobber,
@@ -153,18 +166,22 @@ func TestEventDb_blobberSpecificRevenue(t *testing.T) {
 	err = edb.Store.Get().Model(&Blobber{}).Omit(clause.Associations).Order("id ASC").Find(&blobbersAfter).Error
 	require.NoError(t, err)
 
+	assert.Equal(t, blobbersBefore[0].TotalBlockReward + 10, blobbersAfter[0].TotalBlockReward)
 	assert.Equal(t, blobbersBefore[0].TotalStorageIncome, blobbersAfter[0].TotalStorageIncome)
 	assert.Equal(t, blobbersBefore[0].TotalReadIncome, blobbersAfter[0].TotalReadIncome)
 	assert.Equal(t, blobbersBefore[0].TotalSlashedStake, blobbersAfter[0].TotalSlashedStake)
 
+	assert.Equal(t, blobbersBefore[1].TotalBlockReward, blobbersAfter[1].TotalBlockReward)	
 	assert.Equal(t, blobbersBefore[1].TotalStorageIncome + 20, blobbersAfter[1].TotalStorageIncome)
 	assert.Equal(t, blobbersBefore[1].TotalReadIncome, blobbersAfter[1].TotalReadIncome)
 	assert.Equal(t, blobbersBefore[1].TotalSlashedStake, blobbersAfter[1].TotalSlashedStake)
 
+	assert.Equal(t, blobbersBefore[2].TotalBlockReward, blobbersAfter[2].TotalBlockReward)
 	assert.Equal(t, blobbersBefore[2].TotalStorageIncome, blobbersAfter[2].TotalStorageIncome)
 	assert.Equal(t, blobbersBefore[2].TotalReadIncome + 30, blobbersAfter[2].TotalReadIncome)
 	assert.Equal(t, blobbersBefore[2].TotalSlashedStake, blobbersAfter[2].TotalSlashedStake)
 
+	assert.Equal(t, blobbersBefore[3].TotalBlockReward, blobbersAfter[3].TotalBlockReward)
 	assert.Equal(t, blobbersBefore[3].TotalStorageIncome, blobbersAfter[3].TotalStorageIncome)
 	assert.Equal(t, blobbersBefore[3].TotalReadIncome, blobbersAfter[3].TotalReadIncome)
 	assert.Equal(t, blobbersBefore[3].TotalSlashedStake + 40, blobbersAfter[3].TotalSlashedStake)

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -679,7 +679,15 @@ func (edb *EventDb) addStat(event Event) (err error) {
 		if !ok {
 			return ErrInvalidEventData
 		}
-		return edb.penaltyUpdate(*spus, event.BlockNumber)
+		err := edb.penaltyUpdate(*spus, event.BlockNumber)
+		if err != nil {
+			return err
+		}
+		err = edb.blobberSpecificRevenue(*spus)
+		if err != nil {
+			return fmt.Errorf("could not update blobber specific revenue: %v", err)
+		}
+		return nil
 	case TagAddAllocation:
 		allocs, ok := fromEvent[[]Allocation](event.Data)
 		if !ok {

--- a/code/go/0chain.net/smartcontract/dbs/goose/migrations/1682437500_add_total_block_rewards_field.sql
+++ b/code/go/0chain.net/smartcontract/dbs/goose/migrations/1682437500_add_total_block_rewards_field.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE blobbers ADD COLUMN total_block_rewards bigint NOT NULL DEFAULT 0;
+ALTER TABLE blobber_aggregates ADD COLUMN total_block_rewards bigint NOT NULL DEFAULT 0;
+ALTER TABLE blobber_snapshots ADD COLUMN total_block_rewards bigint NOT NULL DEFAULT 0;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE blobbers DROP COLUMN total_block_rewards;
+ALTER TABLE blobber_aggregates DROP COLUMN total_block_rewards;
+ALTER TABLE blobber_snapshots DROP COLUMN total_block_rewards;
+-- +goose StatementEnd

--- a/code/go/0chain.net/smartcontract/stakepool/edb_stakepool.go
+++ b/code/go/0chain.net/smartcontract/stakepool/edb_stakepool.go
@@ -55,6 +55,7 @@ func stakePoolRewardToStakePoolRewardEvent(spu StakePoolReward) *dbs.StakePoolRe
 		ProviderID:      spu.ProviderID,
 		Reward:          spu.Reward,
 		DelegateRewards: spu.DelegateRewards,
+		DelegatePenalties: spu.DelegatePenalties,
 		RewardType:      spu.RewardType,
 	}
 }


### PR DESCRIPTION
## Fixes
- DelegatePenalties is not passed in the event date ([discussion](https://0chain.slack.com/archives/C03788G8N2D/p1682343298102189))
- blobber TotalSlashedStake is not updated correctly
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
