### PR TITLE
Rollback event db on block finalize error or panic

### DIFF
--- a/code/go/0chain.net/chaincore/block/block_eventdb.go
+++ b/code/go/0chain.net/chaincore/block/block_eventdb.go
@@ -47,8 +47,8 @@ func CreateBlockEvent(block *Block) (error, event.Event) {
 	}
 }
 
-func CreateFinalizeBlockEvent(block *Block) (error, event.Event) {
-	return nil, event.Event{
+func CreateFinalizeBlockEvent(block *Block) event.Event {
+	return event.Event{
 		BlockNumber: block.Round,
 		TxHash:      "",
 		Type:        event.TypeChain,

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -89,7 +89,7 @@ type BlockStateHandler interface {
 	// nil if it don't have this ability.
 	SaveMagicBlock() MagicBlockSaveFunc
 	UpdatePendingBlock(ctx context.Context, b *block.Block, txns []datastore.Entity)
-	UpdateFinalizedBlock(ctx context.Context, b *block.Block) func() error
+	UpdateFinalizedBlock(ctx context.Context, b *block.Block)
 }
 
 type updateLFMBWithReply struct {

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -645,7 +645,7 @@ func (c *Chain) setupInitialState(initStates *state.InitStates, gb *block.Block)
 		if eventDB != nil {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			_, err := eventDB.ProcessEvents(ctx, stateCtx.GetEvents(), 0, gb.Hash, 1)
+			_, err := eventDB.ProcessEvents(ctx, stateCtx.GetEvents(), 0, gb.Hash, 1, event.CommitNow())
 			if err != nil {
 				panic(err)
 			}

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -580,6 +580,7 @@ func (c *Chain) setupInitialState(initStates *state.InitStates, gb *block.Block)
 	txn := transaction.Transaction{HashIDField: datastore.HashIDField{Hash: encryption.Hash(c.OwnerID())}, ClientID: c.OwnerID()}
 	stateCtx := cstate.NewStateContext(gb, pmt, &txn, nil, nil, nil, nil, nil, c.GetEventDb())
 	mustInitPartitions(stateCtx)
+
 	for _, v := range initStates.States {
 		s := mustInitialState(v.Tokens)
 		if _, err := stateCtx.SetClientState(v.ID, s); err != nil {
@@ -644,7 +645,8 @@ func (c *Chain) setupInitialState(initStates *state.InitStates, gb *block.Block)
 		if eventDB != nil {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			if err := eventDB.ProcessEvents(ctx, stateCtx.GetEvents(), 0, gb.Hash, 1); err != nil {
+			_, err := eventDB.ProcessEvents(ctx, stateCtx.GetEvents(), 0, gb.Hash, 1)
+			if err != nil {
 				panic(err)
 			}
 		}
@@ -653,7 +655,7 @@ func (c *Chain) setupInitialState(initStates *state.InitStates, gb *block.Block)
 		logging.Logger.Panic("initialize genesis block state failed", zap.Error(err))
 	}
 
-	logging.Logger.Info("initial state root", zap.Any("hash", util.ToHex(pmt.GetRoot())))
+	logging.Logger.Info("initial state root", zap.String("hash", util.ToHex(pmt.GetRoot())))
 	return pmt
 }
 

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -89,7 +89,7 @@ type BlockStateHandler interface {
 	// nil if it don't have this ability.
 	SaveMagicBlock() MagicBlockSaveFunc
 	UpdatePendingBlock(ctx context.Context, b *block.Block, txns []datastore.Entity)
-	UpdateFinalizedBlock(ctx context.Context, b *block.Block)
+	UpdateFinalizedBlock(ctx context.Context, b *block.Block) func() error
 }
 
 type updateLFMBWithReply struct {

--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -437,6 +437,10 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 				zap.Int64("round", fb.Round),
 				zap.String("block", fb.Hash),
 				zap.Error(err))
+		} else {
+			logging.Logger.Debug("finalize block - commit events",
+				zap.Int64("round", fb.Round),
+				zap.String("block", fb.Hash))
 		}
 	}
 

--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -409,10 +409,6 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 	wg.Run("finalize block - update finalized block", fb.Round, func() {
 		bsh.UpdateFinalizedBlock(ctx, fb) //
 		fbPersisted = true
-		if c.GetEventDb() != nil && fb.Round == 200 {
-			time.Sleep(2 * time.Second)
-			panic("mock fb panic")
-		}
 	})
 
 	wg.Run("finalize block - delete dead blocks", fb.Round, func() {

--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -413,6 +413,10 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 
 	wg.Run("finalize block - update finalized block", fb.Round, func() {
 		bsh.UpdateFinalizedBlock(ctx, fb) //
+		if fb.Round == 200 && c.GetEventDb() != nil {
+			time.Sleep(2 * time.Second) // wait enough time for event to be processed
+			panic("mock panic on finalizing block")
+		}
 	})
 
 	wg.Run("finalize block - delete dead blocks", fb.Round, func() {

--- a/code/go/0chain.net/core/util/waitgroup/waitgroup.go
+++ b/code/go/0chain.net/core/util/waitgroup/waitgroup.go
@@ -1,0 +1,85 @@
+package waitgroup
+
+import (
+	"sync"
+	"time"
+
+	"0chain.net/core/common"
+	"github.com/0chain/common/core/logging"
+	"go.uber.org/zap"
+)
+
+const (
+	errPanicCode = "panic"
+)
+
+// WaitGroupSync wraps sync.WaitGroup and provide the ability to catch panic
+// and return error
+type WaitGroupSync struct {
+	wg     *sync.WaitGroup
+	panicC chan interface{}
+	errC   chan error
+}
+
+// New creates a new WaitGroupSync instance
+func New() *WaitGroupSync {
+	return &WaitGroupSync{
+		wg:     &sync.WaitGroup{},
+		panicC: make(chan interface{}, 1),
+		errC:   make(chan error, 1),
+	}
+}
+
+func (wgs *WaitGroupSync) Run(name string, round int64, f func() error) {
+	wgs.wg.Add(1)
+	ts := time.Now()
+	go func() {
+		defer func() {
+			wgs.wg.Done()
+			if r := recover(); r != nil {
+				wgs.panicC <- r
+			}
+		}()
+		if err := f(); err != nil {
+			select {
+			case wgs.errC <- err:
+			default:
+			}
+		}
+		du := time.Since(ts)
+		if du.Milliseconds() > 50 {
+			logging.Logger.Debug("Run slow on", zap.String("name", name),
+				zap.Int64("round", round),
+				zap.Duration("duration", du))
+		}
+	}()
+}
+
+// Wait waits for all to exit and return error if any
+// This ensures that panic happens in goroutines will be caught and returned so that
+// we can check whether failure or panic happened before continue.
+func (wgs *WaitGroupSync) Wait() error {
+	wgs.wg.Wait()
+	// get error from panic channel first, and from err channel otherwise or nil
+	select {
+	case err := <-wgs.panicC:
+		return common.NewErrorf(errPanicCode, "%v", err)
+	default:
+		select {
+		case err := <-wgs.errC:
+			return err
+		default:
+			return nil
+		}
+	}
+}
+
+// ErrIsPanic checks whethe the error is a panic err
+func ErrIsPanic(err error) bool {
+	cerr, ok := err.(*common.Error)
+	if !ok {
+		return false
+	}
+
+	return cerr.Code == errPanicCode
+}

--- a/code/go/0chain.net/miner/protocol_block_integration_tests.go
+++ b/code/go/0chain.net/miner/protocol_block_integration_tests.go
@@ -92,7 +92,7 @@ type ChallengeResponseTxData struct {
 }
 
 /*UpdateFinalizedBlock - update the latest finalized block */
-func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
+func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) func() error {
 	mc.updateFinalizedBlock(ctx, b)
 
 	addResultIfAdversarialValidatorTest(b)
@@ -104,6 +104,7 @@ func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
 			log.Panicf("Conductor: error while sending round info result: %v", err)
 		}
 	}
+	return func() error { return nil }
 }
 
 func addResultIfAdversarialValidatorTest(b *block.Block) {

--- a/code/go/0chain.net/miner/protocol_block_main.go
+++ b/code/go/0chain.net/miner/protocol_block_main.go
@@ -27,9 +27,8 @@ func (mc *Chain) hashAndSignGeneratedBlock(ctx context.Context,
 }
 
 /*UpdateFinalizedBlock - update the latest finalized block */
-func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) func() error {
+func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
 	go mc.updateFinalizedBlock(ctx, b)
-	return func() error { return nil }
 }
 
 func (mc *Chain) GenerateBlock(ctx context.Context,

--- a/code/go/0chain.net/miner/protocol_block_main.go
+++ b/code/go/0chain.net/miner/protocol_block_main.go
@@ -27,8 +27,9 @@ func (mc *Chain) hashAndSignGeneratedBlock(ctx context.Context,
 }
 
 /*UpdateFinalizedBlock - update the latest finalized block */
-func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
+func (mc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) func() error {
 	go mc.updateFinalizedBlock(ctx, b)
+	return func() error { return nil }
 }
 
 func (mc *Chain) GenerateBlock(ctx context.Context,

--- a/code/go/0chain.net/sharder/protocol_block.go
+++ b/code/go/0chain.net/sharder/protocol_block.go
@@ -86,6 +86,11 @@ func (sc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		if b.Round == 200 {
+			time.Sleep(2 * time.Second)
+			panic("mock fb panic on saving summary block")
+		}
+
 		if err := sc.StoreBlockSummaryFromBlock(b); err != nil {
 			Logger.Panic(
 				fmt.Sprintf("db error (store block summary) round: %d, block: %s, error: %s", b.Round, b.Hash, err.Error()))

--- a/code/go/0chain.net/sharder/protocol_block.go
+++ b/code/go/0chain.net/sharder/protocol_block.go
@@ -82,11 +82,6 @@ func (sc *Chain) UpdateFinalizedBlock(ctx context.Context, b *block.Block) {
 	})
 
 	wg.Run("store block summary", b.Round, func() error {
-		if b.Round == 200 {
-			time.Sleep(2 * time.Second)
-			panic("mock fb panic on saving summary block")
-		}
-
 		if err := sc.StoreBlockSummaryFromBlock(b); err != nil {
 			Logger.Panic(
 				fmt.Sprintf("db error (store block summary) round: %d, block: %s, error: %s", b.Round, b.Hash, err.Error()))

--- a/code/go/0chain.net/sharder/round.go
+++ b/code/go/0chain.net/sharder/round.go
@@ -7,6 +7,8 @@ import (
 	"0chain.net/core/common"
 	"0chain.net/core/datastore"
 	"0chain.net/core/ememorystore"
+	"github.com/0chain/common/core/logging"
+	"go.uber.org/zap"
 )
 
 // RoundSummaries -
@@ -94,6 +96,7 @@ func (mrf SharderRoundFactory) CreateRoundF(roundNum int64) round.RoundI {
 
 /*StoreRound - persists given round to ememory(rocksdb)*/
 func (sc *Chain) StoreRound(r *round.Round) error {
+	logging.Logger.Warn("store round", zap.Int64("round", r.GetRoundNumber()))
 	roundEntityMetadata := r.GetEntityMetadata()
 	rctx := ememorystore.WithEntityConnection(common.GetRootContext(), roundEntityMetadata)
 	defer ememorystore.Close(rctx)

--- a/code/go/0chain.net/sharder/round.go
+++ b/code/go/0chain.net/sharder/round.go
@@ -118,8 +118,9 @@ func (sc *Chain) StoreRoundNoCommit(r *round.Round) (func() error, error) {
 		return nil, err
 	}
 
+	con := ememorystore.GetEntityCon(rctx, roundEntityMetadata)
 	return func() error {
-		return ememorystore.GetEntityCon(rctx, roundEntityMetadata).Commit()
+		return con.Commit()
 	}, nil
 }
 

--- a/code/go/0chain.net/sharder/sharder/sharder.go
+++ b/code/go/0chain.net/sharder/sharder/sharder.go
@@ -109,6 +109,7 @@ func main() {
 				b.Round,
 				b.Hash,
 				len(b.Txns),
+				event.CommitNow(),
 			); err != nil {
 				logging.Logger.Error("process block saving event failed",
 					zap.Error(err),

--- a/code/go/0chain.net/sharder/sharder/sharder.go
+++ b/code/go/0chain.net/sharder/sharder/sharder.go
@@ -103,7 +103,7 @@ func main() {
 			ctx, cancel := context.WithTimeout(rootContext, 5*time.Second)
 			defer cancel()
 
-			if err := serverChain.GetEventDb().ProcessEvents(
+			if _, err := serverChain.GetEventDb().ProcessEvents(
 				ctx,
 				[]event.Event{ev},
 				b.Round,

--- a/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
@@ -115,7 +115,7 @@ type blockEvents struct {
 	blockSize         int
 	round             int64
 	events            []Event
-	doneWithRollbackC chan func() // rollback function
+	doneWithTxCommitC chan func() error // commit function
 }
 
 func (edb *EventDb) AutoMigrate() error {

--- a/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
@@ -111,11 +111,11 @@ func (edb *EventDb) Debug() bool {
 }
 
 type blockEvents struct {
-	block     string
-	blockSize int
-	round     int64
-	events    []Event
-	doneC     chan struct{}
+	block             string
+	blockSize         int
+	round             int64
+	events            []Event
+	doneWithRollbackC chan func() // rollback function
 }
 
 func (edb *EventDb) AutoMigrate() error {

--- a/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/eventdb.go
@@ -111,11 +111,11 @@ func (edb *EventDb) Debug() bool {
 }
 
 type blockEvents struct {
-	block             string
-	blockSize         int
-	round             int64
-	events            []Event
-	doneWithTxCommitC chan func() error // commit function
+	block     string
+	blockSize int
+	round     int64
+	events    []Event
+	txC       chan *EventDb
 }
 
 func (edb *EventDb) AutoMigrate() error {

--- a/code/go/0chain.net/smartcontract/dbs/event/miner_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner_test.go
@@ -437,7 +437,7 @@ func TestMiners(t *testing.T) {
 		Index:       mnMiner2.ID,
 	}
 	events := []Event{eventAddMn, eventAddMnTwo}
-	eventDb.ProcessEvents(context.TODO(), events, 1, "hash", 10)
+	eventDb.ProcessEvents(context.TODO(), events, 1, "hash", 10, CommitNow())
 	time.Sleep(100 * time.Millisecond)
 	miner, err := eventDb.GetMiner(mn.ID)
 	require.NoError(t, err)
@@ -464,7 +464,7 @@ func TestMiners(t *testing.T) {
 		Data:        mnMiner2,
 		Index:       mnMiner2.ID,
 	}
-	eventDb.ProcessEvents(context.TODO(), []Event{eventAddOrOverwriteMn, eventAddOrOverwriteMn2}, 2, "hash", 10)
+	eventDb.ProcessEvents(context.TODO(), []Event{eventAddOrOverwriteMn, eventAddOrOverwriteMn2}, 2, "hash", 10, CommitNow())
 
 	miner, err = eventDb.GetMiner(mn.ID)
 	require.NoError(t, err)
@@ -501,7 +501,7 @@ func TestMiners(t *testing.T) {
 		Tag:         TagUpdateMiner,
 		Data:        update2,
 	}
-	eventDb.ProcessEvents(context.TODO(), []Event{eventUpdateMn, eventUpdateMn2}, 100, "bhash", 10)
+	eventDb.ProcessEvents(context.TODO(), []Event{eventUpdateMn, eventUpdateMn2}, 100, "bhash", 10, CommitNow())
 
 	miner, err = eventDb.GetMiner(mn.ID)
 	require.NoError(t, err)
@@ -516,7 +516,7 @@ func TestMiners(t *testing.T) {
 		Tag:         TagDeleteMiner,
 		Data:        mn.ID,
 	}
-	eventDb.ProcessEvents(context.TODO(), []Event{deleteEvent}, 100, "bhash", 10)
+	eventDb.ProcessEvents(context.TODO(), []Event{deleteEvent}, 100, "bhash", 10, CommitNow())
 
 	miner, err = eventDb.GetMiner(mn.ID)
 	assert.Error(t, err)

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -248,7 +248,6 @@ func (edb *EventDb) work(ctx context.Context,
 	defer func() {
 		es.doneWithTxCommitC <- func() error {
 			if commit {
-				logging.Logger.Debug("commit event db transaction")
 				return tx.Commit()
 			}
 			return nil

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -224,6 +224,7 @@ func (edb *EventDb) work(ctx context.Context, gs *Snapshot, es blockEvents, curr
 		es.doneWithRollbackC <- func() {
 			if !rollbacked {
 				tx.Rollback()
+				logging.Logger.Debug("rollback event db transaction")
 			}
 		}
 	}()

--- a/code/go/0chain.net/smartcontract/dbs/event/process_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process_test.go
@@ -35,7 +35,7 @@ func TestAddEvents(t *testing.T) {
 			Type:   TypeError,
 			Data:   "someData",
 		},
-	}, 100, "hash", 10)
+	}, 100, "hash", 10, CommitNow())
 	errObj := Error{}
 	time.Sleep(100 * time.Millisecond)
 	result := eventDb.Store.Get().Model(&Error{}).Where(&Error{TransactionID: "somehash", Error: "someData"}).Take(&errObj)

--- a/code/go/0chain.net/smartcontract/dbs/event/sharder_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/sharder_test.go
@@ -218,7 +218,7 @@ func TestSharders(t *testing.T) {
 		Data:        string(data),
 	}
 	events := []Event{eventAddSn}
-	eventDb.ProcessEvents(context.TODO(), events, 100, "hash", 10)
+	eventDb.ProcessEvents(context.TODO(), events, 100, "hash", 10, CommitNow())
 
 	sharder, err := eventDb.GetSharder(sn.ID)
 	require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestSharders(t *testing.T) {
 		Tag:         TagAddSharder,
 		Data:        string(data),
 	}
-	eventDb.ProcessEvents(context.TODO(), []Event{eventAddOrOverwriteSn}, 100, "hash", 10)
+	eventDb.ProcessEvents(context.TODO(), []Event{eventAddOrOverwriteSn}, 100, "hash", 10, CommitNow())
 
 	sharder, err = eventDb.GetSharder(sn.ID)
 	require.NoError(t, err)
@@ -262,7 +262,7 @@ func TestSharders(t *testing.T) {
 		Tag:         TagUpdateSharder,
 		Data:        string(data),
 	}
-	eventDb.ProcessEvents(context.TODO(), []Event{eventUpdateSn}, 100, "hash", 10)
+	eventDb.ProcessEvents(context.TODO(), []Event{eventUpdateSn}, 100, "hash", 10, CommitNow())
 
 	sharder, err = eventDb.GetSharder(sn.ID)
 	require.NoError(t, err)
@@ -277,7 +277,7 @@ func TestSharders(t *testing.T) {
 		Tag:         TagDeleteSharder,
 		Data:        sn.ID,
 	}
-	eventDb.ProcessEvents(context.TODO(), []Event{deleteEvent}, 100, "hash", 10)
+	eventDb.ProcessEvents(context.TODO(), []Event{deleteEvent}, 100, "hash", 10, CommitNow())
 
 	sharder, err = eventDb.GetSharder(sn.ID)
 	require.Error(t, err)

--- a/code/go/0chain.net/smartcontract/dbs/event/writemarker_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/writemarker_test.go
@@ -92,7 +92,7 @@ func TestWriteMarker(t *testing.T) {
 		Data:        string(data),
 	}
 	events := []Event{eventAddOrOverwriteWm}
-	eventDb.ProcessEvents(context.TODO(), events, 100, "hash", 10)
+	eventDb.ProcessEvents(context.TODO(), events, 100, "hash", 10, CommitNow())
 
 	wm, err := eventDb.GetWriteMarker(eWriteMarker.TransactionID)
 	require.NoError(t, err)


### PR DESCRIPTION
## Fixes
- closes #2435

## Changes
- Post events commit till finalize block state persisted successfully. So any error or panic happens during the process, the events changes will all be dropped.
- Move the LFB round storing out of goroutine and do it as the last step in UpdateFinalizedBlock method. Because load LFB process on sharder starting starts from getting latest stored round from state db. So if any error or panic happens during the UpdateFinalizedBlock() method, we should not store the round to state db. 

- [x] Test to panic after saving state db successfully, LFB and events were saved, restarting will start from next round
- [x] Test to panic during the state db saving, LFB and events should all be ignored, and restarting should finalize it again

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
