### PR TITLE
Clean eventsdb indexes

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/allocation.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/allocation.go
@@ -27,7 +27,7 @@ type Allocation struct {
 	ReadPriceMax             currency.Coin `json:"read_price_max"`
 	WritePriceMin            currency.Coin `json:"write_price_min"`
 	WritePriceMax            currency.Coin `json:"write_price_max"`
-	StartTime                int64         `json:"start_time" gorm:"index:idx_astart_time"`
+	StartTime                int64         `json:"start_time"`
 	Finalized                bool          `json:"finalized"`
 	Cancelled                bool          `json:"cancelled"`
 	UsedSize                 int64         `json:"used_size"`

--- a/code/go/0chain.net/smartcontract/dbs/event/authorizer.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/authorizer.go
@@ -28,7 +28,7 @@ type Authorizer struct {
 	TotalMint currency.Coin `json:"total_mint"`
 	TotalBurn currency.Coin `json:"total_burn"`
 
-	CreationRound int64 `json:"creation_round" gorm:"index:idx_authorizer_creation_round"`
+	CreationRound int64 `json:"creation_round"`
 }
 
 func (a *Authorizer) GetTotalStake() currency.Coin {

--- a/code/go/0chain.net/smartcontract/dbs/event/authorizer_snapshot.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/authorizer_snapshot.go
@@ -18,7 +18,7 @@ type AuthorizerSnapshot struct {
 	TotalMint     currency.Coin `json:"total_mint"`
 	TotalBurn     currency.Coin `json:"total_burn"`
 	ServiceCharge float64       `json:"service_charge"`
-	CreationRound int64         `json:"creation_round" gorm:"index"`
+	CreationRound int64         `json:"creation_round"`
 	IsKilled      bool          `json:"is_killed"`
 	IsShutdown    bool          `json:"is_shutdown"`
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -58,7 +58,7 @@ type Blobber struct {
 	WriteMarkers []WriteMarker `gorm:"foreignKey:BlobberID;references:ID"`
 	ReadMarkers  []ReadMarker  `gorm:"foreignKey:BlobberID;references:ID"`
 
-	CreationRound int64 `json:"creation_round" gorm:"index:idx_blobber_creation_round"`
+	CreationRound int64 `json:"creation_round"`
 }
 
 // BlobberPriceRange represents a price range allowed by user to filter blobbers.

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber.go
@@ -49,7 +49,7 @@ type Blobber struct {
 	ChallengesPassed    uint64        `json:"challenges_passed"`
 	ChallengesCompleted uint64        `json:"challenges_completed"`
 	OpenChallenges      uint64        `json:"open_challenges"`
-	RankMetric          float64       `json:"rank_metric" gorm:"index"` // currently ChallengesPassed / ChallengesCompleted
+	RankMetric          float64       `json:"rank_metric"` // currently ChallengesPassed / ChallengesCompleted
 	TotalBlockRewards   currency.Coin `json:"total_block_rewards"`
 	TotalStorageIncome  currency.Coin `json:"total_storage_income"`
 	TotalReadIncome     currency.Coin `json:"total_read_income"`

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_aggregate.go
@@ -32,7 +32,7 @@ type BlobberAggregate struct {
 	ChallengesCompleted uint64        `json:"challenges_completed"`
 	OpenChallenges      uint64        `json:"open_challenges"`
 	InactiveRounds      int64         `json:"InactiveRounds"`
-	RankMetric          float64       `json:"rank_metric" gorm:"index:idx_ba_rankmetric"`
+	RankMetric          float64       `json:"rank_metric"`
 	Downtime            uint64        `json:"downtime"`
 }
 

--- a/code/go/0chain.net/smartcontract/dbs/event/blobber_snapshot.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/blobber_snapshot.go
@@ -26,7 +26,7 @@ type BlobberSnapshot struct {
 	ChallengesPassed    uint64        `json:"challenges_passed"`
 	ChallengesCompleted uint64        `json:"challenges_completed"`
 	OpenChallenges      uint64        `json:"open_challenges"`
-	CreationRound       int64         `json:"creation_round" gorm:"index"`
+	CreationRound       int64         `json:"creation_round"`
 	RankMetric          float64       `json:"rank_metric"`
 	IsKilled            bool          `json:"is_killed"`
 	IsShutdown          bool          `json:"is_shutdown"`

--- a/code/go/0chain.net/smartcontract/dbs/event/block.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/block.go
@@ -14,7 +14,7 @@ type Block struct {
 
 	Hash                  string    `json:"hash" gorm:"uniqueIndex:idx_bhash"`
 	Version               string    `json:"version"`
-	CreationDate          int64     `json:"creation_date" gorm:"index:idx_bcreation_date"`
+	CreationDate          int64     `json:"creation_date"`
 	Round                 int64     `json:"round" gorm:"index:idx_bround"`
 	MinerID               string    `json:"miner_id"`
 	RoundRandomSeed       int64     `json:"round_random_seed"`

--- a/code/go/0chain.net/smartcontract/dbs/event/challenge.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/challenge.go
@@ -23,7 +23,7 @@ type Challenge struct {
 	AllocationRoot string           `json:"allocation_root"`
 	Responded      int64            `json:"responded" gorm:"index:idx_copen_challenge,priority:3"`
 	Passed         bool             `json:"passed"`
-	RoundResponded int64            `json:"round_responded" gorm:"index"`
+	RoundResponded int64            `json:"round_responded"`
 	ExpiredN       int              `json:"expired_n" gorm:"-"`
 	Timestamp      common.Timestamp `json:"timestamp" gorm:"timestamp"`
 }
@@ -63,7 +63,7 @@ func (edb *EventDb) GetChallenges(blobberId string, start, end int64) ([]Challen
 		Model(&Challenge{}).
 		Where("blobber_id = ? AND round_responded >= ? AND round_responded < ?",
 			blobberId, start, end).
-		Find(&chs)
+		Find(&chs).Debug()
 	return chs, result.Error
 }
 

--- a/code/go/0chain.net/smartcontract/dbs/event/challenge.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/challenge.go
@@ -1,19 +1,20 @@
 package event
 
 import (
-	common2 "0chain.net/smartcontract/common"
 	"fmt"
+
+	common2 "0chain.net/smartcontract/common"
+	"0chain.net/smartcontract/dbs/model"
 	"gorm.io/gorm/clause"
 
 	"0chain.net/core/common"
-	"gorm.io/gorm"
 )
 
 // swagger:model Challenges
 type Challenges []Challenge
 
 type Challenge struct {
-	gorm.Model
+	model.UpdatableModel
 	ChallengeID    string           `json:"challenge_id" gorm:"index:idx_cchallenge_id,unique"`
 	CreatedAt      common.Timestamp `json:"created_at" gorm:"index:idx_copen_challenge,priority:1"`
 	AllocationID   string           `json:"allocation_id"`

--- a/code/go/0chain.net/smartcontract/dbs/event/delegate_pool.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/delegate_pool.go
@@ -20,7 +20,7 @@ type DelegatePool struct {
 	PoolID       string          `json:"pool_id" gorm:"uniqueIndex:ppp;index:idx_ddel_active"`
 	ProviderType spenum.Provider `json:"provider_type" gorm:"uniqueIndex:ppp;index:idx_dprov_active,priority:2;index:idx_ddel_active,priority:2" `
 	ProviderID   string          `json:"provider_id" gorm:"uniqueIndex:ppp;index:idx_dprov_active,priority:1;index:idx_ddel_active,priority:2"`
-	DelegateID   string          `json:"delegate_id" gorm:"index:idx_ddel_active,priority:2;index:idx_del_id;index:idx_dp_total_staked,priority:1"` //todo think of changing priority for idx_ddel_active
+	DelegateID   string          `json:"delegate_id" gorm:"index:idx_ddel_active,priority:2;index:idx_dp_total_staked,priority:1"` //todo think of changing priority for idx_ddel_active
 
 	Balance              currency.Coin     `json:"balance"`
 	Reward               currency.Coin     `json:"reward"`       // unclaimed reward

--- a/code/go/0chain.net/smartcontract/dbs/event/event.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/event.go
@@ -11,11 +11,11 @@ import (
 
 type Event struct {
 	model.ImmutableModel
-	BlockNumber int64       `json:"block_number" gorm:"index:idx_event"`
-	TxHash      string      `json:"tx_hash" gorm:"index:idx_event"`
-	Type        EventType   `json:"type" gorm:"index:idx_event"`
-	Tag         EventTag    `json:"tag" gorm:"index:idx_event"`
-	Index       string      `json:"index" gorm:"index:idx_event"`
+	BlockNumber int64       `json:"block_number"`
+	TxHash      string      `json:"tx_hash"`
+	Type        EventType   `json:"type"`
+	Tag         EventTag    `json:"tag"`
+	Index       string      `json:"index"`
 	Data        interface{} `json:"data" gorm:"-"`
 }
 

--- a/code/go/0chain.net/smartcontract/dbs/event/miner.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner.go
@@ -27,7 +27,7 @@ type Miner struct {
 	Active        bool
 	Longitude     float64
 	Latitude      float64
-	CreationRound int64 `json:"creation_round" gorm:"index:idx_miner_creation_round"`
+	CreationRound int64 `json:"creation_round"`
 }
 
 // swagger:model MinerGeolocation

--- a/code/go/0chain.net/smartcontract/dbs/event/miner_snapshot.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/miner_snapshot.go
@@ -16,7 +16,7 @@ type MinerSnapshot struct {
 	TotalStake    currency.Coin `json:"total_stake"`
 	TotalRewards  currency.Coin `json:"total_rewards"`
 	ServiceCharge float64       `json:"service_charge"`
-	CreationRound int64         `json:"creation_round" gorm:"index"`
+	CreationRound int64         `json:"creation_round"`
 	IsKilled      bool          `json:"is_killed"`
 	IsShutdown    bool          `json:"is_shutdown"`
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/reward_delegate.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/reward_delegate.go
@@ -13,8 +13,8 @@ import (
 type RewardDelegate struct {
 	model.UpdatableModel
 	Amount       currency.Coin `json:"amount"`
-	BlockNumber  int64         `json:"block_number" gorm:"index:idx_rew_del_prov,priority:1"`
-	PoolID       string        `json:"pool_id" gorm:"index:idx_rew_del_prov,priority:2"`
+	BlockNumber  int64         `json:"block_number"`
+	PoolID       string        `json:"pool_id"`
 	ProviderID   string        `json:"provider_id"`
 	RewardType   spenum.Reward `json:"reward_type"`
 	AllocationID string        `json:"allocation_id"`

--- a/code/go/0chain.net/smartcontract/dbs/event/reward_provider.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/reward_provider.go
@@ -13,8 +13,8 @@ import (
 type RewardProvider struct {
 	model.UpdatableModel
 	Amount       currency.Coin `json:"amount"`
-	BlockNumber  int64         `json:"block_number" gorm:"index:idx_rew_block_prov,priority:1"`
-	ProviderId   string        `json:"provider_id" gorm:"index:idx_rew_block_prov,priority:2"`
+	BlockNumber  int64         `json:"block_number"`
+	ProviderId   string        `json:"provider_id"`
 	RewardType   spenum.Reward `json:"reward_type"`
 	AllocationID string        `json:"allocation_id"`
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/sharder.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/sharder.go
@@ -28,7 +28,7 @@ type Sharder struct {
 	Longitude float64
 	Latitude  float64
 
-	CreationRound int64 `json:"creation_round" gorm:"index:idx_sharder_creation_round"`
+	CreationRound int64 `json:"creation_round"`
 }
 
 func (s *Sharder) GetTotalStake() currency.Coin {

--- a/code/go/0chain.net/smartcontract/dbs/event/sharder_snapshot.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/sharder_snapshot.go
@@ -16,7 +16,7 @@ type SharderSnapshot struct {
 	TotalStake    currency.Coin `json:"total_stake"`
 	TotalRewards  currency.Coin `json:"total_rewards"`
 	ServiceCharge float64       `json:"service_charge"`
-	CreationRound int64         `json:"creation_round" gorm:"index"`
+	CreationRound int64         `json:"creation_round"`
 	IsKilled      bool          `json:"is_killed"`
 	IsShutdown    bool          `json:"is_shutdown"`
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/transaction.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/transaction.go
@@ -24,7 +24,7 @@ type Transaction struct {
 	TransactionData   string        `json:"transaction_data"`
 	Value             currency.Coin `json:"value"`
 	Signature         string        `json:"signature"`
-	CreationDate      int64         `json:"creation_date"  gorm:"index:idx_tcreation_date"`
+	CreationDate      int64         `json:"creation_date"`
 	Fee               currency.Coin `json:"fee"`
 	Nonce             int64         `json:"nonce"`
 	TransactionType   int           `json:"transaction_type"`
@@ -47,6 +47,7 @@ func mergeAddTransactionsEvents() *eventsMergerImpl[Transaction] {
 }
 
 // GetTransactionByHash finds the transaction record by hash
+// Used Index: idx_thash
 func (edb *EventDb) GetTransactionByHash(hash string) (Transaction, error) {
 	tr := Transaction{}
 	res := edb.Store.
@@ -58,6 +59,7 @@ func (edb *EventDb) GetTransactionByHash(hash string) (Transaction, error) {
 }
 
 // GetTransactionByClientId searches for transaction by clientID
+// Used Index: idx_tclient_id
 func (edb *EventDb) GetTransactionByClientId(clientID string, limit common.Pagination) ([]Transaction, error) {
 	var tr []Transaction
 	res := edb.Store.
@@ -79,6 +81,7 @@ func (edb *EventDb) GetTransactionByClientId(clientID string, limit common.Pagin
 }
 
 // GetTransactionByToClientId searches for transaction by toClientID
+// Used Index: idx_tto_client_id
 func (edb *EventDb) GetTransactionByToClientId(toClientID string, limit common.Pagination) ([]Transaction, error) {
 	var tr []Transaction
 	res := edb.Store.
@@ -99,6 +102,8 @@ func (edb *EventDb) GetTransactionByToClientId(toClientID string, limit common.P
 	return tr, res.Error
 }
 
+// GetTransactionByBlockHash finds the transaction record by block hash
+// Used Index: idx_tblock_hash
 func (edb *EventDb) GetTransactionByBlockHash(blockHash string, limit common.Pagination) ([]Transaction, error) {
 	var tr []Transaction
 	res := edb.Store.
@@ -152,6 +157,7 @@ func (edb *EventDb) GetTransactionByBlockNumbers(blockStart, blockEnd int64, lim
 	return tr, res.Error
 }
 
+// GetTransactionsForBlocks finds the transaction record between two block numbers
 func (edb *EventDb) GetTransactionsForBlocks(blockStart, blockEnd int64) ([]Transaction, error) {
 	tr := []Transaction{}
 	res := edb.Store.Get().

--- a/code/go/0chain.net/smartcontract/dbs/event/validator.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/validator.go
@@ -21,7 +21,7 @@ type Validator struct {
 	BaseUrl   string `json:"url"`
 	PublicKey string `json:"public_key"`
 
-	CreationRound int64 `json:"creation_round" gorm:"index:idx_validator_creation_round"`
+	CreationRound int64 `json:"creation_round"`
 }
 
 func (v *Validator) GetTotalStake() currency.Coin {

--- a/code/go/0chain.net/smartcontract/dbs/event/validator_snapshot.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/validator_snapshot.go
@@ -14,7 +14,7 @@ type ValidatorSnapshot struct {
 	TotalStake    currency.Coin `json:"total_stake"`
 	TotalRewards  currency.Coin `json:"total_rewards"`
 	ServiceCharge float64       `json:"service_charge"`
-	CreationRound int64         `json:"creation_round" gorm:"index"`
+	CreationRound int64         `json:"creation_round"`
 	IsKilled      bool          `json:"is_killed"`
 	IsShutdown    bool          `json:"is_shutdown"`
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
@@ -12,7 +12,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// swagger:model WriteMarker
+// swagger:model WriteMarker 
 type WriteMarker struct {
 	model.UpdatableModel
 	ClientID      string `json:"client_id"`

--- a/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/writemarker.go
@@ -17,7 +17,7 @@ type WriteMarker struct {
 	model.UpdatableModel
 	ClientID      string `json:"client_id"`
 	BlobberID     string `json:"blobber_id"`
-	AllocationID  string `json:"allocation_id" gorm:"index:idx_walloc_block,priority:1;index:idx_walloc_file,priority:2"` //used in alloc_write_marker_count, alloc_written_size
+	AllocationID  string `json:"allocation_id" gorm:"index:idx_walloc_block,priority:1"` //used in alloc_write_marker_count, alloc_written_size
 	TransactionID string `json:"transaction_id" gorm:"uniqueIndex"`
 
 	AllocationRoot         string `json:"allocation_root"`
@@ -26,7 +26,7 @@ type WriteMarker struct {
 	Size                   int64  `json:"size"`
 	Timestamp              int64  `json:"timestamp"`
 	Signature              string `json:"signature"`
-	BlockNumber            int64  `json:"block_number" gorm:"index:idx_wblocknum,priority:1;index:idx_walloc_block,priority:2"` //used in alloc_written_size
+	BlockNumber            int64  `json:"block_number" gorm:"index:idx_walloc_block,priority:2"` //used in alloc_written_size
 
 	MovedTokens currency.Coin `json:"-" gorm:"-"`
 

--- a/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
+++ b/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
@@ -9,6 +9,8 @@ DROP INDEX IF EXISTS idx_challenges_round_responded;
 DROP INDEX IF EXISTS idx_challenges_deleted_at;
 ALTER TABLE challenges DROP COLUMN deleted_at;
 DROP INDEX IF EXISTS idx_ba_rankmetric;
+DROP INDEX IF EXISTS idx_walloc_file;
+DROP INDEX IF EXISTS idx_wblocknum;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
+++ b/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
@@ -6,6 +6,8 @@ DROP INDEX IF EXISTS idx_event;
 DROP INDEX IF EXISTS idx_tcreation_date;
 DROP INDEX IF EXISTS idx_bcreation_date;
 DROP INDEX IF EXISTS idx_challenges_round_responded;
+DROP INDEX IF EXISTS idx_challenges_deleted_at;
+ALTER TABLE challenges DROP COLUMN deleted_at;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
+++ b/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
@@ -8,6 +8,7 @@ DROP INDEX IF EXISTS idx_bcreation_date;
 DROP INDEX IF EXISTS idx_challenges_round_responded;
 DROP INDEX IF EXISTS idx_challenges_deleted_at;
 ALTER TABLE challenges DROP COLUMN deleted_at;
+DROP INDEX IF EXISTS idx_ba_rankmetric;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
+++ b/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
@@ -11,6 +11,17 @@ ALTER TABLE challenges DROP COLUMN deleted_at;
 DROP INDEX IF EXISTS idx_ba_rankmetric;
 DROP INDEX IF EXISTS idx_walloc_file;
 DROP INDEX IF EXISTS idx_wblocknum;
+DROP INDEX IF EXISTS idx_astart_time;
+DROP INDEX IF EXISTS idx_authorizer_creation_round;
+DROP INDEX IF EXISTS idx_authorizer_snapshots_creation_round;
+DROP INDEX IF EXISTS idx_validator_creation_round;
+DROP INDEX IF EXISTS idx_validator_snapshots_creation_round;
+DROP INDEX IF EXISTS idx_miner_creation_round;
+DROP INDEX IF EXISTS idx_miner_snapshots_creation_round;
+DROP INDEX IF EXISTS idx_sharder_creation_round;
+DROP INDEX IF EXISTS idx_sharder_snapshots_creation_round;
+DROP INDEX IF EXISTS idx_blobber_creation_round;
+DROP INDEX IF EXISTS idx_blobber_snapshots_creation_round;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
+++ b/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
@@ -5,6 +5,7 @@ DROP INDEX IF EXISTS idx_rew_del_prov;
 DROP INDEX IF EXISTS idx_event;
 DROP INDEX IF EXISTS idx_tcreation_date;
 DROP INDEX IF EXISTS idx_bcreation_date;
+DROP INDEX IF EXISTS idx_challenges_round_responded;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
+++ b/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_rew_block_prov;
+DROP INDEX IF EXISTS idx_rew_del_prov;
+DROP INDEX IF EXISTS idx_event;
+DROP INDEX IF EXISTS idx_tcreation_date;
+DROP INDEX IF EXISTS idx_bcreation_date;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- +goose StatementEnd

--- a/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
+++ b/code/go/0chain.net/smartcontract/dbs/goose/migrations/1687700443_remove_unused_indexes.sql
@@ -22,6 +22,8 @@ DROP INDEX IF EXISTS idx_sharder_creation_round;
 DROP INDEX IF EXISTS idx_sharder_snapshots_creation_round;
 DROP INDEX IF EXISTS idx_blobber_creation_round;
 DROP INDEX IF EXISTS idx_blobber_snapshots_creation_round;
+DROP INDEX IF EXISTS idx_del_id;
+DROP INDEX IF EXISTS idx_blobbers_rank_metric;
 -- +goose StatementEnd
 
 -- +goose Down

--- a/code/go/0chain.net/smartcontract/storagesc/handler.go
+++ b/code/go/0chain.net/smartcontract/storagesc/handler.go
@@ -2351,7 +2351,7 @@ func (srh *StorageRestHandler) getBlobbers(w http.ResponseWriter, r *http.Reques
 
 // getBlobbers swagger:route GET /v1/screst/6dba10422e368813802877a85039d3985d96760ed844092319743fb3a76712d7/blobbers-by-rank blobbers-by-rank
 // Gets list of all blobbers ordered by rank
-//
+// TODO: See if we need to remove since no longer used
 // parameters:
 //
 //	+name: offset


### PR DESCRIPTION
## Fixes
- Remove unused indexes

## Changes
- Ran the following query against a n/w with 2M+ rounds
```sql
select relname, indexrelname, idx_scan, pg_size_pretty(pg_table_size(indexrelname::text)) as size from pg_stat_all_indexes where schemaname = 'public' and idx_scan < 10 order by pg_table_size(indexrelname::text) desc;
```
Based on the results of the query, found the following indexes not scanned and based on code analysis took the following decisions for the following reasons.

| relname          |                   indexrelname                    | idx_scan |    size | Decision | Reason |
|-----------------|-------------------------------------------|------------|--------|--------|--------|
| transactions             | idx_thash                                         |        5 | 699 MB| Keep | Unique key |
| reward_providers         | idx_rew_block_prov                                |        6 | 578 MB| Remove | Only used in test/debugging environment |
| reward_delegates         | idx_rew_del_prov                                  |        0 | 450 MB| Remove | Only used in test/debugging environment |
| transactions             | idx_tblock_hash                                   |        0 | 320 MB| Keep | Used |
| events_20                | events_20_block_number_tx_hash_type_tag_index_idx |        0 | 194 MB| Remove | Endpoint not used |
| events_5                 | events_5_block_number_tx_hash_type_tag_index_idx  |        0 | 193 MB| Remove | Endpoint not used |
| events_6                 | events_6_block_number_tx_hash_type_tag_index_idx  |        0 | 193 MB| Remove | Endpoint not used |
| events_19                | events_19_block_number_tx_hash_type_tag_index_idx |        0 | 193 MB| Remove | Endpoint not used |
| events_18                | events_18_block_number_tx_hash_type_tag_index_idx |        0 | 192 MB| Remove | Endpoint not used |
| events_4                 | events_4_block_number_tx_hash_type_tag_index_idx  |        0 | 192 MB| Remove | Endpoint not used |
| events_16                | events_16_block_number_tx_hash_type_tag_index_idx |        0 | 192 MB| Remove | Endpoint not used |
| events_17                | events_17_block_number_tx_hash_type_tag_index_idx |        0 | 192 MB| Remove | Endpoint not used |
| events_3                 | events_3_block_number_tx_hash_type_tag_index_idx  |        0 | 191 MB| Remove | Endpoint not used |
| events_9                 | events_9_block_number_tx_hash_type_tag_index_idx  |        0 | 191 MB| Remove | Endpoint not used |
| events_15                | events_15_block_number_tx_hash_type_tag_index_idx |        0 | 191 MB| Remove | Endpoint not used |
| events_2                 | events_2_block_number_tx_hash_type_tag_index_idx  |        0 | 191 MB| Remove | Endpoint not used |
| events_14                | events_14_block_number_tx_hash_type_tag_index_idx |        0 | 191 MB| Remove | Endpoint not used |
| events_8                 | events_8_block_number_tx_hash_type_tag_index_idx  |        0 | 191 MB| Remove | Endpoint not used |
| events_11                | events_11_block_number_tx_hash_type_tag_index_idx |        0 | 190 MB| Remove | Endpoint not used |
| events_12                | events_12_block_number_tx_hash_type_tag_index_idx |        0 | 190 MB| Remove | Endpoint not used |
| events_10                | events_10_block_number_tx_hash_type_tag_index_idx |        0 | 190 MB| Remove | Endpoint not used |
| events_7                 | events_7_block_number_tx_hash_type_tag_index_idx  |        0 | 189 MB| Remove | Endpoint not used |
| events_13                | events_13_block_number_tx_hash_type_tag_index_idx |        0 | 189 MB| Remove | Endpoint not used |
| reward_providers         | reward_providers_pkey                             |        0 | 147 MB| Keep | PK |
| reward_delegates         | reward_delegates_pkey                             |        0 | 146 MB| Keep | PK |
| transactions             | transactions_pkey                                 |        0 | 126 MB| Keep | PK |
| challenges               | challenges_pkey                                   |        0 | 72 MB| Keep | PK |
| events_21                | events_21_block_number_tx_hash_type_tag_index_idx |        0 | 62 MB| Remove | Endpoint not used |
| blocks                   | blocks_pkey                                       |        0 | 51 MB| Keep | PK |
| blocks                   | idx_bround                                        |        0 | 50 MB| Keep | Useful. Used [here](https://github.com/0chain/gosdk/blob/6d98b815ed3eec18e53e9c78be3b0246ce96c939/core/transaction/utils.go#L49) |
| transactions             | idx_tcreation_date                                |        0 | 50 MB| Remove | Not used |
| events_5                 | events_5_pkey                                     |        0 | 42 MB| Keep | PK |
| events_6                 | events_6_pkey                                     |        0 | 42 MB| Keep | PK |
| events_4                 | events_4_pkey                                     |        0 | 41 MB| Keep | PK |
| events_3                 | events_3_pkey                                     |        0 | 41 MB| Keep | PK |
| events_20                | events_20_pkey                                    |        0 | 41 MB| Keep | PK |
| events_19                | events_19_pkey                                    |        0 | 41 MB| Keep | PK |
| events_9                 | events_9_pkey                                     |        0 | 41 MB| Keep | PK |
| events_2                 | events_2_pkey                                     |        0 | 41 MB| Keep | PK |
| events_8                 | events_8_pkey                                     |        0 | 41 MB| Keep | PK |
| events_11                | events_11_pkey                                    |        0 | 41 MB| Keep | PK |
| events_18                | events_18_pkey                                    |        0 | 41 MB| Keep | PK |
| events_17                | events_17_pkey                                    |        0 | 41 MB| Keep | PK |
| events_15                | events_15_pkey                                    |        0 | 41 MB| Keep | PK |
| events_10                | events_10_pkey                                    |        0 | 41 MB| Keep | PK |
| events_14                | events_14_pkey                                    |        0 | 41 MB| Keep | PK |
| events_7                 | events_7_pkey                                     |        0 | 41 MB| Keep | PK |
| events_16                | events_16_pkey                                    |        0 | 41 MB| Keep | PK |
| events_12                | events_12_pkey                                    |        0 | 41 MB| Keep | PK |
| events_13                | events_13_pkey                                    |        0 | 40 MB| Keep | PK |
| blocks                   | idx_bcreation_date                                |        0 | 26 MB| Remove | Unused. If searching by date is really needed, can turn this date into rounds and search by rounds |
| user_aggregates_20       | user_aggregates_20_pkey                           |        0 | 26 MB| Keep | PK |
| user_aggregates_19       | user_aggregates_19_pkey                           |        0 | 26 MB| Keep | PK |
| user_aggregates_2        | user_aggregates_2_pkey                            |        0 | 26 MB| Keep | PK |
| user_aggregates_5        | user_aggregates_5_pkey                            |        0 | 26 MB| Keep | PK |
| user_aggregates_6        | user_aggregates_6_pkey                            |        0 | 26 MB| Keep | PK |
| user_aggregates_4        | user_aggregates_4_pkey                            |        0 | 26 MB| Keep | PK |
| user_aggregates_8        | user_aggregates_8_pkey                            |        0 | 26 MB| Keep | PK |
| user_aggregates_9        | user_aggregates_9_pkey                            |        0 | 25 MB| Keep | PK |
| user_aggregates_7        | user_aggregates_7_pkey                            |        0 | 25 MB| Keep | PK |
| user_aggregates_18       | user_aggregates_18_pkey                           |        0 | 25 MB| Keep | PK |
| user_aggregates_10       | user_aggregates_10_pkey                           |        0 | 25 MB| Keep | PK |
| user_aggregates_11       | user_aggregates_11_pkey                           |        0 | 25 MB| Keep | PK |
| user_aggregates_3        | user_aggregates_3_pkey                            |        0 | 25 MB| Keep | PK |
| user_aggregates_15       | user_aggregates_15_pkey                           |        0 | 25 MB| Keep | PK |
| user_aggregates_14       | user_aggregates_14_pkey                           |        0 | 25 MB| Keep | PK |
| user_aggregates_16       | user_aggregates_16_pkey                           |        0 | 25 MB| Keep | PK |
| user_aggregates_12       | user_aggregates_12_pkey                           |        0 | 25 MB| Keep | PK |
| user_aggregates_17       | user_aggregates_17_pkey                           |        0 | 25 MB| Keep | PK |
| user_aggregates_13       | user_aggregates_13_pkey                           |        0 | 25 MB| Keep | PK |
| challenges               | idx_challenges_round_responded                    |        0 | 20 MB| Remove | Endpoint not used |
| challenges               | idx_challenges_deleted_at                         |        0 | 20 MB| Remove | Challenges are not removed |
| validator_aggregates_12  | validator_aggregates_12_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_17  | validator_aggregates_17_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_11  | validator_aggregates_11_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_15  | validator_aggregates_15_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_20  | validator_aggregates_20_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_19  | validator_aggregates_19_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_18  | validator_aggregates_18_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_16  | validator_aggregates_16_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_13  | validator_aggregates_13_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_14  | validator_aggregates_14_validator_id_round_idx    |        0 | 19 MB| Keep | Unique Key |
| validator_aggregates_10  | validator_aggregates_10_validator_id_round_idx    |        0 | 16 MB| Keep | Unique Key |
| validator_aggregates_9   | validator_aggregates_9_validator_id_round_idx     |        0 | 14 MB| Keep | Unique Key |
| validator_aggregates_6   | validator_aggregates_6_validator_id_round_idx     |        0 | 14 MB| Keep | Unique Key |
| validator_aggregates_3   | validator_aggregates_3_validator_id_round_idx     |        0 | 14 MB| Keep | Unique Key |
| validator_aggregates_7   | validator_aggregates_7_validator_id_round_idx     |        0 | 14 MB| Keep | Unique Key |
| validator_aggregates_2   | validator_aggregates_2_validator_id_round_idx     |        0 | 14 MB| Keep | Unique Key |
| validator_aggregates_4   | validator_aggregates_4_validator_id_round_idx     |        0 | 14 MB| Keep | Unique Key |
| validator_aggregates_5   | validator_aggregates_5_validator_id_round_idx     |        0 | 14 MB| Keep | Unique Key |
| validator_aggregates_8   | validator_aggregates_8_validator_id_round_idx     |        0 | 14 MB| Keep | Unique Key |
| blobber_aggregates_16    | blobber_aggregates_16_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| blobber_aggregates_12    | blobber_aggregates_12_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| blobber_aggregates_15    | blobber_aggregates_15_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| blobber_aggregates_17    | blobber_aggregates_17_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| blobber_aggregates_19    | blobber_aggregates_19_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| blobber_aggregates_14    | blobber_aggregates_14_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| blobber_aggregates_18    | blobber_aggregates_18_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| blobber_aggregates_11    | blobber_aggregates_11_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| blobber_aggregates_13    | blobber_aggregates_13_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| blobber_aggregates_20    | blobber_aggregates_20_round_blobber_id_idx        |        0 | 13 MB| Keep | Unique Key |
| events_21                | events_21_pkey                                    |        0 | 13 MB| Keep | PK |
| blobber_aggregates_10    | blobber_aggregates_10_round_blobber_id_idx        |        0 | 11 MB| Keep | Unique Key |
| blobber_aggregates_9     | blobber_aggregates_9_round_blobber_id_idx         |        0 | 10232 kB| Keep | Unique Key |
| blobber_aggregates_8     | blobber_aggregates_8_round_blobber_id_idx         |        0 | 10216 kB| Keep | Unique Key |
| blobber_aggregates_7     | blobber_aggregates_7_round_blobber_id_idx         |        0 | 10216 kB| Keep | Unique Key |
| blobber_aggregates_6     | blobber_aggregates_6_round_blobber_id_idx         |        0 | 9408 kB| Keep | Unique Key |
| user_aggregates_21       | user_aggregates_21_pkey                           |        0 | 8392 kB| Keep | PK |
| blobber_aggregates_4     | blobber_aggregates_4_round_blobber_id_idx         |        0 | 8168 kB| Keep | Unique Key |
| blobber_aggregates_2     | blobber_aggregates_2_round_blobber_id_idx         |        0 | 8168 kB| Keep | Unique Key |
| blobber_aggregates_5     | blobber_aggregates_5_round_blobber_id_idx         |        4 | 8168 kB| Keep | Unique Key |
| blobber_aggregates_3     | blobber_aggregates_3_round_blobber_id_idx         |        0 | 8168 kB| Keep | Unique Key |
| validator_aggregates_21  | validator_aggregates_21_validator_id_round_idx    |        0 | 6040 kB| Keep | Unique Key |
| blobber_aggregates_16    | blobber_aggregates_16_rank_metric_idx             |        0 | 5656 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_13    | blobber_aggregates_13_rank_metric_idx             |        0 | 5624 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_14    | blobber_aggregates_14_rank_metric_idx             |        0 | 5616 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_12    | blobber_aggregates_12_rank_metric_idx             |        0 | 5608 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_15    | blobber_aggregates_15_rank_metric_idx             |        0 | 5544 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_11    | blobber_aggregates_11_rank_metric_idx             |        0 | 5472 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_17    | blobber_aggregates_17_rank_metric_idx             |        0 | 5360 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_19    | blobber_aggregates_19_rank_metric_idx             |        0 | 5264 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_20    | blobber_aggregates_20_rank_metric_idx             |        0 | 5168 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_18    | blobber_aggregates_18_rank_metric_idx             |        0 | 5104 kB| Remove | Useless - Only useful in 0box |
| authorizer_aggregates_19 | authorizer_aggregates_19_authorizer_id_round_idx  |        0 | 4752 kB| Keep     | Unique Key                                                   |
| miner_aggregates_20      | miner_aggregates_20_miner_id_round_idx            |        0 | 4752 kB| Keep     | Unique Key                                                   |
| miner_aggregates_10      | miner_aggregates_10_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_20    | sharder_aggregates_20_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_10    | sharder_aggregates_10_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_10 | authorizer_aggregates_10_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_20 | authorizer_aggregates_20_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_6       | miner_aggregates_6_miner_id_round_idx             |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_6     | sharder_aggregates_6_sharder_id_round_idx         |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_6  | authorizer_aggregates_6_authorizer_id_round_idx   |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_5       | miner_aggregates_5_miner_id_round_idx             |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_5     | sharder_aggregates_5_sharder_id_round_idx         |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_5  | authorizer_aggregates_5_authorizer_id_round_idx   |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_8       | miner_aggregates_8_miner_id_round_idx             |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_8     | sharder_aggregates_8_sharder_id_round_idx         |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_8  | authorizer_aggregates_8_authorizer_id_round_idx   |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_3       | miner_aggregates_3_miner_id_round_idx             |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_3     | sharder_aggregates_3_sharder_id_round_idx         |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_3  | authorizer_aggregates_3_authorizer_id_round_idx   |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_14      | miner_aggregates_14_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_14    | sharder_aggregates_14_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_14 | authorizer_aggregates_14_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_9       | miner_aggregates_9_miner_id_round_idx             |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_9     | sharder_aggregates_9_sharder_id_round_idx         |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_9  | authorizer_aggregates_9_authorizer_id_round_idx   |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_16      | miner_aggregates_16_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_16    | sharder_aggregates_16_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_16 | authorizer_aggregates_16_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_12      | miner_aggregates_12_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_12    | sharder_aggregates_12_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_12 | authorizer_aggregates_12_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_4       | miner_aggregates_4_miner_id_round_idx             |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_4     | sharder_aggregates_4_sharder_id_round_idx         |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_4  | authorizer_aggregates_4_authorizer_id_round_idx   |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_2       | miner_aggregates_2_miner_id_round_idx             |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_2     | sharder_aggregates_2_sharder_id_round_idx         |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_2  | authorizer_aggregates_2_authorizer_id_round_idx   |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_13      | miner_aggregates_13_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_13    | sharder_aggregates_13_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_13 | authorizer_aggregates_13_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_7       | miner_aggregates_7_miner_id_round_idx             |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_7     | sharder_aggregates_7_sharder_id_round_idx         |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_7  | authorizer_aggregates_7_authorizer_id_round_idx   |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_17      | miner_aggregates_17_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_17    | sharder_aggregates_17_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_17 | authorizer_aggregates_17_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_11      | miner_aggregates_11_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_11    | sharder_aggregates_11_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_11 | authorizer_aggregates_11_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_15      | miner_aggregates_15_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_15    | sharder_aggregates_15_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_15 | authorizer_aggregates_15_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_18      | miner_aggregates_18_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_18    | sharder_aggregates_18_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| miner_aggregates_19      | miner_aggregates_19_miner_id_round_idx            |        0 | 4752 kB| Keep | Unique Key |
| sharder_aggregates_19    | sharder_aggregates_19_sharder_id_round_idx        |        0 | 4752 kB| Keep | Unique Key |
| authorizer_aggregates_18 | authorizer_aggregates_18_authorizer_id_round_idx  |        0 | 4752 kB| Keep | Unique Key |
| blobber_aggregates_10    | blobber_aggregates_10_rank_metric_idx             |        0 | 4520 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_21    | blobber_aggregates_21_round_blobber_id_idx        |        0 | 4184 kB| Keep     | Unique Key                                                   |
| blobber_aggregates_9     | blobber_aggregates_9_rank_metric_idx              |        0 | 4144 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_8     | blobber_aggregates_8_rank_metric_idx              |        0 | 4120 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_7     | blobber_aggregates_7_rank_metric_idx              |        0 | 4120 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_11    | blobber_aggregates_11_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_17    | blobber_aggregates_17_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_18    | blobber_aggregates_18_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_13    | blobber_aggregates_13_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_19    | blobber_aggregates_19_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_14    | blobber_aggregates_14_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_20    | blobber_aggregates_20_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_16    | blobber_aggregates_16_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_12    | blobber_aggregates_12_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_15    | blobber_aggregates_15_pkey                        |        0 | 4016 kB| Keep | PK |
| blobber_aggregates_6     | blobber_aggregates_6_rank_metric_idx              |        0 | 3864 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_10    | blobber_aggregates_10_pkey                        |        0 | 3480 kB| Keep | PK |
| blobber_aggregates_5     | blobber_aggregates_5_rank_metric_idx              |        0 | 3432 kB| Remove | Useless - Only useful in 0box |
| validator_aggregates_18  | validator_aggregates_18_pkey                      |        0 | 3408 kB| Keep | PK |
| validator_aggregates_11  | validator_aggregates_11_pkey                      |        0 | 3408 kB| Keep | PK |
| validator_aggregates_17  | validator_aggregates_17_pkey                      |        0 | 3408 kB| Keep | PK |
| validator_aggregates_15  | validator_aggregates_15_pkey                      |        0 | 3408 kB| Keep | PK |
| validator_aggregates_16  | validator_aggregates_16_pkey                      |        0 | 3408 kB| Keep | PK |
| validator_aggregates_19  | validator_aggregates_19_pkey                      |        0 | 3408 kB| Keep | PK |
| validator_aggregates_20  | validator_aggregates_20_pkey                      |        0 | 3408 kB| Keep | PK |
| validator_aggregates_12  | validator_aggregates_12_pkey                      |        0 | 3408 kB| Keep | PK |
| validator_aggregates_14  | validator_aggregates_14_pkey                      |        0 | 3408 kB| Keep | PK |
| validator_aggregates_13  | validator_aggregates_13_pkey                      |        0 | 3408 kB| Keep | PK |
| blobber_aggregates_4     | blobber_aggregates_4_rank_metric_idx              |        0 | 3360 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_3     | blobber_aggregates_3_rank_metric_idx              |        0 | 3240 kB| Remove | Useless - Only useful in 0box |
| blobber_aggregates_7     | blobber_aggregates_7_pkey                         |        0 | 3088 kB| Keep | PK |
| blobber_aggregates_9     | blobber_aggregates_9_pkey                         |        0 | 3088 kB| Keep | PK |
| blobber_aggregates_8     | blobber_aggregates_8_pkey                         |        0 | 3088 kB| Keep | PK |
| blobber_aggregates_2     | blobber_aggregates_2_rank_metric_idx              |        0 | 2960 kB| Remove | Useless - Only useful in 0box |
| validator_aggregates_10  | validator_aggregates_10_pkey                      |        0 | 2848 kB| Keep | PK |
| blobber_aggregates_6     | blobber_aggregates_6_pkey                         |        0 | 2848 kB| Keep | PK |
| blobber_aggregates_2     | blobber_aggregates_2_pkey                         |        0 | 2472 kB| Keep | PK |
| validator_aggregates_4   | validator_aggregates_4_pkey                       |        0 | 2472 kB| Keep | PK |
| validator_aggregates_5   | validator_aggregates_5_pkey                       |        0 | 2472 kB| Keep | PK |
| blobber_aggregates_3     | blobber_aggregates_3_pkey                         |        0 | 2472 kB| Keep | PK |
| validator_aggregates_6   | validator_aggregates_6_pkey                       |        0 | 2472 kB| Keep | PK |
| validator_aggregates_9   | validator_aggregates_9_pkey                       |        0 | 2472 kB| Keep | PK |
| validator_aggregates_8   | validator_aggregates_8_pkey                       |        0 | 2472 kB| Keep | PK |
| validator_aggregates_2   | validator_aggregates_2_pkey                       |        0 | 2472 kB| Keep | PK |
| validator_aggregates_3   | validator_aggregates_3_pkey                       |        0 | 2472 kB| Keep | PK |
| blobber_aggregates_5     | blobber_aggregates_5_pkey                         |        0 | 2472 kB| Keep | PK |
| blobber_aggregates_4     | blobber_aggregates_4_pkey                         |        0 | 2472 kB| Keep | PK |
| validator_aggregates_7   | validator_aggregates_7_pkey                       |        0 | 2472 kB| Keep | PK |
| blobber_aggregates_21    | blobber_aggregates_21_rank_metric_idx             |        0 | 1672 kB| Remove | Useless - Only useful in 0box |
| authorizer_aggregates_21 | authorizer_aggregates_21_authorizer_id_round_idx  |        0 | 1480 kB| Keep | Unique Key |
| miner_aggregates_21      | miner_aggregates_21_miner_id_round_idx            |        0 | 1480 kB| Remove | Useless - Only useful in 0box |
| sharder_aggregates_21    | sharder_aggregates_21_sharder_id_round_idx        |        0 | 1480 kB| Keep | Unique Key |
| blobber_aggregates_21    | blobber_aggregates_21_pkey                        |        0 | 1256 kB| Keep | PK |
| validator_aggregates_21  | validator_aggregates_21_pkey                      |        0 | 1072 kB| Keep | PK |
| sharder_aggregates_16    | sharder_aggregates_16_pkey                        |        0 | 936 kB| Keep | PK |
| miner_aggregates_5       | miner_aggregates_5_pkey                           |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_16 | authorizer_aggregates_16_pkey                     |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_15 | authorizer_aggregates_15_pkey                     |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_6  | authorizer_aggregates_6_pkey                      |        0 | 936 kB| Keep | PK |
| sharder_aggregates_6     | sharder_aggregates_6_pkey                         |        0 | 936 kB| Keep | PK |
| miner_aggregates_12      | miner_aggregates_12_pkey                          |        0 | 936 kB| Keep | PK |
| sharder_aggregates_12    | sharder_aggregates_12_pkey                        |        0 | 936 kB| Keep | PK |
| miner_aggregates_6       | miner_aggregates_6_pkey                           |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_12 | authorizer_aggregates_12_pkey                     |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_20 | authorizer_aggregates_20_pkey                     |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_10 | authorizer_aggregates_10_pkey                     |        0 | 936 kB| Keep | PK |
| miner_aggregates_4       | miner_aggregates_4_pkey                           |        0 | 936 kB| Keep | PK |
| sharder_aggregates_4     | sharder_aggregates_4_pkey                         |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_4  | authorizer_aggregates_4_pkey                      |        0 | 936 kB| Keep | PK |
| sharder_aggregates_10    | sharder_aggregates_10_pkey                        |        0 | 936 kB| Keep | PK |
| sharder_aggregates_20    | sharder_aggregates_20_pkey                        |        0 | 936 kB| Keep | PK |
| miner_aggregates_2       | miner_aggregates_2_pkey                           |        0 | 936 kB| Keep | PK |
| sharder_aggregates_2     | sharder_aggregates_2_pkey                         |        0 | 936 kB| Keep | PK |
| miner_aggregates_10      | miner_aggregates_10_pkey                          |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_2  | authorizer_aggregates_2_pkey                      |        0 | 936 kB| Keep | PK |
| miner_aggregates_20      | miner_aggregates_20_pkey                          |        0 | 936 kB| Keep | PK |
| miner_aggregates_13      | miner_aggregates_13_pkey                          |        0 | 936 kB| Keep | PK |
| sharder_aggregates_13    | sharder_aggregates_13_pkey                        |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_13 | authorizer_aggregates_13_pkey                     |        0 | 936 kB| Keep | PK |
| miner_aggregates_7       | miner_aggregates_7_pkey                           |        0 | 936 kB| Keep | PK |
| miner_aggregates_18      | miner_aggregates_18_pkey                          |        0 | 936 kB| Keep | PK |
| sharder_aggregates_7     | sharder_aggregates_7_pkey                         |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_7  | authorizer_aggregates_7_pkey                      |        0 | 936 kB| Keep | PK |
| sharder_aggregates_18    | sharder_aggregates_18_pkey                        |        0 | 936 kB| Keep | PK |
| miner_aggregates_17      | miner_aggregates_17_pkey                          |        0 | 936 kB| Keep | PK |
| sharder_aggregates_17    | sharder_aggregates_17_pkey                        |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_17 | authorizer_aggregates_17_pkey                     |        0 | 936 kB| Keep | PK |
| miner_aggregates_11      | miner_aggregates_11_pkey                          |        0 | 936 kB| Keep | PK |
| miner_aggregates_19      | miner_aggregates_19_pkey                          |        0 | 936 kB| Keep | PK |
| sharder_aggregates_11    | sharder_aggregates_11_pkey                        |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_11 | authorizer_aggregates_11_pkey                     |        0 | 936 kB| Keep | PK |
| sharder_aggregates_19    | sharder_aggregates_19_pkey                        |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_3  | authorizer_aggregates_3_pkey                      |        0 | 936 kB| Keep | PK |
| sharder_aggregates_3     | sharder_aggregates_3_pkey                         |        0 | 936 kB| Keep | PK |
| miner_aggregates_3       | miner_aggregates_3_pkey                           |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_8  | authorizer_aggregates_8_pkey                      |        0 | 936 kB| Keep | PK |
| miner_aggregates_14      | miner_aggregates_14_pkey                          |        0 | 936 kB| Keep | PK |
| sharder_aggregates_14    | sharder_aggregates_14_pkey                        |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_14 | authorizer_aggregates_14_pkey                     |        0 | 936 kB| Keep | PK |
| miner_aggregates_15      | miner_aggregates_15_pkey                          |        0 | 936 kB| Keep | PK |
| sharder_aggregates_8     | sharder_aggregates_8_pkey                         |        0 | 936 kB| Keep | PK |
| miner_aggregates_9       | miner_aggregates_9_pkey                           |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_19 | authorizer_aggregates_19_pkey                     |        0 | 936 kB| Keep | PK |
| sharder_aggregates_9     | sharder_aggregates_9_pkey                         |        0 | 936 kB| Keep | PK |
| sharder_aggregates_15    | sharder_aggregates_15_pkey                        |        0 | 936 kB| Keep | PK |
| miner_aggregates_8       | miner_aggregates_8_pkey                           |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_9  | authorizer_aggregates_9_pkey                      |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_18 | authorizer_aggregates_18_pkey                     |        0 | 936 kB| Keep | PK |
| authorizer_aggregates_5  | authorizer_aggregates_5_pkey                      |        0 | 936 kB| Keep | PK |
| sharder_aggregates_5     | sharder_aggregates_5_pkey                         |        0 | 936 kB| Keep | PK |
| miner_aggregates_16      | miner_aggregates_16_pkey                          |        0 | 936 kB| Keep | PK |
| read_markers             | idx_ralloc_block                                  |        0 | 512 kB| Keep | Used when filtering rms by allocation |
| write_markers            | idx_write_markers_transaction_id                  |        0 | 368 kB| Keep | Unique key |
| sharder_aggregates_21    | sharder_aggregates_21_pkey                        |        0 | 304 kB| Keep | PK |
| miner_aggregates_21      | miner_aggregates_21_pkey                          |        0 | 304 kB| Keep | PK |
| authorizer_aggregates_21 | authorizer_aggregates_21_pkey                     |        0 | 304 kB| Keep | PK |
| write_markers            | idx_walloc_block                                  |        0 | 240 kB| Keep | Used when filtering was by allocation |
| write_markers            | write_markers_pkey                                |        0 | 88 kB| Keep | PK |
| read_markers             | read_markers_pkey                                 |        0 | 88 kB| Keep | PK |
| write_markers            | idx_walloc_file                                   |        0 | 72 kB| Remove | Unused |
| write_markers            | idx_wblocknum                                     |        0 | 72 kB| Remove | Unused |
| read_markers             | idx_rauth_alloc                                   |        0 | 56 kB| Keep | Used when auth ticket is used to search for readmarker |
| challenge_pools          | idx_challenge_pools_allocation_id                 |        0 | 48 kB| Keep | Unique Key |
| users                    | users_pkey                                        |        0 | 32 kB| Keep | PK |
| authorizers              | idx_authorizer_creation_round                     |        0 | 16 kB| Remove | Not used |
| provider_rewards         | provider_rewards_pkey                             |        8 | 16 kB| Keep | PK |
| allocations              | allocations_pkey                                  |        0 | 16 kB| Keep | PK |
| allocations              | idx_allocations_deleted_at                        |        0 | 16 kB| Keep | Allocations can be deleted |
| sharder_snapshots        | idx_sharder_snapshots_sharder_id                  |        0 | 16 kB| Keep | Unique Key |
| blobber_snapshots        | idx_blobber_snapshots_blobber_id                  |        0 | 16 kB| Keep | Unique Key |
| allocation_blobber_terms | idx_allocation_blobber_terms_deleted_at           |        0 | 16 kB| Keep | AllocationBlobberTerms can be deleted |
| allocations              | idx_astart_time                                   |        0 | 16 kB| Remove | Useless |
| validators               | idx_validator_creation_round                      |        0 | 16 kB| Remove | Useless |
| validator_snapshots      | idx_validator_snapshots_validator_id              |        0 | 16 kB| Keep | Unique Key |
| validator_snapshots      | idx_validator_snapshots_creation_round            |        0 | 16 kB| Remove | Useless |
| transaction_errors       | transaction_errors_pkey                           |        0 | 16 kB| Keep | PK |
| miners                   | idx_miner_creation_round                          |        0 | 16 kB| Remove | Useless |
| sharder_snapshots        | idx_sharder_snapshots_creation_round              |        0 | 16 kB| Remove | Useless |
| blobbers                 | idx_blobber_creation_round                        |        0 | 16 kB| Remove | Useless |
| delegate_pools           | delegate_pools_pkey                               |        0 | 16 kB| Keep | PK |
| delegate_pools           | idx_del_id                                        |        0 | 16 kB| Remove | idx_dp_total_staked is used instead when getting the pools of a delegate |
| reward_mints             | reward_mints_pkey                                 |        0 | 16 kB| Keep | PK |
| blobbers                 | idx_blobbers_base_url                             |        2 | 16 kB| Keep | Used by an active endpoint |
| miner_snapshots          | idx_miner_snapshots_creation_round                |        0 | 16 kB| Remove | Useless |
| blobbers                 | idx_blobbers_rank_metric                          |        0 | 16 kB| Remove | It's endpoint is no longer used. This info is now brought from 0box. |
| authorizer_snapshots     | idx_authorizer_snapshots_authorizer_id            |        0 | 16 kB| Keep | Unique Key |
| miner_snapshots          | idx_miner_snapshots_miner_id                      |        0 | 16 kB| Keep | Unique Key |
| goose_db_version         | goose_db_version_pkey                             |        0 | 16 kB| Keep | PK |
| authorizer_snapshots     | idx_authorizer_snapshots_creation_round           |        0 | 16 kB| Remove | Useless |
| blobber_snapshots        | idx_blobber_snapshots_creation_round              |        0 | 16 kB| Remove | Useless |
| delegate_pools           | idx_dprov_active                                  |        0 | 16 kB| Keep | Useful when you need to find the active delegate pools of a provider |
| sharders                 | idx_sharder_creation_round                        |        0 | 16 kB| Remove | Useless |
| authorizers              | authorizers_pkey                                  |        0 | 16 kB| Keep | PK |
| errors                   | errors_pkey                                       |        0 | 8192 `bytes`| Keep | PK |

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
