### PR TITLE
Fully order all event database pagination queries

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/allocation.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/allocation.go
@@ -66,11 +66,19 @@ func (edb *EventDb) GetClientsAllocation(clientID string, limit common.Paginatio
 
 	err := edb.Store.Get().
 		Preload("Terms").
-		Model(&Allocation{}).Where("owner = ?", clientID).Limit(limit.Limit).Offset(limit.Offset).
+		Model(&Allocation{}).
+		Where("owner = ?", clientID).
+		Limit(limit.Limit).
+		Offset(limit.Offset).
 		Order(clause.OrderByColumn{
 			Column: clause.Column{Name: "start_time"},
 			Desc:   limit.IsDescending,
-		}).Find(&allocs).Error
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "allocation_id"},
+			Desc:   limit.IsDescending,
+		}).
+		Find(&allocs).Error
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving allocation for client: %v, error: %v", clientID, err)
 	}

--- a/code/go/0chain.net/smartcontract/dbs/event/allocation_blobber_term.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/allocation_blobber_term.go
@@ -25,12 +25,20 @@ func (edb *EventDb) GetAllocationBlobberTerm(allocationID string, blobberID stri
 
 func (edb *EventDb) GetAllocationBlobberTerms(allocationID string, limit common2.Pagination) ([]AllocationBlobberTerm, error) {
 	var terms []AllocationBlobberTerm
-	return terms, edb.Store.Get().Model(&AllocationBlobberTerm{}).
+	return terms, edb.Store.Get().
+		Model(&AllocationBlobberTerm{}).
 		Where(AllocationBlobberTerm{AllocationID: allocationID}).
-		Offset(limit.Offset).Limit(limit.Limit).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "id"},
-		Desc:   limit.IsDescending,
-	}).Find(&terms).Error
+		Offset(limit.Offset).
+		Limit(limit.Limit).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "allocation_id"},
+			Desc:   limit.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "blobber_id"},
+			Desc:   limit.IsDescending,
+		}).
+		Find(&terms).Error
 }
 
 func deleteAllocationBlobberTerms(edb *EventDb, allocBlobbers map[string][]string) error {

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -90,7 +90,12 @@ func (edb *EventDb) GetBlobbers(limit common2.Pagination) ([]Blobber, error) {
 		Order(clause.OrderByColumn{
 			Column: clause.Column{Name: "capacity"},
 			Desc:   limit.IsDescending,
-		}).Find(&blobbers)
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   limit.IsDescending,
+		}).
+		Find(&blobbers)
 
 	return blobbers, result.Error
 }
@@ -107,7 +112,12 @@ func (edb *EventDb) GetActiveBlobbers(limit common2.Pagination) ([]Blobber, erro
 		Order(clause.OrderByColumn{
 			Column: clause.Column{Name: "capacity"},
 			Desc:   limit.IsDescending,
-		}).Find(&blobbers)
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   limit.IsDescending,
+		}).
+		Find(&blobbers)
 	return blobbers, result.Error
 }
 
@@ -122,7 +132,12 @@ func (edb *EventDb) GetBlobbersByRank(limit common2.Pagination) ([]string, error
 		Order(clause.OrderByColumn{
 			Column: clause.Column{Name: "rank_metric"},
 			Desc:   true,
-		}).Find(&blobberIDs)
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   true,
+		}).
+		Find(&blobberIDs)
 
 	return blobberIDs, result.Error
 }
@@ -135,10 +150,18 @@ func (edb *EventDb) GeBlobberByLatLong(
 		Model(&Blobber{}).
 		Select("id").
 		Where("latitude <= ? AND latitude >= ? AND longitude <= ? AND longitude >= ? ",
-			maxLatitude, minLatitude, maxLongitude, minLongitude).Offset(limit.Offset).Limit(limit.Limit).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "capacity"},
-		Desc:   true,
-	}).Find(&blobberIDs)
+			maxLatitude, minLatitude, maxLongitude, minLongitude).
+		Offset(limit.Offset).
+		Limit(limit.Limit).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "capacity"},
+			Desc:   true,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   true,
+		}).
+		Find(&blobberIDs)
 
 	return blobberIDs, result.Error
 }
@@ -146,7 +169,10 @@ func (edb *EventDb) GeBlobberByLatLong(
 func (edb *EventDb) GetBlobbersFromIDs(ids []string) ([]Blobber, error) {
 	var blobbers []Blobber
 	result := edb.Store.Get().Preload("Rewards").
-		Model(&Blobber{}).Order("id").Where("id IN ?", ids).Find(&blobbers)
+		Model(&Blobber{}).
+		Order("id").
+		Where("id IN ?", ids).
+		Find(&blobbers)
 	return blobbers, result.Error
 }
 
@@ -195,10 +221,13 @@ type AllocationQuery struct {
 
 func (edb *EventDb) GetBlobberIdsFromUrls(urls []string, data common2.Pagination) ([]string, error) {
 	dbStore := edb.Store.Get().Model(&Blobber{})
-	dbStore = dbStore.Where("base_url IN ?", urls).Limit(data.Limit).Offset(data.Offset).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "id"},
-		Desc:   data.IsDescending,
-	})
+	dbStore = dbStore.Where("base_url IN ?", urls).
+		Limit(data.Limit).
+		Offset(data.Offset).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   data.IsDescending,
+		})
 	var blobberIDs []string
 	return blobberIDs, dbStore.Select("id").Find(&blobberIDs).Error
 }
@@ -213,10 +242,16 @@ func (edb *EventDb) GetBlobbersFromParams(allocation AllocationQuery, limit comm
 	dbStore = dbStore.Where("is_killed = false")
 	dbStore = dbStore.Where("is_shutdown = false")
 	dbStore = dbStore.Where("is_available = true")
-	dbStore = dbStore.Limit(limit.Limit).Offset(limit.Offset).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "write_price"},
-		Desc:   limit.IsDescending,
-	})
+	dbStore = dbStore.Limit(limit.Limit).
+		Offset(limit.Offset).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "write_price"},
+			Desc:   limit.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   limit.IsDescending,
+		})
 	var blobberIDs []string
 	return blobberIDs, dbStore.Select("id").Find(&blobberIDs).Error
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/block.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/block.go
@@ -71,12 +71,14 @@ func (edb *EventDb) GetBlockByRound(round int64) (Block, error) {
 func (edb *EventDb) GetBlockByDate(date string) (Block, error) {
 	block := Block{}
 
-	return block, edb.Store.Get().Table("blocks").Where("creation_date <= ?", date).Limit(1).Order(
-		clause.OrderByColumn{
-			Column: clause.Column{Name: "creation_date"},
+	return block, edb.Store.Get().Table("blocks").
+		Where("creation_date <= ?", date).
+		Limit(1).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "round"},
 			Desc:   true,
-		},
-	).Scan(&block).Error
+		}).
+		Scan(&block).Error
 }
 
 func (edb *EventDb) GetBlocksByRound(round string) (Block, error) {

--- a/code/go/0chain.net/smartcontract/dbs/event/challenge.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/challenge.go
@@ -65,10 +65,17 @@ func (edb *EventDb) GetOpenChallengesForBlobber(blobberID string, from, now, cct
 
 	query := edb.Store.Get().Model(&Challenge{}).
 		Where("created_at > ? AND blobber_id = ? AND responded = ?",
-			from, blobberID, 0).Limit(limit.Limit).Offset(limit.Offset).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "created_at"},
-		Desc:   limit.IsDescending,
-	})
+			from, blobberID, 0).
+		Limit(limit.Limit).
+		Offset(limit.Offset).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "created_at"},
+			Desc:   limit.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "challenge_id"},
+			Desc:   limit.IsDescending,
+		})
 
 	result := query.Find(&chs)
 	if result.Error != nil {

--- a/code/go/0chain.net/smartcontract/dbs/event/delegate_pool.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/delegate_pool.go
@@ -70,7 +70,10 @@ func (edb *EventDb) GetUserDelegatePools(userId string, pType spenum.Provider, p
 		Not(&DelegatePool{Status: spenum.Deleted}).
 		Offset(pagination.Offset).Limit(pagination.Limit).
 		Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "id"},
+			Column: clause.Column{Name: "pool_id"},
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "provider_type"},
 		}).
 		Find(&dps)
 	if result.Error != nil {

--- a/code/go/0chain.net/smartcontract/dbs/event/error.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/error.go
@@ -19,8 +19,14 @@ func (edb *EventDb) addError(err Error) error {
 
 func (edb *EventDb) GetErrorByTransactionHash(transactionID string, limit common.Pagination) ([]Error, error) {
 	var transactionErrors []Error
-	return transactionErrors, edb.Store.Get().Model(&Error{}).Offset(limit.Offset).Limit(limit.Limit).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "id"},
-		Desc:   limit.IsDescending,
-	}).Where(Error{TransactionID: transactionID}).Find(&transactionErrors).Error
+	return transactionErrors, edb.Store.Get().
+		Model(&Error{}).
+		Offset(limit.Offset).
+		Limit(limit.Limit).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   limit.IsDescending,
+		}).
+		Where(Error{TransactionID: transactionID}).
+		Find(&transactionErrors).Error
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/event.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/event.go
@@ -44,10 +44,16 @@ func (edb *EventDb) FindEvents(ctx context.Context, search Event, p common.Pagin
 		db = db.Where("tag", search.Tag).Find(eventTable)
 	}
 
-	db = db.Offset(p.Offset).Limit(p.Limit).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "created_at"},
-		Desc:   p.IsDescending,
-	})
+	db = db.Offset(p.Offset).
+		Limit(p.Limit).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "tx_hash"},
+			Desc:   p.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "index"},
+			Desc:   p.IsDescending,
+		})
 
 	var events []Event
 	db.WithContext(ctx).Find(&events)

--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -46,7 +46,7 @@ func (edb *EventDb) GetMiner(id string) (Miner, error) {
 		First(&miner).Error
 }
 
-//nolint
+// nolint
 func (edb *EventDb) GetMinerWithDelegatePools(id string) (Miner, []DelegatePool, error) {
 	var minerDps []struct {
 		Miner
@@ -146,18 +146,31 @@ func (edb *EventDb) GetMinersWithFiltersAndPagination(filter MinerQuery, p commo
 		Model(&Miner{}).
 		Where(&filter).Offset(p.Offset).Limit(p.Limit).
 		Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "created_at"},
+			Column: clause.Column{Name: "creation_round"},
+			Desc:   p.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
 			Desc:   p.IsDescending,
 		})
+
 	return miners, query.Scan(&miners).Error
 }
 
 func (edb *EventDb) GetMinerGeolocations(filter MinerQuery, p common2.Pagination) ([]MinerGeolocation, error) {
 	var minerLocations []MinerGeolocation
-	query := edb.Get().Model(&Miner{}).Where(&filter).Offset(p.Offset).Limit(p.Limit).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "created_at"},
-		Desc:   p.IsDescending,
-	})
+	query := edb.Get().Model(&Miner{}).
+		Where(&filter).
+		Offset(p.Offset).
+		Limit(p.Limit).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "creation_round"},
+			Desc:   p.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   p.IsDescending,
+		})
 	result := query.Scan(&minerLocations)
 
 	return minerLocations, result.Error

--- a/code/go/0chain.net/smartcontract/dbs/event/readmarker.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/readmarker.go
@@ -37,7 +37,10 @@ func (edb *EventDb) GetReadMarkersFromQueryPaginated(query ReadMarker, limit com
 		Where(query).Offset(limit.Offset).Limit(limit.Limit)
 
 	queryBuilder.Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "id"},
+		Column: clause.Column{Name: "block_number"},
+		Desc:   limit.IsDescending,
+	}).Order(clause.OrderByColumn{
+		Column: clause.Column{Name: "transaction_id"},
 		Desc:   limit.IsDescending,
 	})
 	var rms []ReadMarker

--- a/code/go/0chain.net/smartcontract/dbs/event/reward_delegate.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/reward_delegate.go
@@ -74,5 +74,10 @@ func (edb *EventDb) GetDelegateRewards(limit common.Pagination, PoolId string, s
 		Order(clause.OrderByColumn{
 			Column: clause.Column{Name: "block_number"},
 			Desc:   limit.IsDescending,
-		}).Scan(&rds).Error
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   limit.IsDescending,
+		}).
+		Scan(&rds).Error
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/reward_provider.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/reward_provider.go
@@ -59,5 +59,10 @@ func (edb *EventDb) GetProviderRewards(limit common.Pagination, id string, start
 		Order(clause.OrderByColumn{
 			Column: clause.Column{Name: "block_number"},
 			Desc:   limit.IsDescending,
-		}).Scan(&rps).Error
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
+			Desc:   limit.IsDescending,
+		}).
+		Scan(&rps).Error
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/sharder.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/sharder.go
@@ -57,7 +57,7 @@ func (s *Sharder) SetTotalRewards(value currency.Coin) {
 
 // swagger:model SharderGeolocation
 type SharderGeolocation struct {
-	SharderID string  `json:"sharder_id"`
+	ID        string  `json:"id"`
 	Latitude  float64 `json:"latitude"`
 	Longitude float64 `json:"longitude"`
 }
@@ -204,7 +204,11 @@ func (edb *EventDb) GetShardersWithFilterAndPagination(filter SharderQuery, p co
 		Model(&Sharder{}).
 		Where(&filter).Offset(p.Offset).Limit(p.Limit).
 		Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "created_at"},
+			Column: clause.Column{Name: "creation_round"},
+			Desc:   p.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
 			Desc:   p.IsDescending,
 		})
 	return sharders, query.Scan(&sharders).Error
@@ -217,7 +221,11 @@ func (edb *EventDb) GetSharderGeolocations(filter SharderQuery, p common2.Pagina
 		Model(&Sharder{}).
 		Where(&filter).Offset(p.Offset).Limit(p.Limit).
 		Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "created_at"},
+			Column: clause.Column{Name: "creation_round"},
+			Desc:   p.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "id"},
 			Desc:   p.IsDescending,
 		})
 

--- a/code/go/0chain.net/smartcontract/dbs/event/sharder_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/sharder_test.go
@@ -357,7 +357,7 @@ func TestGetSharderLocations(t *testing.T) {
 		assert.NoError(t, err, "There should be no error")
 		assert.Equal(t, 12, len(locations), "all sharders should be returned")
 		for _, location := range locations {
-			id, err := strconv.ParseInt(location.SharderID, 10, 0)
+			id, err := strconv.ParseInt(location.ID, 10, 0)
 			assert.NoError(t, err, "sharder id should be parsed to integer")
 			assert.Equal(t, location.Longitude, float64(100+id), "longitude should match")
 			assert.Equal(t, location.Latitude, float64(100-id), "longitude should match")
@@ -368,7 +368,7 @@ func TestGetSharderLocations(t *testing.T) {
 		assert.NoError(t, err, "There should be no error")
 		assert.Equal(t, 6, len(locations), "locations of only active sharders should be returned")
 		for _, location := range locations {
-			id, err := strconv.ParseInt(location.SharderID, 10, 0)
+			id, err := strconv.ParseInt(location.ID, 10, 0)
 			assert.NoError(t, err, "sharder id should be parsed to integer")
 			assert.Equal(t, location.Longitude, float64(100+id), "longitude should match")
 			assert.Equal(t, location.Latitude, float64(100-id), "longitude should match")
@@ -379,7 +379,7 @@ func TestGetSharderLocations(t *testing.T) {
 		assert.NoError(t, err, "There should be no error")
 		assert.Equal(t, 6, len(locations), "locations of only active sharders should be returned")
 		for _, location := range locations {
-			id, err := strconv.ParseInt(location.SharderID, 10, 0)
+			id, err := strconv.ParseInt(location.ID, 10, 0)
 			assert.NoError(t, err, "sharder id should be parsed to integer")
 			assert.Equal(t, location.Longitude, float64(100+id), "longitude should match")
 			assert.Equal(t, location.Latitude, float64(100-id), "longitude should match")

--- a/code/go/0chain.net/smartcontract/dbs/event/transaction.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/transaction.go
@@ -67,7 +67,11 @@ func (edb *EventDb) GetTransactionByClientId(clientID string, limit common.Pagin
 		Offset(limit.Offset).
 		Limit(limit.Limit).
 		Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "creation_date"},
+			Column: clause.Column{Name: "round"},
+			Desc:   limit.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "hash"},
 			Desc:   limit.IsDescending,
 		}).
 		Scan(&tr)
@@ -84,9 +88,14 @@ func (edb *EventDb) GetTransactionByToClientId(toClientID string, limit common.P
 		Offset(limit.Offset).
 		Limit(limit.Limit).
 		Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "creation_date"},
+			Column: clause.Column{Name: "round"},
 			Desc:   limit.IsDescending,
-		}).Scan(&tr)
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "hash"},
+			Desc:   limit.IsDescending,
+		}).
+		Scan(&tr)
 	return tr, res.Error
 }
 
@@ -111,9 +120,14 @@ func (edb *EventDb) GetTransactions(limit common.Pagination) ([]Transaction, err
 		Offset(limit.Offset).
 		Limit(limit.Limit).
 		Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "creation_date"},
+			Column: clause.Column{Name: "round"},
 			Desc:   limit.IsDescending,
-		}).Find(&tr)
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "hash"},
+			Desc:   limit.IsDescending,
+		}).
+		Find(&tr)
 
 	return tr, res.Error
 }
@@ -130,6 +144,10 @@ func (edb *EventDb) GetTransactionByBlockNumbers(blockStart, blockEnd int64, lim
 			Column: clause.Column{Name: "round"},
 			Desc:   limit.IsDescending,
 		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "hash"},
+			Desc:   limit.IsDescending,
+		}).
 		Find(&tr)
 	return tr, res.Error
 }
@@ -140,6 +158,7 @@ func (edb *EventDb) GetTransactionsForBlocks(blockStart, blockEnd int64) ([]Tran
 		Model(&Transaction{}).
 		Where("round >= ? AND round < ?", blockStart, blockEnd).
 		Order("round asc").
+		Order("hash desc").
 		Find(&tr)
 	return tr, res.Error
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
@@ -63,19 +63,32 @@ func (edb *EventDb) GetWriteMarkers(limit common.Pagination) ([]WriteMarker, err
 		Offset(limit.Offset).
 		Limit(limit.Limit).
 		Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "id"},
+			Column: clause.Column{Name: "block_number"},
 			Desc:   limit.IsDescending,
-		}).Scan(&wm).Error
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "transaction_id"},
+			Desc:   limit.IsDescending,
+		}).
+		Scan(&wm).Error
 }
 
 func (edb *EventDb) GetWriteMarkersForAllocationID(allocationID string, limit common.Pagination) ([]WriteMarker, error) {
 	var wms []WriteMarker
 	result := edb.Store.Get().
 		Model(&WriteMarker{}).
-		Where(&WriteMarker{AllocationID: allocationID}).Offset(limit.Offset).Limit(limit.Limit).Order(clause.OrderByColumn{
-		Column: clause.Column{Name: "id"},
-		Desc:   limit.IsDescending,
-	}).Scan(&wms)
+		Where(&WriteMarker{AllocationID: allocationID}).
+		Offset(limit.Offset).
+		Limit(limit.Limit).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "block_number"},
+			Desc:   limit.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "transaction_id"},
+			Desc:   limit.IsDescending,
+		}).
+		Scan(&wms)
 	return wms, result.Error
 }
 
@@ -112,7 +125,11 @@ func (edb *EventDb) GetWriteMakersFromFilter(filter, value string, limit common.
 		Where(filter+" = ?", value).
 		Offset(limit.Offset).Limit(limit.Limit).
 		Order(clause.OrderByColumn{
-			Column: clause.Column{Name: "id"},
+			Column: clause.Column{Name: "block_number"},
+			Desc:   limit.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "transaction_id"},
 			Desc:   limit.IsDescending,
 		}).Scan(&wms)
 	return wms, result.Error
@@ -135,6 +152,10 @@ func (edb *EventDb) GetWriteMarkersByFilters(filters WriteMarker, selectString s
 		Where(filters).
 		Order(clause.OrderByColumn{
 			Column: clause.Column{Name: "block_number"},
+			Desc:   limit.IsDescending,
+		}).
+		Order(clause.OrderByColumn{
+			Column: clause.Column{Name: "transaction_id"},
 			Desc:   limit.IsDescending,
 		}).
 		Scan(&wm)


### PR DESCRIPTION
## Fixes
When using pagination we need the order results are returned in to be fully defined. Otherwise, order could be different between different offsets leading to confused results.

The Pr adds order by clauses to pagination queries to fully define the order. In general, we try to use data defined by smart contracts so that they remain consistent between sharders. `RewardProvider` and `RewardDelegate` were problematic so we used `id` which is defined by the sharder.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test: https://github.com/0chain/system_test/pull/660
- zboxcli:
- zwalletcli:
- Other: ...
