### PR TITLE
Remove/expiry flag

### DIFF
--- a/docker.local/bin/conductor/delete_and_verify.sh
+++ b/docker.local/bin/conductor/delete_and_verify.sh
@@ -34,7 +34,7 @@ BLOBBER4=2a4d5a5c6c0976873f426128d2ff23a060ee715bccf0fd3ca5e987d57f25b78e
 # create allocation
 ./zboxcli/zbox --wallet testing.json newallocation \
     --read_price 0.001-10 --write_price 0.01-10 --size 104857600 --lock 2 \
-    --data 2 --parity 2 --expire 721h
+    --data 2 --parity 2
 
 # add to read pools
 ./zboxcli/zbox --wallet testing.json rp-lock \

--- a/docker.local/bin/conductor/download_and_verify.sh
+++ b/docker.local/bin/conductor/download_and_verify.sh
@@ -34,7 +34,7 @@ BLOBBER4=2a4d5a5c6c0976873f426128d2ff23a060ee715bccf0fd3ca5e987d57f25b78e
 # create allocation
 ./zboxcli/zbox --wallet testing.json newallocation \
     --read_price 0.001-10 --write_price 0.01-10 --size 104857600 --lock 2 \
-    --data 2 --parity 2 --expire 721h
+    --data 2 --parity 2
 
 # add to read pools
 ./zboxcli/zbox --wallet testing.json rp-lock \

--- a/docker.local/bin/conductor/init_allocation.sh
+++ b/docker.local/bin/conductor/init_allocation.sh
@@ -33,7 +33,7 @@ BLOBBER3=2f051ca6447d8712a020213672bece683dbd0d23a81fdf93ff273043a0764d18
 # create allocation
 ./zboxcli/zbox --wallet testing.json newallocation \
     --read_price 0.001-10 --write_price 0.01-10 --size 104857600 --lock 2 \
-    --data 1 --parity 2 --expire 721h
+    --data 1 --parity 2
 
 # add to read pools
 ./zboxcli/zbox --wallet testing.json rp-lock --tokens 4.0

--- a/docker.local/bin/conductor/init_pour_allocation.sh
+++ b/docker.local/bin/conductor/init_pour_allocation.sh
@@ -37,7 +37,7 @@ BLOBBER2=7a90e6790bcd3d78422d7a230390edc102870fe58c15472073922024985b1c7d
 # create allocation
 ./zboxcli/zbox --wallet testing.json newallocation \
     --read_price 0.001-10 --write_price 0.01-10 --size 104857600 \
-    --lock 0.01953125 --data 1 --parity 1 --expire 721h
+    --lock 0.01953125 --data 1 --parity 1
 
 # create random file
 head -c 52428800 < /dev/urandom > random.bin

--- a/docker.local/bin/conductor/list_and_verify.sh
+++ b/docker.local/bin/conductor/list_and_verify.sh
@@ -34,7 +34,7 @@ BLOBBER4=2a4d5a5c6c0976873f426128d2ff23a060ee715bccf0fd3ca5e987d57f25b78e
 # create allocation
 ./zboxcli/zbox --wallet testing.json newallocation \
     --read_price 0.001-10 --write_price 0.01-10 --size 104857600 --lock 2 \
-    --data 2 --parity 2 --expire 721h
+    --data 2 --parity 2
 
 # add to read pools
 ./zboxcli/zbox --wallet testing.json rp-lock \

--- a/docker.local/bin/conductor/repair_allocation.sh
+++ b/docker.local/bin/conductor/repair_allocation.sh
@@ -31,7 +31,7 @@ BLOBBER4=2a4d5a5c6c0976873f426128d2ff23a060ee715bccf0fd3ca5e987d57f25b78e
 # create allocation
 ./zboxcli/zbox --wallet testing.json newallocation \
     --read_price 0.001-10 --write_price 0.01-10 --size 104857600 \
-    --lock 2 --data 2 --parity 2 --expire 721h
+    --lock 2 --data 2 --parity 2
 
 # for test logs
 ./zboxcli/zbox --wallet testing.json ls-blobbers

--- a/docker.local/bin/conductor/upload_and_verify.sh
+++ b/docker.local/bin/conductor/upload_and_verify.sh
@@ -34,7 +34,7 @@ BLOBBER4=2a4d5a5c6c0976873f426128d2ff23a060ee715bccf0fd3ca5e987d57f25b78e
 # create allocation
 ./zboxcli/zbox --wallet testing.json newallocation \
     --read_price 0.001-10 --write_price 0.01-10 --size 104857600 --lock 2 \
-    --data 2 --parity 2 --expire 721h
+    --data 2 --parity 2
 
 # add to read pools
 ./zboxcli/zbox --wallet testing.json rp-lock \


### PR DESCRIPTION
## Fixes
Since `--expire` flag is removed from the `newallocation` command, it is removed from the bash script as well.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
