### PR TITLE
Use local LFB whenever get error on fetching it from remote

### DIFF
--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -442,18 +442,12 @@ func (sc *Chain) loadLFBRoundAndBlocks(ctx context.Context, lfbr *chain.LfbRound
 	}
 
 	if err != nil {
-		if err == context.DeadlineExceeded {
-			// means there's no available sharders in the network yet, so use the local LFB to start
-			//
-			// why not try get from miners? when the network is restarting, miners do not have
-			// blocks persisted, so it will fail as well.
-			return &bl, nil
-		}
-
-		logging.Logger.Warn("load_lfb, could not sync LFB from remote",
+		logging.Logger.Debug("load_lfb, could not sync LFB from remote, use local LFB",
 			zap.Int64("round", lfb.Round),
-			zap.String("lfb", lfb.Hash))
-		return nil, fmt.Errorf("load_lfb - could not sync LFB from remote: %v", err)
+			zap.String("lfb", lfb.Hash),
+			zap.Error(err))
+
+		return &bl, nil
 	}
 
 	logging.Logger.Debug("load_lfb, got notarized block from remote and compare with local")


### PR DESCRIPTION
## Fixes
- Use local LFB if it failed to fetch block from remote. Previously we only use local if all remotes are not responding, but the case is they may response, but give different error. So in this case, we should use LFB instead of panic.

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
