### PR TITLE
Fix miner state health status

### DIFF
--- a/code/go/0chain.net/chaincore/chain/handler.go
+++ b/code/go/0chain.net/chaincore/chain/handler.go
@@ -871,10 +871,10 @@ func (c *Chain) printNodePool(w http.ResponseWriter, np *node.Pool) {
 		}
 		fmt.Fprintf(w, "<td><div class='fixed-text' style='width:100px;' title='%s'>%s</div></td>", nd.Description, nd.Description)
 		fmt.Fprintf(w, "<td><div class='fixed-text' style='width:100px;' title='%s'>%s</div></td>", nd.Info.BuildTag, nd.Info.BuildTag)
-		if nd.Info.StateMissingNodes < 0 {
+		if nd.Info.GetStateMissingNodes() < 0 {
 			fmt.Fprintf(w, "<td>pending</td>")
 		} else {
-			fmt.Fprintf(w, "<td class='number'>%v</td>", nd.Info.StateMissingNodes)
+			fmt.Fprintf(w, "<td class='number'>%v</td>", nd.Info.GetStateMissingNodes())
 		}
 		fmt.Fprintf(w, "<td class='number'>%v</td>", nd.Info.MinersMedianNetworkTime)
 		fmt.Fprintf(w, "<td class='number'>%v</td>", nd.Info.AvgBlockTxns)

--- a/code/go/0chain.net/chaincore/chain/handler.go
+++ b/code/go/0chain.net/chaincore/chain/handler.go
@@ -526,7 +526,7 @@ func (c *Chain) infraHealthInATable(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "<td class='number'>")
 	ps := c.GetPruneStats()
 	if ps != nil {
-		fmt.Fprintf(w, "%v", ps.MissingNodes)
+		fmt.Fprintf(w, "%v", node.Self.Underlying().Info.GetStateMissingNodes())
 	} else {
 		fmt.Fprintf(w, "pending")
 	}
@@ -820,7 +820,7 @@ func (c *Chain) printNodePool(w http.ResponseWriter, np *node.Pool) {
 	lfb := c.GetLatestFinalizedBlock()
 	fmt.Fprintf(w, "<table style='border-collapse: collapse;'>")
 	fmt.Fprintf(w, "<tr class='header'><td rowspan='2'>Set Index</td><td rowspan='2'>Node</td><td rowspan='2'>Sent</td><td rowspan='2'>Send Errors</td><td rowspan='2'>Received</td><td rowspan='2'>Last Active</td><td colspan='3' style='text-align:center'>Message Time</td><td rowspan='2'>Description</td><td colspan='4' style='text-align:center'>Remote Data</td></tr>")
-	fmt.Fprintf(w, "<tr class='header'><td>Small</td><td>Large</td><td>Large Optimal</td><td>Build Tag</td><td>State Health</td><td title='median network time'>Miners MNT</td><td>Avg Block Size</td></tr>")
+	fmt.Fprintf(w, "<tr class='header'><td>Small</td><td>Large</td><td>Large Optimal</td><td>Build Tag</td><td title='median network time'>Miners MNT</td><td>Avg Block Size</td></tr>")
 	nodes := np.CopyNodes()
 	sort.SliceStable(nodes, func(i, j int) bool {
 		return nodes[i].SetIndex < nodes[j].SetIndex
@@ -871,11 +871,11 @@ func (c *Chain) printNodePool(w http.ResponseWriter, np *node.Pool) {
 		}
 		fmt.Fprintf(w, "<td><div class='fixed-text' style='width:100px;' title='%s'>%s</div></td>", nd.Description, nd.Description)
 		fmt.Fprintf(w, "<td><div class='fixed-text' style='width:100px;' title='%s'>%s</div></td>", nd.Info.BuildTag, nd.Info.BuildTag)
-		if nd.Info.GetStateMissingNodes() < 0 {
-			fmt.Fprintf(w, "<td>pending</td>")
-		} else {
-			fmt.Fprintf(w, "<td class='number'>%v</td>", nd.Info.GetStateMissingNodes())
-		}
+		// if nd.Info.GetStateMissingNodes() < 0 {
+		// 	fmt.Fprintf(w, "<td>pending</td>")
+		// } else {
+		// 	fmt.Fprintf(w, "<td class='number'>%v</td>", nd.Info.GetStateMissingNodes())
+		// }
 		fmt.Fprintf(w, "<td class='number'>%v</td>", nd.Info.MinersMedianNetworkTime)
 		fmt.Fprintf(w, "<td class='number'>%v</td>", nd.Info.AvgBlockTxns)
 		fmt.Fprintf(w, "</tr>")

--- a/code/go/0chain.net/chaincore/chain/handler.go
+++ b/code/go/0chain.net/chaincore/chain/handler.go
@@ -524,12 +524,11 @@ func (c *Chain) infraHealthInATable(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "State missing nodes")
 	fmt.Fprintf(w, "</td>")
 	fmt.Fprintf(w, "<td class='number'>")
-	ps := c.GetPruneStats()
-	if ps != nil {
-		fmt.Fprintf(w, "%v", node.Self.Underlying().Info.GetStateMissingNodes())
-	} else {
-		fmt.Fprintf(w, "pending")
+	var missingNodes int64
+	if !node.Self.IsSharder() {
+		missingNodes = node.Self.Underlying().Info.GetStateMissingNodes()
 	}
+	fmt.Fprintf(w, "%v", missingNodes)
 	fmt.Fprintf(w, "</td>")
 	fmt.Fprintf(w, "</tr>")
 

--- a/code/go/0chain.net/chaincore/chain/json_handler.go
+++ b/code/go/0chain.net/chaincore/chain/json_handler.go
@@ -102,7 +102,7 @@ func (c *Chain) getNodePool(np *node.Pool) []nodeInfo {
 			OptimalLargeMessageSendTime: nd.GetOptimalLargeMessageSendTime(),
 			Description:                 nd.Description,
 			BuildTag:                    nd.Info.BuildTag,
-			StateMissingNodes:           nd.Info.StateMissingNodes,
+			StateMissingNodes:           nd.Info.GetStateMissingNodes(),
 			MinersMedianNetworkTime:     nd.Info.MinersMedianNetworkTime,
 			AvgBlockTxns:                nd.Info.AvgBlockTxns,
 		}

--- a/code/go/0chain.net/chaincore/node/info.go
+++ b/code/go/0chain.net/chaincore/node/info.go
@@ -1,16 +1,25 @@
 package node
 
 import (
+	"sync/atomic"
 	"time"
 )
 
 //go:generate msgp -io=false -tests=false -v
 
-//Info - (informal) info of a node that can be shared with other nodes
+// Info - (informal) info of a node that can be shared with other nodes
 type Info struct {
 	AsOf                    time.Time     `json:"-" msgpack:"-" msg:"-"`
 	BuildTag                string        `json:"build_tag"`
 	StateMissingNodes       int64         `json:"state_missing_nodes"`
 	MinersMedianNetworkTime time.Duration `json:"miners_median_network_time"`
 	AvgBlockTxns            int           `json:"avg_block_txns"`
+}
+
+func (i *Info) SetStateMissingNodes(num int64) {
+	atomic.StoreInt64(&i.StateMissingNodes, num)
+}
+
+func (i *Info) GetStateMissingNodes() int64 {
+	return atomic.LoadInt64(&i.StateMissingNodes)
 }

--- a/code/go/0chain.net/chaincore/node/self_node.go
+++ b/code/go/0chain.net/chaincore/node/self_node.go
@@ -134,7 +134,6 @@ func (sn *SelfNode) SetNodeIfPublicKeyIsEqual(node *Node) {
 	}
 
 	sn.Node = node
-	sn.Node.Info.StateMissingNodes = -1
 	sn.Node.Info.BuildTag = build.BuildTag
 	sn.Node.Status = NodeStatusActive
 }

--- a/code/go/0chain.net/miner/handler.go
+++ b/code/go/0chain.net/miner/handler.go
@@ -161,7 +161,7 @@ func MinerStatsHandler(ctx context.Context, r *http.Request) (interface{}, error
 	return ExplorerStats{BlockFinality: chain.SteadyStateFinalizationTimer.Mean() / 1000000.0,
 		LastFinalizedRound: c.GetLatestFinalizedBlock().Round,
 		BlocksFinalized:    total,
-		StateHealth:        node.Self.Underlying().Info.StateMissingNodes,
+		StateHealth:        node.Self.Underlying().Info.GetStateMissingNodes(),
 		CurrentRound:       c.GetCurrentRound(),
 		RoundTimeout:       rtoc,
 		Timeouts:           c.RoundTimeoutsCount,

--- a/code/go/0chain.net/miner/worker.go
+++ b/code/go/0chain.net/miner/worker.go
@@ -338,6 +338,8 @@ func (mc *Chain) syncAllMissingNodes(ctx context.Context) {
 		logging.Logger.Debug("sync all missing nodes - pull missing nodes",
 			zap.Int("num", batchSize),
 			zap.Int("remaining", len(missingNodes)-end))
+
+		node.Self.Underlying().Info.SetStateMissingNodes(int64(len(missingNodes) - end))
 		tk.Reset(2 * time.Second)
 	}
 

--- a/code/go/0chain.net/miner/worker.go
+++ b/code/go/0chain.net/miner/worker.go
@@ -302,6 +302,7 @@ func (mc *Chain) syncAllMissingNodes(ctx context.Context) {
 		// Record the number of missing nodes and the time it took to acquire them
 		mc.MissingNodesStat.Counter.Inc(int64(len(missingNodes)))
 		mc.MissingNodesStat.Timer.UpdateSince(start)
+		node.Self.Underlying().Info.SetStateMissingNodes(int64(len(missingNodes)))
 
 		logging.Logger.Debug("sync all missing nodes - finish load all missing nodes",
 			zap.Int("num", len(missingNodes)))

--- a/code/go/0chain.net/sharder/handler.go
+++ b/code/go/0chain.net/sharder/handler.go
@@ -273,7 +273,7 @@ func SharderStatsHandler(ctx context.Context, r *http.Request) (interface{}, err
 	}
 	selfNodeInfo := node.Self.Underlying().Info
 	return ExplorerStats{LastFinalizedRound: sc.Chain.GetLatestFinalizedBlock().Round,
-		StateHealth:            selfNodeInfo.StateMissingNodes,
+		StateHealth:            selfNodeInfo.GetStateMissingNodes(),
 		AverageBlockSize:       selfNodeInfo.AvgBlockTxns,
 		PrevInvocationCount:    previous.HealthCheckInvocations,
 		PrevInvocationScanTime: previousElapsed,


### PR DESCRIPTION
## Fixes
- Fix 'pending' status of miner state health
## Changes
- Remove the remote nodes's State Health as we don't have send miner/sharder's missing nodes stat to remotes. 
- Show the missing nodes for miners only as we do get the missing nodes checking periodically in miners to sync nodes. But sharders should have full state, and we don't do that checking for the sake of performance. 
## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
