### PR TITLE
Remove getUserLockedTotal from 0chain

### DIFF
--- a/code/go/0chain.net/chaincore/smartcontract/handler_test.go
+++ b/code/go/0chain.net/chaincore/smartcontract/handler_test.go
@@ -135,7 +135,7 @@ func TestGetSmartContract(t *testing.T) {
 		{
 			name:       "storage",
 			address:    storagesc.ADDRESS,
-			restpoints: 48,
+			restpoints: 47,
 		},
 		{
 			name:       "multisig",

--- a/code/go/0chain.net/smartcontract/dbs/event/delegate_pool.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/delegate_pool.go
@@ -59,13 +59,6 @@ func (edb *EventDb) GetDelegatePool(poolID, pID string) (*DelegatePool, error) {
 	return &dp, nil
 }
 
-func (edb *EventDb) GetUserTotalLocked(id string) (int64, error) {
-	res := int64(0)
-	err := edb.Store.Get().Table("delegate_pools").Select("coalesce(sum(balance),0)").
-		Where("delegate_id = ? AND status in (?, ?)", id, spenum.Active, spenum.Pending).Row().Scan(&res)
-	return res, err
-}
-
 func (edb *EventDb) GetUserDelegatePools(userId string, pType spenum.Provider, pagination common2.Pagination) ([]DelegatePool, error) {
 	var dps []DelegatePool
 	result := edb.Store.Get().

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_rest_tests_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_rest_tests_test.go
@@ -14,7 +14,7 @@ import (
 const (
 	numberDevelopmentEndpoints = 6
 	numberDuplicatedTests      = 3
-	numberMissingTests         = 8
+	numberMissingTests         = 7
 )
 
 // TestStorageBenchmarkRestTests

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -76,7 +76,6 @@ func GetEndpoints(rh rest.RestHandlerI) []rest.Endpoint {
 		rest.MakeEndpoint(storage+"/blobber-challenges", common.UserRateLimit(srh.getBlobberChallenges)),
 		rest.MakeEndpoint(storage+"/getStakePoolStat", common.UserRateLimit(srh.getStakePoolStat)),
 		rest.MakeEndpoint(storage+"/getUserStakePoolStat", common.UserRateLimit(srh.getUserStakePoolStat)),
-		rest.MakeEndpoint(storage+"/getUserLockedTotal", common.UserRateLimit(srh.getUserLockedTotal)),
 		rest.MakeEndpoint(storage+"/block", common.UserRateLimit(srh.getBlock)),
 		rest.MakeEndpoint(storage+"/get_blocks", common.UserRateLimit(srh.getBlocks)),
 		rest.MakeEndpoint(storage+"/storage-config", common.UserRateLimit(srh.getConfig)),
@@ -903,43 +902,6 @@ func (srh *StorageRestHandler) getUserStakePoolStat(w http.ResponseWriter, r *ht
 	}
 
 	common.Respond(w, r, ups, nil)
-}
-
-// swagger:model userLockedTotalResponse
-type userLockedTotalResponse struct {
-	Total int64 `json:"total"`
-}
-
-// swagger:route GET /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/getUserLockedTotal getUserLockedTotal
-// Gets statistic for a user's stake pools
-//
-// parameters:
-//
-//	+name: client_id
-//	 description: client for which to get stake pool information
-//	 required: true
-//	 in: query
-//	 type: string
-//
-// responses:
-//
-//	200: userLockedTotalResponse
-//	400:
-func (srh *StorageRestHandler) getUserLockedTotal(w http.ResponseWriter, r *http.Request) {
-	clientID := r.URL.Query().Get("client_id")
-	edb := srh.GetQueryStateContext().GetEventDB()
-	if edb == nil {
-		common.Respond(w, r, nil, common.NewErrInternal("no db connection"))
-		return
-	}
-	locked, err := edb.GetUserTotalLocked(clientID)
-	if err != nil {
-		common.Respond(w, r, nil, common.NewErrBadRequest("blobber not found in event database: "+err.Error()))
-		return
-	}
-
-	common.Respond(w, r, &userLockedTotalResponse{Total: locked}, nil)
-
 }
 
 // swagger:route GET /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/getStakePoolStat getStakePoolStat


### PR DESCRIPTION
## Fixes

## Changes
Remove getUserLockedTotal from 0chain. Its been moved to 0box.
## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
