### PR TITLE
Fix settings got from config rather than MPT

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/allocation.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation.go
@@ -609,12 +609,16 @@ func (sc *StorageSmartContract) getAllocationBlobbers(alloc *StorageAllocation,
 
 // closeAllocation making it expired; the allocation will be alive the
 // challenge_completion_time and be closed then
-func (sc *StorageSmartContract) closeAllocation(t *transaction.Transaction,
-	alloc *StorageAllocation, balances chainstate.StateContextI) (
+func (sc *StorageSmartContract) closeAllocation(
+	t *transaction.Transaction,
+	alloc *StorageAllocation,
+	maxChallengeCompletionTime time.Duration,
+	balances chainstate.StateContextI,
+) (
 	resp string, err error) {
 
 	if alloc.Expiration-t.CreationDate <
-		toSeconds(getMaxChallengeCompletionTime()) {
+		toSeconds(maxChallengeCompletionTime) {
 		return "", common.NewError("allocation_closing_failed",
 			"doesn't need to close allocation is about to expire")
 	}
@@ -1112,7 +1116,7 @@ func (sc *StorageSmartContract) updateAllocationRequestInternal(
 		// close allocation now
 
 		if newExpiration <= t.CreationDate {
-			return sc.closeAllocation(t, alloc, balances) // update alloc tx, expir
+			return sc.closeAllocation(t, alloc, conf.MaxChallengeCompletionTime, balances) // update alloc tx, expir
 		}
 
 		// an allocation can't be shorter than configured in SC
@@ -1306,8 +1310,12 @@ func (sc *StorageSmartContract) finalizedPassRates(alloc *StorageAllocation) ([]
 
 // a blobber can not send a challenge response, thus we have to check out
 // challenge requests and their expiration
-func (sc *StorageSmartContract) canceledPassRates(alloc *StorageAllocation,
-	now common.Timestamp, balances chainstate.StateContextI) (
+func (sc *StorageSmartContract) canceledPassRates(
+	alloc *StorageAllocation,
+	now common.Timestamp,
+	maxChallengeCompletionTime time.Duration,
+	balances chainstate.StateContextI,
+) (
 	passRates []float64, err error) {
 
 	if alloc.Stats == nil {
@@ -1329,7 +1337,7 @@ func (sc *StorageSmartContract) canceledPassRates(alloc *StorageAllocation,
 				ba.Stats = new(StorageAllocationStats) // make sure
 			}
 
-			var expire = oc.CreatedAt + toSeconds(getMaxChallengeCompletionTime())
+			var expire = oc.CreatedAt + toSeconds(maxChallengeCompletionTime)
 			if expire < now {
 				ba.Stats.FailedChallenges++
 				alloc.Stats.FailedChallenges++
@@ -1396,8 +1404,12 @@ func (sc *StorageSmartContract) cancelAllocationRequest(
 			"trying to cancel expired allocation")
 	}
 
+	conf, err := getConfig(balances)
+	if err != nil {
+		return "", common.NewError("can't get config", err.Error())
+	}
 	var passRates []float64
-	passRates, err = sc.canceledPassRates(alloc, t.CreationDate, balances)
+	passRates, err = sc.canceledPassRates(alloc, t.CreationDate, conf.MaxChallengeCompletionTime, balances)
 	if err != nil {
 		return "", common.NewError("alloc_cancel_failed",
 			"calculating rest challenges success/fail rates: "+err.Error())
@@ -1419,10 +1431,6 @@ func (sc *StorageSmartContract) cancelAllocationRequest(
 				"error removing offer: "+err.Error())
 		}
 		sps = append(sps, sp)
-	}
-	conf, err := getConfig(balances)
-	if err != nil {
-		return "", common.NewError("can't get config", err.Error())
 	}
 
 	err = sc.finishAllocation(t, alloc, passRates, sps, balances, conf)

--- a/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/allocation_test.go
@@ -1560,17 +1560,17 @@ func TestStorageSmartContract_closeAllocation(t *testing.T) {
 
 	// 1. expiring allocation
 	alloc.Expiration = 1049
-	_, err = ssc.closeAllocation(&tx, alloc, balances)
-	requireErrMsg(t, err, errMsg1)
-
 	var conf = Config{
 		MaxChallengeCompletionTime: 30 * time.Minute,
 	}
 
+	_, err = ssc.closeAllocation(&tx, alloc, conf.MaxChallengeCompletionTime, balances)
+	requireErrMsg(t, err, errMsg1)
+
 	// 2. close (all related pools has created)
 	alloc.Expiration = tx.CreationDate +
 		toSeconds(conf.MaxChallengeCompletionTime) + 20
-	resp, err = ssc.closeAllocation(&tx, alloc, balances)
+	resp, err = ssc.closeAllocation(&tx, alloc, conf.MaxChallengeCompletionTime, balances)
 	require.NoError(t, err)
 	assert.NotZero(t, resp)
 

--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_tests.go
@@ -824,14 +824,19 @@ func BenchmarkTests(
 				_ []byte,
 				balances cstate.StateContextI,
 			) (string, error) {
-				challengesEnabled := viper.GetBool(bk.StorageChallengeEnabled)
-				input := &GenerateChallengeInput{Round: balances.GetBlock().Round}
-				marshal, err2 := json.Marshal(input)
-				if err2 != nil {
-					return "", err2
+				conf, err := getConfig(balances)
+				if err != nil {
+					return "", err
 				}
-				if challengesEnabled {
-					err := ssc.generateChallenge(txn, balances.GetBlock(), marshal, balances)
+
+				input := &GenerateChallengeInput{Round: balances.GetBlock().Round}
+				marshal, err := json.Marshal(input)
+				if err != nil {
+					return "", err
+				}
+
+				if conf.ChallengeEnabled {
+					err := ssc.generateChallenge(txn, balances.GetBlock(), marshal, conf, balances)
 					if err != nil {
 						return "", nil
 					}

--- a/code/go/0chain.net/smartcontract/storagesc/blobber_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/blobber_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"0chain.net/chaincore/config"
+
 	"0chain.net/smartcontract/stakepool/spenum"
 
 	"github.com/0chain/common/core/currency"
@@ -993,7 +995,7 @@ func Test_flow_no_challenge_responses_finalize(t *testing.T) {
 		}
 
 		// let expire all the challenges
-		tp += int64(toSeconds(getMaxChallengeCompletionTime()))
+		tp += int64(toSeconds(config.SmartContractConfig.GetDuration(confMaxChallengeCompletionTime)))
 
 		// add open challenges to allocation stats
 		alloc, err = ssc.getAllocation(allocID, balances)
@@ -1209,7 +1211,7 @@ func Test_flow_no_challenge_responses_cancel(t *testing.T) {
 		}
 
 		// let expire all the challenges
-		tp += int64(toSeconds(getMaxChallengeCompletionTime()))
+		tp += int64(toSeconds(config.SmartContractConfig.GetDuration(confMaxChallengeCompletionTime)))
 
 		tp += 10 // a not expired allocation to cancel
 

--- a/code/go/0chain.net/smartcontract/storagesc/challenge.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge.go
@@ -77,9 +77,16 @@ func (sc *StorageSmartContract) getAllocationChallenges(allocID string,
 }
 
 // move tokens from challenge pool to blobber's stake pool (to unlocked)
-func (sc *StorageSmartContract) blobberReward(alloc *StorageAllocation, latestCompletedChallTime common.Timestamp,
-	blobAlloc *BlobberAllocation, validators []string, partial float64,
-	balances cstate.StateContextI, options ...string) error {
+func (sc *StorageSmartContract) blobberReward(
+	alloc *StorageAllocation,
+	latestCompletedChallTime common.Timestamp,
+	blobAlloc *BlobberAllocation,
+	validators []string,
+	partial float64,
+	maxChallengeCompletionTime time.Duration,
+	balances cstate.StateContextI,
+	options ...string,
+) error {
 	conf, err := sc.getConfig(balances, true)
 	if err != nil {
 		return fmt.Errorf("can't get SC configurations: %v", err.Error())
@@ -87,7 +94,7 @@ func (sc *StorageSmartContract) blobberReward(alloc *StorageAllocation, latestCo
 
 	// time of this challenge
 	challengeCompletedTime := blobAlloc.LatestCompletedChallenge.Created
-	if challengeCompletedTime > alloc.Expiration+toSeconds(getMaxChallengeCompletionTime()) {
+	if challengeCompletedTime > alloc.Expiration+toSeconds(maxChallengeCompletionTime) {
 		return errors.New("late challenge response")
 	}
 
@@ -279,8 +286,15 @@ func (ssc *StorageSmartContract) saveStakePools(validators []datastore.Key,
 }
 
 // move tokens from challenge pool back to write pool
-func (sc *StorageSmartContract) blobberPenalty(alloc *StorageAllocation, prev common.Timestamp,
-	blobAlloc *BlobberAllocation, validators []string, balances cstate.StateContextI, options ...string) (err error) {
+func (sc *StorageSmartContract) blobberPenalty(
+	alloc *StorageAllocation,
+	prev common.Timestamp,
+	blobAlloc *BlobberAllocation,
+	validators []string,
+	maxChallengeCompletionTime time.Duration,
+	balances cstate.StateContextI,
+	options ...string,
+) (err error) {
 	var conf *Config
 	if conf, err = sc.getConfig(balances, true); err != nil {
 		return fmt.Errorf("can't get SC configurations: %v", err.Error())
@@ -288,7 +302,7 @@ func (sc *StorageSmartContract) blobberPenalty(alloc *StorageAllocation, prev co
 
 	// time of this challenge
 	challengeCompleteTime := blobAlloc.LatestCompletedChallenge.Created
-	if challengeCompleteTime > alloc.Expiration+toSeconds(getMaxChallengeCompletionTime()) {
+	if challengeCompleteTime > alloc.Expiration+toSeconds(maxChallengeCompletionTime) {
 		return errors.New("late challenge response")
 	}
 
@@ -467,15 +481,15 @@ func (sc *StorageSmartContract) verifyChallenge(t *transaction.Transaction,
 		zap.String("challenge_id", challenge.ID),
 		zap.Duration("delay", time.Since(common.ToTime(challenge.Created))))
 
-	result, err := verifyChallengeTickets(balances, t, challenge, &challResp)
-	if err != nil {
-		return "", common.NewError(errCode, err.Error())
-	}
-
 	conf, err := sc.getConfig(balances, true)
 	if err != nil {
 		return "", common.NewErrorf(errCode,
 			"cannot get smart contract configurations: %v", err)
+	}
+
+	result, err := verifyChallengeTickets(balances, t, challenge, &challResp, conf.MaxChallengeCompletionTime)
+	if err != nil {
+		return "", common.NewError(errCode, err.Error())
 	}
 
 	allocChallenges, err := sc.getAllocationChallenges(challenge.AllocationID, balances)
@@ -526,10 +540,10 @@ func (sc *StorageSmartContract) verifyChallenge(t *transaction.Transaction,
 	}
 
 	if !(result.pass && result.fresh) {
-		return sc.challengeFailed(balances, t, cab)
+		return sc.challengeFailed(balances, cab, conf.MaxChallengeCompletionTime)
 	}
 
-	return sc.challengePassed(balances, t, conf.BlockReward.TriggerPeriod, cab)
+	return sc.challengePassed(balances, t, conf.BlockReward.TriggerPeriod, cab, conf.MaxChallengeCompletionTime)
 }
 
 type verifyTicketsResult struct {
@@ -553,7 +567,9 @@ type challengeAllocBlobberPassResult struct {
 func verifyChallengeTickets(balances cstate.StateContextI,
 	t *transaction.Transaction,
 	challenge *StorageChallenge,
-	cr *ChallengeResponse) (*verifyTicketsResult, error) {
+	cr *ChallengeResponse,
+	maxChallengeCompletionTime time.Duration,
+) (*verifyTicketsResult, error) {
 	// get unique validation tickets map
 	vtsMap := make(map[string]struct{}, len(cr.ValidationTickets))
 	for _, vt := range cr.ValidationTickets {
@@ -602,8 +618,7 @@ func verifyChallengeTickets(balances cstate.StateContextI,
 
 	var (
 		pass  = success > threshold
-		cct   = toSeconds(getMaxChallengeCompletionTime())
-		fresh = challenge.Created+cct >= t.CreationDate
+		fresh = challenge.Created+toSeconds(maxChallengeCompletionTime) >= t.CreationDate
 	)
 
 	return &verifyTicketsResult{
@@ -619,7 +634,9 @@ func (sc *StorageSmartContract) challengePassed(
 	balances cstate.StateContextI,
 	t *transaction.Transaction,
 	triggerPeriod int64,
-	cab *challengeAllocBlobberPassResult) (string, error) {
+	cab *challengeAllocBlobberPassResult,
+	maxChallengeCompletionTime time.Duration,
+) (string, error) {
 	ongoingParts, err := getOngoingPassedBlobberRewardsPartitions(balances, triggerPeriod)
 	if err != nil {
 		return "", common.NewError("verify_challenge",
@@ -717,7 +734,13 @@ func (sc *StorageSmartContract) challengePassed(
 		partial = float64(cab.success) / float64(cab.threshold)
 	}
 
-	err = sc.blobberReward(cab.alloc, cab.latestCompletedChallTime, cab.blobAlloc, cab.validators, partial, balances, cab.challenge.ID)
+	err = sc.blobberReward(
+		cab.alloc, cab.latestCompletedChallTime, cab.blobAlloc, cab.validators,
+		partial,
+		maxChallengeCompletionTime,
+		balances,
+		cab.challenge.ID,
+	)
 	if err != nil {
 		return "", common.NewError("challenge_reward_error", err.Error())
 	}
@@ -736,8 +759,9 @@ func (sc *StorageSmartContract) challengePassed(
 
 func (sc *StorageSmartContract) challengeFailed(
 	balances cstate.StateContextI,
-	t *transaction.Transaction,
-	cab *challengeAllocBlobberPassResult) (string, error) {
+	cab *challengeAllocBlobberPassResult,
+	maxChallengeCompletionTime time.Duration,
+) (string, error) {
 	if !sc.completeChallenge(cab) {
 		return "", common.NewError("challenge_out_of_order",
 			"First challenge on the list is not same as the one"+
@@ -759,8 +783,11 @@ func (sc *StorageSmartContract) challengeFailed(
 
 	logging.Logger.Info("Challenge failed", zap.String("challenge", cab.challenge.ID))
 
-	err := sc.blobberPenalty(cab.alloc, cab.latestCompletedChallTime, cab.blobAlloc,
-		cab.validators, balances)
+	err := sc.blobberPenalty(
+		cab.alloc, cab.latestCompletedChallTime, cab.blobAlloc, cab.validators,
+		maxChallengeCompletionTime,
+		balances,
+	)
 	if err != nil {
 		return "", common.NewError("challenge_penalty_error", err.Error())
 	}
@@ -1102,9 +1129,13 @@ type GenerateChallengeInput struct {
 	Round int64 `json:"round,omitempty"`
 }
 
-func (sc *StorageSmartContract) generateChallenge(t *transaction.Transaction,
-	b *block.Block, input []byte, balances cstate.StateContextI) (err error) {
-
+func (sc *StorageSmartContract) generateChallenge(
+	t *transaction.Transaction,
+	b *block.Block,
+	input []byte,
+	conf *Config,
+	balances cstate.StateContextI,
+) (err error) {
 	inputRound := GenerateChallengeInput{}
 	if err := json.Unmarshal(input, &inputRound); err != nil {
 		return err
@@ -1112,11 +1143,6 @@ func (sc *StorageSmartContract) generateChallenge(t *transaction.Transaction,
 
 	if inputRound.Round != b.Round {
 		return fmt.Errorf("bad round, block %v but input %v", b.Round, inputRound.Round)
-	}
-
-	var conf *Config
-	if conf, err = sc.getConfig(balances, true); err != nil {
-		return fmt.Errorf("can't get SC configurations: %v", err.Error())
 	}
 
 	validators, err := getValidatorsList(balances)
@@ -1191,6 +1217,7 @@ func (sc *StorageSmartContract) generateChallenge(t *transaction.Transaction,
 		result.storageChallenge,
 		result.allocChallenges,
 		result.challInfo,
+		conf,
 		balances)
 	if err != nil {
 		return common.NewErrorf("adding_challenge_error",
@@ -1206,8 +1233,9 @@ func (sc *StorageSmartContract) addChallenge(alloc *StorageAllocation,
 	challenge *StorageChallenge,
 	allocChallenges *AllocationChallenges,
 	challInfo *StorageChallengeResponse,
-	balances cstate.StateContextI) error {
-
+	conf *Config,
+	balances cstate.StateContextI,
+) error {
 	if challenge.BlobberID == "" {
 		return common.NewError("add_challenge",
 			"no blobber to add challenge to")
@@ -1220,7 +1248,7 @@ func (sc *StorageSmartContract) addChallenge(alloc *StorageAllocation,
 	}
 
 	// remove expired challenges
-	expiredIDsMap, err := alloc.removeExpiredChallenges(allocChallenges, challenge.Created, balances)
+	expiredIDsMap, err := alloc.removeExpiredChallenges(allocChallenges, challenge.Created, conf.MaxChallengeCompletionTime, balances)
 	if err != nil {
 		return common.NewErrorf("add_challenge", "remove expired challenges: %v", err)
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/challenge_test.go
@@ -135,8 +135,10 @@ func TestAddChallenge(t *testing.T) {
 				StorageChallenge: c,
 				AllocationRoot:   alloc.BlobberAllocsMap[bid].AllocationRoot,
 			}
-
-			err = ssc.addChallenge(alloc, c, allocChallenges, challInfo, balances)
+			var conf = &Config{
+				MaxChallengeCompletionTime: p.cct,
+			}
+			err = ssc.addChallenge(alloc, c, allocChallenges, challInfo, conf, balances)
 			require.NoError(t, err)
 		}
 
@@ -262,10 +264,14 @@ func TestAddChallenge(t *testing.T) {
 
 			// add new challenge
 			c, challInfo := newChallenge(args.alloc.ID, tt.parameters.add.blobberID, tt.parameters.add.ts)
+			var conf = &Config{
+				MaxChallengeCompletionTime: tt.parameters.cct,
+			}
 			err := ssc.addChallenge(args.alloc,
 				c,
 				args.allocChallenges,
 				challInfo,
+				conf,
 				args.balances)
 
 			if tt.want.error {
@@ -953,7 +959,7 @@ func testBlobberPenalty(
 	var ssc, allocation, details, ctx = setupChallengeMocks(t, scYaml, blobberYaml, validatorYamls, stakes, validators,
 		validatorStakes, wpBalance, challengePoolIntegralValue, challengePoolBalance, thisChallange, thisExpires, now, size)
 
-	err = ssc.blobberPenalty(allocation, previous, details, validators, ctx)
+	err = ssc.blobberPenalty(allocation, previous, details, validators, scYaml.MaxChallengeCompletionTime, ctx)
 	if err != nil {
 		return err
 	}
@@ -1007,7 +1013,7 @@ func testBlobberReward(
 	var ssc, allocation, details, ctx = setupChallengeMocks(t, scYaml, blobberYaml, validatorYamls, stakes, validators,
 		validatorStakes, wpBalance, challengePoolIntegralValue, challengePoolBalance, thisChallange, thisExpires, now, 0)
 
-	err = ssc.blobberReward(allocation, previous, details, validators, partial, ctx)
+	err = ssc.blobberReward(allocation, previous, details, validators, partial, scYaml.MaxChallengeCompletionTime, ctx)
 	if err != nil {
 		return err
 	}

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -1184,7 +1184,15 @@ func (srh *StorageRestHandler) getOpenChallenges(w http.ResponseWriter, r *http.
 		return
 	}
 
-	challenges, err := getOpenChallengesForBlobber(blobberID, from, common.Timestamp(getMaxChallengeCompletionTime().Seconds()), limit, sctx.GetEventDB())
+	conf, err := getConfig(sctx)
+	if err != nil {
+		common.Respond(w, r, nil, common.NewErrInternal(err.Error()))
+		return
+	}
+
+	challenges, err := getOpenChallengesForBlobber(
+		blobberID, from, common.Timestamp(conf.MaxChallengeCompletionTime.Seconds()), limit, sctx.GetEventDB(),
+	)
 	if err != nil {
 		common.Respond(w, r, "", smartcontract.NewErrNoResourceOrErrInternal(err, true, "can't find challenges"))
 		return

--- a/code/go/0chain.net/smartcontract/storagesc/models.go
+++ b/code/go/0chain.net/smartcontract/storagesc/models.go
@@ -24,7 +24,6 @@ import (
 
 	"go.uber.org/zap"
 
-	"0chain.net/chaincore/config"
 	"0chain.net/smartcontract/stakepool"
 
 	cstate "0chain.net/chaincore/chain/state"
@@ -1329,19 +1328,16 @@ func (sn *StorageAllocation) UnmarshalMsg(data []byte) ([]byte, error) {
 	return o, nil
 }
 
-func getMaxChallengeCompletionTime() time.Duration {
-	return config.SmartContractConfig.GetDuration(confMaxChallengeCompletionTime)
-}
-
 // removeExpiredChallenges removes all expired challenges from the allocation,
 // return the expired challenge ids per blobber (maps blobber id to its expiredIDs), or error if any.
 // the expired challenge ids could be used to delete the challenge node from MPT when needed
-func (sa *StorageAllocation) removeExpiredChallenges(allocChallenges *AllocationChallenges,
-	now common.Timestamp, balances cstate.StateContextI) (map[string]string, error) {
+func (sa *StorageAllocation) removeExpiredChallenges(
+	allocChallenges *AllocationChallenges,
+	now common.Timestamp,
+	cct time.Duration,
+	balances cstate.StateContextI,
+) (map[string]string, error) {
 	var expiredChallengeBlobberMap = make(map[string]string)
-
-	cct := getMaxChallengeCompletionTime()
-
 	var nonExpiredChallenges []*AllocOpenChallenge
 
 	for _, oc := range allocChallenges.OpenChallenges {

--- a/code/go/0chain.net/smartcontract/storagesc/sc.go
+++ b/code/go/0chain.net/smartcontract/storagesc/sc.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rcrowley/go-metrics"
 
 	chainstate "0chain.net/chaincore/chain/state"
-	"0chain.net/chaincore/config"
 	sci "0chain.net/chaincore/smartcontractinterface"
 	"0chain.net/chaincore/transaction"
 	"0chain.net/core/common"
@@ -253,10 +252,12 @@ func (sc *StorageSmartContract) Execute(t *transaction.Transaction,
 	case "collect_reward":
 		resp, err = sc.collectReward(t, input, balances)
 	case "generate_challenge":
-		challengesEnabled := config.SmartContractConfig.GetBool(
-			"smart_contracts.storagesc.challenge_enabled")
-		if challengesEnabled {
-			err = sc.generateChallenge(t, balances.GetBlock(), input, balances)
+		var conf *Config
+		if conf, err = sc.getConfig(balances, true); err != nil {
+			return "", fmt.Errorf("can't get SC configurations: %v", err.Error())
+		}
+		if conf.ChallengeEnabled {
+			err = sc.generateChallenge(t, balances.GetBlock(), input, conf, balances)
 			if err != nil {
 				return
 			}

--- a/code/go/0chain.net/smartcontract/storagesc/transactions_bench_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/transactions_bench_test.go
@@ -282,7 +282,7 @@ func Benchmark_generateChallenges(b *testing.B) {
 				}
 				b.StartTimer()
 
-				err = ssc.generateChallenge(tx, blk, nil, balances)
+				err = ssc.generateChallenge(tx, blk, nil, conf, balances)
 				require.NoError(b, err)
 			}
 			b.ReportAllocs()
@@ -439,6 +439,7 @@ func Benchmark_verifyChallenge(b *testing.B) {
 					storageChall,
 					allocChall,
 					challInfo,
+					conf,
 					balances)
 
 				require.NoError(b, err)


### PR DESCRIPTION
## Fixes
`max_challenge_completion_time` and `challenges_enabled` where being read from viper rather than MPT.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
