### PR TITLE
WorkAggregates: return err

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -375,12 +375,14 @@ func (edb *EventDb) WorkAggregates(
 				zap.Int("block size", blockEvents.blockSize),
 				zap.Error(err),
 			)
+			return nil, err
 		}
 		err = edb.updateUserAggregates(&blockEvents)
 		if err != nil {
 			logging.Logger.Error("user aggregate could not be processed",
 				zap.Error(err),
 			)
+			return nil, err
 		}
 	}
 	return gSnapshot, nil


### PR DESCRIPTION
## Fixes
Returns an error that was being lost. This will cause some extra panics when aggregates fail, and the error is now being [returned rather than forgotten.](https://github.com/0chain/0chain/blob/staging/code/go/0chain.net/smartcontract/dbs/event/process.go#L255). Hopefully this will highlight some aggregate errors that were previously being missed.
``` go
func (edb *EventDb) addEventsWorker(ctx context.Context) {
	var gs *Snapshot
	p := int64(-1)
	edb.managePartitions(0)

	for {
		es := <-edb.eventsChannel

		s, err := edb.work(ctx, gs, es, &p)
		if err != nil {
			if config.Development() { //panic in case of development
				log.Panic(err)
			}
		}
		if s != nil {
			gs = s
		}
	}
}
```
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
