### PR TITLE
Delete blobber/validator when kill/shutdown

### DIFF
--- a/code/go/0chain.net/smartcontract/storagesc/kill.go
+++ b/code/go/0chain.net/smartcontract/storagesc/kill.go
@@ -25,7 +25,10 @@ func (_ *StorageSmartContract) killBlobber(
 		return "", common.NewError("can't get config", err.Error())
 	}
 
-	var blobber = &StorageNode{}
+	var (
+		blobber = &StorageNode{}
+		sp      stakepool.AbstractStakePool
+	)
 	err = provider.Kill(
 		input,
 		tx.ClientID,
@@ -45,7 +48,7 @@ func (_ *StorageSmartContract) killBlobber(
 				}
 			}
 
-			sp, err := getStakePoolAdapter(blobber.Type(), blobber.Id(), balances)
+			sp, err = getStakePoolAdapter(blobber.Type(), blobber.Id(), balances)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -57,6 +60,18 @@ func (_ *StorageSmartContract) killBlobber(
 	if err != nil {
 		return "", common.NewError("kill_blobber_failed", err.Error())
 	}
+
+	// delete the blobber from MPT if it's empty and has no stake pools
+	if blobber.SavedData <= 0 && len(sp.GetPools()) == 0 {
+		// remove the blobber from MPT
+		_, err := balances.DeleteTrieNode(blobber.GetKey())
+		if err != nil {
+			return "", common.NewErrorf("kill_blobber_failed", "deleting blobber: %v", err)
+		}
+
+		return "", nil
+	}
+
 	_, err = balances.InsertTrieNode(blobber.GetKey(), blobber)
 	if err != nil {
 		return "", common.NewError("kill_blobber_failed", "saving blobber: "+err.Error())
@@ -77,7 +92,10 @@ func (_ *StorageSmartContract) killValidator(
 		return "", common.NewError("can't get config", err.Error())
 	}
 
-	var validator = &ValidationNode{}
+	var (
+		validator = &ValidationNode{}
+		sp        = stakepool.AbstractStakePool
+	)
 	err = provider.Kill(
 		input,
 		tx.ClientID,
@@ -103,7 +121,7 @@ func (_ *StorageSmartContract) killValidator(
 				}
 			}
 
-			sp, err := getStakePoolAdapter(validator.Type(), validator.Id(), balances)
+			sp, err = getStakePoolAdapter(validator.Type(), validator.Id(), balances)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -114,6 +132,18 @@ func (_ *StorageSmartContract) killValidator(
 	if err != nil {
 		return "", common.NewError("kill_validator_failed", err.Error())
 	}
+
+	// delete the validator from MPT if its stake pools is empty
+	if len(sp.GetPools()) == 0 {
+		// remove the validator from MPT
+		_, err := balances.DeleteTrieNode(validator.GetKey(""))
+		if err != nil {
+			return "", common.NewErrorf("kill_validator_failed", "deleting validator: %v", err)
+		}
+
+		return "", nil
+	}
+
 	_, err = balances.InsertTrieNode(validator.GetKey(""), validator)
 	if err != nil {
 		return "", common.NewError("kill_validator_failed", "saving validator: "+err.Error())

--- a/code/go/0chain.net/smartcontract/storagesc/kill.go
+++ b/code/go/0chain.net/smartcontract/storagesc/kill.go
@@ -94,7 +94,7 @@ func (_ *StorageSmartContract) killValidator(
 
 	var (
 		validator = &ValidationNode{}
-		sp        = stakepool.AbstractStakePool
+		sp        stakepool.AbstractStakePool
 	)
 	err = provider.Kill(
 		input,

--- a/code/go/0chain.net/smartcontract/storagesc/kill.go
+++ b/code/go/0chain.net/smartcontract/storagesc/kill.go
@@ -69,6 +69,10 @@ func (_ *StorageSmartContract) killBlobber(
 			return "", common.NewErrorf("kill_blobber_failed", "deleting blobber: %v", err)
 		}
 
+		if err = deleteStakepool(balances, blobber.ProviderType, blobber.Id()); err != nil {
+			return "", common.NewErrorf("kill_blobber_failed", "deleting stakepool: %v", err)
+		}
+
 		return "", nil
 	}
 
@@ -139,6 +143,10 @@ func (_ *StorageSmartContract) killValidator(
 		_, err := balances.DeleteTrieNode(validator.GetKey(""))
 		if err != nil {
 			return "", common.NewErrorf("kill_validator_failed", "deleting validator: %v", err)
+		}
+
+		if err = deleteStakepool(balances, validator.ProviderType, validator.Id()); err != nil {
+			return "", common.NewErrorf("kill_validator_failed", "deleting stakepool: %v", err)
 		}
 
 		return "", nil

--- a/code/go/0chain.net/smartcontract/storagesc/kill_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/kill_test.go
@@ -1,0 +1,121 @@
+package storagesc
+
+import (
+	"testing"
+
+	"github.com/0chain/common/core/util"
+	"github.com/stretchr/testify/require"
+
+	"0chain.net/chaincore/transaction"
+	"0chain.net/smartcontract/provider"
+	"0chain.net/smartcontract/stakepool"
+	"0chain.net/smartcontract/stakepool/spenum"
+)
+
+func TestStorageSmartContract_killBlobber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		blobberSavedSize  int64
+		stakePool         *stakePool
+		input             []byte
+		clientID          string
+		expectedStateFunc func(t *testing.T, state *testBalances)
+	}{
+		{
+			name:             "both blobber and stake pools are empty",
+			blobberSavedSize: 0,
+			stakePool:        newStakePool(),
+			input:            []byte(`{"provider_id":"blobber_id"}`),
+			clientID:         "blobber_id",
+			expectedStateFunc: func(t *testing.T, state *testBalances) {
+				var b StorageNode
+				b.ID = "blobber_id"
+				err := state.GetTrieNode(b.GetKey(), &b)
+				require.Error(t, util.ErrValueNotPresent, err)
+
+				var s stakepool.StakePool
+				err = state.GetTrieNode(stakePoolKey(spenum.Blobber, "blobber_id"), &s)
+				require.Error(t, util.ErrValueNotPresent, err)
+			},
+		},
+		{
+			name:             "blobber is not empty",
+			blobberSavedSize: 10,
+			stakePool:        newStakePool(),
+			input:            []byte(`{"provider_id":"blobber_id"}`),
+			clientID:         "blobber_id",
+			expectedStateFunc: func(t *testing.T, state *testBalances) {
+				var b StorageNode
+				b.ID = "blobber_id"
+				err := state.GetTrieNode(b.GetKey(), &b)
+				require.NoError(t, err)
+
+				var s stakepool.StakePool
+				err = state.GetTrieNode(stakePoolKey(spenum.Blobber, "blobber_id"), &s)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:             "stake pool is not empty",
+			blobberSavedSize: 0,
+			stakePool: &stakePool{
+				StakePool: &stakepool.StakePool{
+					Pools: map[string]*stakepool.DelegatePool{
+						"stake_pool_1": &stakepool.DelegatePool{},
+						"stake_pool_2": &stakepool.DelegatePool{},
+					},
+				},
+			},
+			input:    []byte(`{"provider_id":"blobber_id"}`),
+			clientID: "blobber_id",
+			expectedStateFunc: func(t *testing.T, state *testBalances) {
+				var b StorageNode
+				b.ID = "blobber_id"
+				b.ProviderType = spenum.Blobber
+				err := state.GetTrieNode(b.GetKey(), &b)
+				require.NoError(t, err)
+
+				var sp stakePool
+				err = state.GetTrieNode(stakePoolKey(spenum.Blobber, "blobber_id"), &sp)
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ssc := &StorageSmartContract{}
+
+			balances := newTestBalances(t, false)
+			balances.txn = &transaction.Transaction{
+				ClientID: tc.clientID,
+			}
+
+			conf := &Config{
+				OwnerId:   tc.clientID,
+				StakePool: &stakePoolConfig{},
+			}
+
+			mustSave(t, scConfigKey(ADDRESS), conf, balances)
+
+			// Create a blobber and a stake pool
+			blobber := &StorageNode{
+				Provider: provider.Provider{
+					ID:           "blobber_id",
+					ProviderType: spenum.Blobber,
+				},
+				SavedData: tc.blobberSavedSize,
+			}
+			balances.InsertTrieNode(blobber.GetKey(), blobber)
+			balances.InsertTrieNode(stakePoolKey(spenum.Blobber, blobber.ID), tc.stakePool)
+
+			// Call the killBlobber method
+			_, err := ssc.killBlobber(balances.txn, tc.input, balances)
+			require.NoError(t, err)
+
+			tc.expectedStateFunc(t, balances)
+		})
+	}
+}

--- a/code/go/0chain.net/smartcontract/storagesc/shutdown.go
+++ b/code/go/0chain.net/smartcontract/storagesc/shutdown.go
@@ -25,9 +25,16 @@ func (_ *StorageSmartContract) shutdownBlobber(
 		blobber = newBlobber("")
 		sp      stakepool.AbstractStakePool
 	)
-	err := provider.ShutDown(
+
+	conf, err := getConfig(balances)
+	if err != nil {
+		return "", common.NewErrorf("shutdown_blobber_failed", "can't get config: %v", err)
+	}
+
+	err = provider.ShutDown(
 		input,
 		tx.ClientID,
+		conf.OwnerId,
 		func(req provider.ProviderRequest) (provider.AbstractProvider, stakepool.AbstractStakePool, error) {
 			var err error
 			if blobber, err = getBlobber(req.ID, balances); err != nil {
@@ -87,9 +94,16 @@ func (_ *StorageSmartContract) shutdownValidator(
 		validator = newValidator("")
 		sp        stakepool.AbstractStakePool
 	)
-	err := provider.ShutDown(
+
+	conf, err := getConfig(balances)
+	if err != nil {
+		return "", common.NewErrorf("shutdown_validator_failed", "can't get config: %v", err)
+	}
+
+	err = provider.ShutDown(
 		input,
 		tx.ClientID,
+		conf.OwnerId,
 		func(req provider.ProviderRequest) (provider.AbstractProvider, stakepool.AbstractStakePool, error) {
 			var err error
 			if err = balances.GetTrieNode(provider.GetKey(req.ID), validator); err != nil {

--- a/code/go/0chain.net/smartcontract/storagesc/shutdown.go
+++ b/code/go/0chain.net/smartcontract/storagesc/shutdown.go
@@ -118,8 +118,10 @@ func (_ *StorageSmartContract) shutdownValidator(
 			}
 
 			if err := validatorPartitions.Remove(balances, validator.Id()); err != nil {
-				return nil, nil, common.NewError("shutdown_validator_failed",
-					"failed to remove validator."+err.Error())
+				if !strings.HasPrefix(err.Error(), partitions.ErrItemNotFoundCode) {
+					return nil, nil, common.NewErrorf("shutdown_validator_failed",
+						"failed to remove validator: %v", err)
+				}
 			}
 
 			sp, err = getStakePoolAdapter(validator.Type(), validator.Id(), balances)

--- a/code/go/0chain.net/smartcontract/storagesc/shutdown.go
+++ b/code/go/0chain.net/smartcontract/storagesc/shutdown.go
@@ -1,6 +1,9 @@
 package storagesc
 
 import (
+	"strings"
+
+	"0chain.net/smartcontract/partitions"
 	"0chain.net/smartcontract/provider"
 	"0chain.net/smartcontract/stakepool"
 	"0chain.net/smartcontract/stakepool/spenum"
@@ -33,7 +36,10 @@ func (_ *StorageSmartContract) shutdownBlobber(
 			}
 
 			if err := partitionsChallengeReadyBlobbersRemove(balances, blobber.Id()); err != nil {
-				return nil, nil, err
+				if !strings.HasPrefix(err.Error(), partitions.ErrItemNotFoundCode) {
+					return nil, nil, common.NewError("shutdown_blobber_failed",
+						"remove blobber form challenge partition, "+err.Error())
+				}
 			}
 
 			sp, err = getStakePoolAdapter(blobber.Type(), blobber.Id(), balances)

--- a/code/go/0chain.net/smartcontract/storagesc/shutdown_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/shutdown_test.go
@@ -1,0 +1,120 @@
+package storagesc
+
+import (
+	"testing"
+
+	"0chain.net/chaincore/transaction"
+	"0chain.net/smartcontract/provider"
+	"0chain.net/smartcontract/stakepool"
+	"0chain.net/smartcontract/stakepool/spenum"
+	"github.com/0chain/common/core/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageSmartContract_shutdownBlobber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		blobberSavedSize  int64
+		stakePool         *stakePool
+		input             []byte
+		clientID          string
+		expectedStateFunc func(t *testing.T, state *testBalances)
+	}{
+		{
+			name:             "both blobber and stake pools are empty",
+			blobberSavedSize: 0,
+			stakePool:        newStakePool(),
+			input:            []byte(`{"provider_id":"blobber_id"}`),
+			clientID:         "blobber_id",
+			expectedStateFunc: func(t *testing.T, state *testBalances) {
+				var b StorageNode
+				b.ID = "blobber_id"
+				err := state.GetTrieNode(b.GetKey(), &b)
+				require.Error(t, util.ErrValueNotPresent, err)
+
+				var s stakepool.StakePool
+				err = state.GetTrieNode(stakePoolKey(spenum.Blobber, "blobber_id"), &s)
+				require.Error(t, util.ErrValueNotPresent, err)
+			},
+		},
+		{
+			name:             "blobber is not empty",
+			blobberSavedSize: 10,
+			stakePool:        newStakePool(),
+			input:            []byte(`{"provider_id":"blobber_id"}`),
+			clientID:         "blobber_id",
+			expectedStateFunc: func(t *testing.T, state *testBalances) {
+				var b StorageNode
+				b.ID = "blobber_id"
+				err := state.GetTrieNode(b.GetKey(), &b)
+				require.NoError(t, err)
+
+				var s stakepool.StakePool
+				err = state.GetTrieNode(stakePoolKey(spenum.Blobber, "blobber_id"), &s)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:             "stake pool is not empty",
+			blobberSavedSize: 0,
+			stakePool: &stakePool{
+				StakePool: &stakepool.StakePool{
+					Pools: map[string]*stakepool.DelegatePool{
+						"stake_pool_1": &stakepool.DelegatePool{},
+						"stake_pool_2": &stakepool.DelegatePool{},
+					},
+				},
+			},
+			input:    []byte(`{"provider_id":"blobber_id"}`),
+			clientID: "blobber_id",
+			expectedStateFunc: func(t *testing.T, state *testBalances) {
+				var b StorageNode
+				b.ID = "blobber_id"
+				b.ProviderType = spenum.Blobber
+				err := state.GetTrieNode(b.GetKey(), &b)
+				require.NoError(t, err)
+
+				var sp stakePool
+				err = state.GetTrieNode(stakePoolKey(spenum.Blobber, "blobber_id"), &sp)
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ssc := &StorageSmartContract{}
+
+			balances := newTestBalances(t, false)
+			balances.txn = &transaction.Transaction{
+				ClientID: tc.clientID,
+			}
+
+			conf := &Config{
+				OwnerId:   tc.clientID,
+				StakePool: &stakePoolConfig{},
+			}
+
+			mustSave(t, scConfigKey(ADDRESS), conf, balances)
+
+			// Create a blobber and a stake pool
+			blobber := &StorageNode{
+				Provider: provider.Provider{
+					ID:           "blobber_id",
+					ProviderType: spenum.Blobber,
+				},
+				SavedData: tc.blobberSavedSize,
+			}
+			balances.InsertTrieNode(blobber.GetKey(), blobber)
+			balances.InsertTrieNode(stakePoolKey(spenum.Blobber, blobber.ID), tc.stakePool)
+
+			// Call the shutdown method
+			_, err := ssc.shutdownBlobber(balances.txn, tc.input, balances)
+			require.NoError(t, err)
+
+			tc.expectedStateFunc(t, balances)
+		})
+	}
+}

--- a/code/go/0chain.net/smartcontract/storagesc/shutdown_test.go
+++ b/code/go/0chain.net/smartcontract/storagesc/shutdown_test.go
@@ -118,3 +118,90 @@ func TestStorageSmartContract_shutdownBlobber(t *testing.T) {
 		})
 	}
 }
+
+func TestStorageSmartContract_shutdownValidator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		stakePool         *stakePool
+		input             []byte
+		clientID          string
+		expectedStateFunc func(t *testing.T, state *testBalances)
+	}{
+		{
+			name:      "stake pool is empty",
+			stakePool: newStakePool(),
+			input:     []byte(`{"provider_id":"validator_id"}`),
+			clientID:  "validator_id",
+			expectedStateFunc: func(t *testing.T, state *testBalances) {
+				var b StorageNode
+				b.ID = "validator_id"
+				err := state.GetTrieNode(b.GetKey(), &b)
+				require.Error(t, util.ErrValueNotPresent, err)
+
+				var s stakepool.StakePool
+				err = state.GetTrieNode(stakePoolKey(spenum.Validator, "validator_id"), &s)
+				require.Error(t, util.ErrValueNotPresent, err)
+			},
+		},
+		{
+			name: "stake pool is not empty",
+			stakePool: &stakePool{
+				StakePool: &stakepool.StakePool{
+					Pools: map[string]*stakepool.DelegatePool{
+						"stake_pool_1": &stakepool.DelegatePool{},
+						"stake_pool_2": &stakepool.DelegatePool{},
+					},
+				},
+			},
+			input:    []byte(`{"provider_id":"validator_id"}`),
+			clientID: "validator_id",
+			expectedStateFunc: func(t *testing.T, state *testBalances) {
+				var b StorageNode
+				b.ID = "validator_id"
+				b.ProviderType = spenum.Validator
+				err := state.GetTrieNode(b.GetKey(), &b)
+				require.NoError(t, err)
+
+				var sp stakePool
+				err = state.GetTrieNode(stakePoolKey(spenum.Validator, "validator_id"), &sp)
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ssc := &StorageSmartContract{}
+
+			balances := newTestBalances(t, false)
+			balances.txn = &transaction.Transaction{
+				ClientID: tc.clientID,
+			}
+
+			conf := &Config{
+				OwnerId:   tc.clientID,
+				StakePool: &stakePoolConfig{},
+			}
+
+			mustSave(t, scConfigKey(ADDRESS), conf, balances)
+
+			// Create a blobber and a stake pool
+			vn := &ValidationNode{
+				Provider: provider.Provider{
+					ID:           "validator_id",
+					ProviderType: spenum.Validator,
+				},
+			}
+			balances.InsertTrieNode(vn.GetKey(""), vn)
+			balances.InsertTrieNode(stakePoolKey(spenum.Validator, vn.ID), tc.stakePool)
+
+			// Call the killBlobber method
+			_, err := ssc.shutdownValidator(balances.txn, tc.input, balances)
+			require.NoError(t, err)
+
+			tc.expectedStateFunc(t, balances)
+		})
+	}
+}


### PR DESCRIPTION
## Fixes
- #2825
## Changes
- Update to allowed SC owner to shutdown blobber and validator. Previously only delegate wallet can do that.
- Changed to do not return error of `item not found` when removing the blobber from challenge ready partitions. If the blobber is not in the partition, we should continue the clean up work.

Delete empty blobber/validator from MPT when they are killed or shutdown

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
