### PR TITLE
Use consistent time when creating benchmark MPT

### DIFF
--- a/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
+++ b/code/go/0chain.net/smartcontract/benchmark/main/cmd/mpt.go
@@ -225,7 +225,7 @@ func setUpMpt(
 	bk.Round = viper.GetInt64(benchmark.NumBlocks)
 	magicBlock := &block.MagicBlock{}
 	signatureScheme := &encryption.BLS0ChainScheme{}
-
+	var benchmarkTime = common.Now()
 	balances := cstate.NewStateContext(
 		bk,
 		pMpt,
@@ -233,7 +233,7 @@ func setUpMpt(
 			HashIDField: datastore.HashIDField{
 				Hash: encryption.Hash("mock transaction hash"),
 			},
-			CreationDate: common.Now(),
+			CreationDate: benchmarkTime,
 		},
 		func(int64) *block.MagicBlock { return magicBlock },
 		func() *block.Block { return bk },
@@ -553,7 +553,7 @@ func setUpMpt(
 			log.Fatal(err)
 		}
 
-		benchData.Now = common.Now()
+		benchData.Now = benchmarkTime
 
 		if _, err := balances.InsertTrieNode(BenchDataKey, &benchData); err != nil {
 			log.Fatal(err)

--- a/code/go/0chain.net/smartcontract/zcnsc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/zcnsc/benchmark_setup.go
@@ -65,7 +65,10 @@ func addMockGlobalNode(balances cstate.StateContextI) {
 	gn.PercentAuthorizers = config.SmartContractConfig.GetFloat64(benchmark.ZcnPercentAuthorizers)
 	gn.BurnAddress = config.SmartContractConfig.GetString(benchmark.ZcnBurnAddress)
 	gn.MaxDelegates = viper.GetInt(benchmark.ZcnMaxDelegates)
-	_, _ = balances.InsertTrieNode(gn.GetKey(), gn)
+	_, err = balances.InsertTrieNode(gn.GetKey(), gn)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func addMockAuthorizers(eventDb *event.EventDb, clients, publicKeys []string, ctx cstate.StateContextI) {


### PR DESCRIPTION
## Fixes
When creating benchmark MPT we use two different values for now, which can cause issues if it takes longer than the health check period to create the simulated MPT.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
