### PR TITLE
Fix unit testing script failing to run `0chain.net/smartcontract/dbs/event` tests

### DIFF
--- a/docker.local/bin/unit_test.sh
+++ b/docker.local/bin/unit_test.sh
@@ -50,9 +50,9 @@ if [[ -n "$PACKAGE" ]]; then
     # Run tests from a single package.
     # assume that $PACKAGE looks something like: 0chain.net/chaincore/threshold/bls
     echo "Running unit tests from $PACKAGE:"
-    docker run "$INTERACTIVE" zchain_unit_test sh -c "cd /0chain/code/go/$PACKAGE; go test -tags bn256 ./..."
+    docker run "$INTERACTIVE" --network="host" -v /var/run/docker.sock:/var/run/docker.sock zchain_unit_test sh -c "cd /0chain/code/go/$PACKAGE; go test -tags bn256 ./..."
 else
     # Run all tests.
     echo "Running general unit tests:"
-    docker run "$INTERACTIVE" -v $(pwd)/code:/codecov zchain_unit_test sh -c "cd 0chain.net; go test -tags bn256 -coverprofile=/codecov/coverage.txt -covermode=atomic ./..." 
+    docker run "$INTERACTIVE" --network="host" -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/code:/codecov zchain_unit_test sh -c "cd 0chain.net; go test -tags bn256 -coverprofile=/codecov/coverage.txt -covermode=atomic ./..." 
 fi

--- a/docker.local/build.unit_test/Dockerfile
+++ b/docker.local/build.unit_test/Dockerfile
@@ -1,7 +1,7 @@
 FROM zchain_build_base
 ENV SRC_DIR=/0chain
 
-RUN apk add --update --no-cache curl
+RUN apk add --update --no-cache curl docker
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
 
 # Download the dependencies:


### PR DESCRIPTION
## Fixes
Unit testing script is not working as `0chain.net/smartcontract/dbs/event` need docker within the test environment
## Changes
- Install docker within the test environment
- Use host's docker daemon as it's not possible to get docker service running inside the container running `zchain_unit_test` image. It's built on docker's official Alpine image and this is a known issue [here](https://github.com/gliderlabs/docker-alpine/issues/183). This is done by mounting docker's socket from the host to the container.
- Add `--network=host` to the container to be able to the database created during the test setup using `localhost` as database host.
## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
