### PR TITLE
New metric sharder sync time

### DIFF
--- a/code/go/0chain.net/sharder/handler.go
+++ b/code/go/0chain.net/sharder/handler.go
@@ -227,6 +227,14 @@ func ChainStatsWriter(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "<tr><td>")
 		fmt.Fprintf(w, "<h3>Prune Stats</h3>")
 		diagnostics.WritePruneStats(w, c.GetPruneStats())
+		fmt.Fprintf(w, "</td><td valign='top'>")
+		fmt.Fprintf(w, "<h3>Sync catchup time Statistics</h3>")
+		diagnostics.WriteHistogramStatistics(w, c, syncCatchupTime)
+		fmt.Fprintf(w, "</td></tr>")
+	} else {
+		fmt.Fprintf(w, "<tr><td>")
+		fmt.Fprintf(w, "<h3>Sync catchup time Statistics</h3>")
+		diagnostics.WriteHistogramStatistics(w, c, syncCatchupTime)
 		fmt.Fprintf(w, "</td></tr>")
 	}
 

--- a/code/go/0chain.net/sharder/protocol_block.go
+++ b/code/go/0chain.net/sharder/protocol_block.go
@@ -26,10 +26,12 @@ import (
 
 var blockSaveTimer metrics.Timer
 var bsHistogram metrics.Histogram
+var syncCatchupTime metrics.Histogram
 
 func init() {
 	blockSaveTimer = metrics.GetOrRegisterTimer("block_save_time", nil)
 	bsHistogram = metrics.GetOrRegisterHistogram("bs_histogram", nil, metrics.NewUniformSample(1024))
+	syncCatchupTime = metrics.GetOrRegisterHistogram("sync_catch_up_time", nil, metrics.NewUniformSample(1024))
 }
 
 /*UpdatePendingBlock - update the pending block */


### PR DESCRIPTION
## Fixes

## Changes
```
When a downed sharder comes back online, we should have a metric for how long it takes to catch up to LFB. Add this metric and expose it via an API on sharder.
```
## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...