### PR TITLE
2211 blobbers.allocated data and blobbers.saved _data is not affected by allocation cancellation/expiry

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/enums.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/enums.go
@@ -41,7 +41,7 @@ const (
 	TagNone EventTag = iota
 	TagAddBlobber
 	TagUpdateBlobber
-	TagUpdateBlobberAllocatedHealth
+	TagUpdateBlobberAllocatedSavedHealth
 	TagUpdateBlobberTotalStake
 	TagUpdateBlobberTotalUnStake
 	TagUpdateBlobberTotalOffers
@@ -144,7 +144,7 @@ func initTagString() {
 	TagString[TagNone] = "none"
 	TagString[TagAddBlobber] = "TagAddBlobber"
 	TagString[TagUpdateBlobber] = "TagUpdateBlobber"
-	TagString[TagUpdateBlobberAllocatedHealth] = "TagUpdateBlobberAllocatedHealth"
+	TagString[TagUpdateBlobberAllocatedSavedHealth] = "TagUpdateBlobberAllocatedSavedHealth"
 	TagString[TagUpdateBlobberTotalStake] = "TagUpdateBlobberTotalStake"
 	TagString[TagUpdateBlobberTotalUnStake] = "TagUpdateBlobberTotalUnStake"
 	TagString[TagUpdateBlobberTotalOffers] = "TagUpdateBlobberTotalOffers"

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -462,12 +462,12 @@ func (edb *EventDb) addStat(event Event) (err error) {
 			return ErrInvalidEventData
 		}
 		return edb.updateBlobber(*blobbers)
-	case TagUpdateBlobberAllocatedHealth:
+	case TagUpdateBlobberAllocatedSavedHealth:
 		blobbers, ok := fromEvent[[]Blobber](event.Data)
 		if !ok {
 			return ErrInvalidEventData
 		}
-		return edb.updateBlobbersAllocatedAndHealth(*blobbers)
+		return edb.updateBlobbersAllocatedSavedAndHealth(*blobbers)
 	case TagUpdateBlobberTotalStake:
 		bs, ok := fromEvent[[]Blobber](event.Data)
 		if !ok {

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -321,7 +321,7 @@ func (sc *StorageSmartContract) newAllocationRequestInternal(
 			Delta:        bSize(request.Size, request.DataShards),
 		})
 
-		emitUpdateBlobberAllocatedHealth(b, balances)
+		emitUpdateBlobberAllocatedSavedHealth(b, balances)
 	}
 
 	var options []WithOption
@@ -670,7 +670,7 @@ func (sa *StorageAllocation) saveUpdatedAllocation(
 		if _, err = balances.InsertTrieNode(b.GetKey(), b); err != nil {
 			return
 		}
-		emitUpdateBlobberAllocatedHealth(b, balances)
+		emitUpdateBlobberAllocatedSavedHealth(b, balances)
 	}
 	// Save allocation
 	_, err = balances.InsertTrieNode(sa.GetKey(ADDRESS), sa)
@@ -1027,7 +1027,7 @@ func (sc *StorageSmartContract) reduceAllocation(
 				return fmt.Errorf("can't Save stake pool of %s: %v", ba.BlobberID,
 					err)
 			}
-			emitUpdateBlobberAllocatedHealth(b, balances)
+			emitUpdateBlobberAllocatedSavedHealth(b, balances)
 		}
 	}
 

--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -1550,6 +1550,24 @@ func (sc *StorageSmartContract) finalizeAllocation(
 			"saving allocation: "+err.Error())
 	}
 
+	for _, ba := range alloc.BlobberAllocs {
+		blobber, err := sc.getBlobber(ba.BlobberID, balances)
+		if err != nil {
+			return "", common.NewError("fini_alloc_failed",
+				"can't get blobber "+ba.BlobberID+": "+err.Error())
+		}
+		blobber.SavedData += (-ba.Stats.UsedSize)
+		blobber.Allocated += (-ba.Size)
+		_, err = balances.InsertTrieNode(blobber.GetKey(), blobber)
+		if err != nil {
+			return "", common.NewError("fini_alloc_failed",
+				"saving blobber "+ba.BlobberID+": "+err.Error())
+		}
+
+		// Update saved data on events_db
+		emitUpdateBlobberAllocatedSavedHealth(blobber, balances)
+	}
+
 	balances.EmitEvent(event.TypeStats, event.TagUpdateAllocation, alloc.ID, alloc.buildDbUpdates())
 
 	emitUpdateAllocationBlobberTerms(alloc, balances, t)

--- a/code/go/0chain.net/smartcontract/storagesc/blobber_eventdb.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber_eventdb.go
@@ -81,13 +81,14 @@ func emitAddBlobber(sn *StorageNode, sp *stakePool, balances cstate.StateContext
 	return nil
 }
 
-func emitUpdateBlobberAllocatedHealth(sn *StorageNode, balances cstate.StateContextI) {
-	balances.EmitEvent(event.TypeStats, event.TagUpdateBlobberAllocatedHealth, sn.ID, event.Blobber{
+func emitUpdateBlobberAllocatedSavedHealth(sn *StorageNode, balances cstate.StateContextI) {
+	balances.EmitEvent(event.TypeStats, event.TagUpdateBlobberAllocatedSavedHealth, sn.ID, event.Blobber{
 		Provider: event.Provider{
 			ID:              sn.ID,
 			LastHealthCheck: sn.LastHealthCheck,
 		},
 		Allocated: sn.Allocated,
+		SavedData: sn.SavedData,
 	})
 }
 

--- a/code/go/0chain.net/smartcontract/storagesc/free_allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/free_allocation_test.go
@@ -634,7 +634,7 @@ func TestUpdateFreeStorageRequest(t *testing.T) {
 		).Return().Maybe()
 
 		balances.On(
-			"EmitEvent", event.TypeStats, event.TagUpdateBlobberAllocatedHealth,
+			"EmitEvent", event.TypeStats, event.TagUpdateBlobberAllocatedSavedHealth,
 			mock.Anything, mock.Anything).Return().Maybe()
 		balances.On(
 			"EmitEvent", event.TypeStats, event.TagLockWritePool,


### PR DESCRIPTION
## Fixes
- Update `blobber.saved_data` and `blobber.allocated` after the allocation is cancelled
## Changes
## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
