### PR TITLE
Fix/fault tolerance conductor test issue

### DIFF
--- a/.github/workflows/conductor-fault-tolerance-tests.yml
+++ b/.github/workflows/conductor-fault-tolerance-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Docker Compose Setup.
       run: |
-        sudo curl -L https://github.com/docker/compose/releases/download/1.29.2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+        sudo curl -L "https://github.com/docker/compose/releases/download/1.29.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
         sudo chmod +x /usr/local/bin/docker-compose
         docker-compose --version
     

--- a/.github/workflows/conductor-fault-tolerance-tests.yml
+++ b/.github/workflows/conductor-fault-tolerance-tests.yml
@@ -40,6 +40,7 @@ jobs:
 
     - name: Docker Compose Setup.
       run: |
+        sudo rm /usr/local/bin/docker-compose
         sudo curl -L "https://github.com/docker/compose/releases/download/1.29.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
         sudo chmod +x /usr/local/bin/docker-compose
         docker-compose --version

--- a/.github/workflows/conductor-fault-tolerance-tests.yml
+++ b/.github/workflows/conductor-fault-tolerance-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Docker Compose Setup.
       run: |
-        sudo rm /usr/local/bin/docker-compose
+        sudo rm /usr/local/bin/docker-compose || true
         sudo curl -L "https://github.com/docker/compose/releases/download/1.29.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
         sudo chmod +x /usr/local/bin/docker-compose
         docker-compose --version

--- a/docker.local/config/conductor.no-view-change.fault-tolerance.yaml
+++ b/docker.local/config/conductor.no-view-change.fault-tolerance.yaml
@@ -144,25 +144,21 @@ tests:
           start: true
       - wait_round:
           shift: 20
-          timeout: "1m"
       - stop: ["miner-4"]
       - wait_round:
           shift: 10
-          timeout: "1m"
       - command:
           name: "sleep_3m"
       - stop: ["miner-3"]
       - start: ["miner-4"]
       - wait_round:
           shift: 10
-          timeout: "3m"
       - command:
           name: "sleep_3m"
       - stop: ["miner-2"]
       - start: ["miner-3"]
       - wait_round:
           shift: 10
-          timeout: "3m"
 
   # SHARDERS GO DOWN
   - name: "All sharders go down"
@@ -205,23 +201,19 @@ tests:
           start: true
       - wait_round:
           shift: 50
-          timeout: "1m"
       - stop: ["sharder-2"]
       - command:
           name: "sleep_3m"
       - wait_round:
           shift: 50
-          timeout: "1m"
       - start: ["sharder-2"]
       - command:
           name: "sleep_3m"
       - wait_round:
           shift: 50
-          timeout: "10m"
       - stop: ["sharder-1"]
       - wait_round:
           shift: 50
-          timeout: "10m"
 
   # NODES GO DOWN AND COME UP
   - name: "All nodes go down and come up"


### PR DESCRIPTION
## Fixes
The issue was with early timeout and conductor server would send stop signal to sharder and other nodes. It would thus crash sharder.
The directive can take timeout of case itself which is 10 minutes.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
