### PR TITLE
Fix panic due to double close of channel

### DIFF
--- a/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_view_change_main.go
@@ -15,9 +15,10 @@ func (c *Chain) SetupSC(ctx context.Context) {
 	logging.Logger.Info("SetupSC start...")
 	// create timer with 0 duration to start it immediately
 	var (
-		tm      = time.NewTicker(1)
-		timeout = 10 * time.Second
-		doneC   = make(chan struct{})
+		tm            = time.NewTicker(1)
+		timeout       = 10 * time.Second
+		doneC         = make(chan struct{})
+		channelClosed = false
 	)
 
 	for {
@@ -49,7 +50,10 @@ func (c *Chain) SetupSC(ctx context.Context) {
 				case reg := <-isRegisteredC:
 					if reg {
 						logging.Logger.Debug("SetupSC - node is already registered")
-						close(doneC)
+						if !channelClosed {
+							close(doneC)
+							channelClosed = true
+						}
 						return
 					}
 				case <-cctx.Done():
@@ -66,7 +70,10 @@ func (c *Chain) SetupSC(ctx context.Context) {
 
 				if txn != nil && c.ConfirmTransaction(ctx, txn, 30) {
 					logging.Logger.Debug("Register node transaction confirmed")
-					close(doneC)
+					if !channelClosed {
+						close(doneC)
+						channelClosed = true
+					}
 					return
 				}
 


### PR DESCRIPTION
## Fixes
- It is not guaranteed that select statement will select output from closed channel even though it is first case of select. It can select such closed channels randomly. In our case there are three channels that select was looking at. One is `doneC` , second is `ctx.Done()` and third is `tm.C`.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
