### PR TITLE
Fix benchmark test case - storage.challenge_response

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
+++ b/code/go/0chain.net/smartcontract/storagesc/benchmark_setup.go
@@ -330,6 +330,7 @@ func setupMockChallenge(
 		TotalValidators: totalValidatorsNum,
 		BlobberID:       blobber.ID,
 		ValidatorIDs:    validatorIds[:viper.GetInt(sc.StorageValidatorsPerChallenge)],
+		RoundCreatedAt:  int64(index) - 1,
 	}
 	_, err := balances.InsertTrieNode(challenge.GetKey(ADDRESS), challenge)
 	if err != nil {


### PR DESCRIPTION
## Fixes
- Fixed `storage.challenge_response` by adding missing field initialization in mock challenge generation for benchmarks

![image](https://github.com/0chain/0chain/assets/52813950/dd30260a-1dd5-45b4-8ef0-c5a6aab43543)


## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
