### PR TITLE
Read healthcheck period from config

### DIFF
--- a/code/go/0chain.net/smartcontract/dbs/event/authorizer.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/authorizer.go
@@ -11,8 +11,6 @@ import (
 	"github.com/0chain/common/core/currency"
 )
 
-const ActiveAuthorizerTimeLimit = 5 * time.Minute // 5 Minutes
-
 type Authorizer struct {
 	Provider
 
@@ -107,12 +105,12 @@ func (edb *EventDb) GetAuthorizer(id string) (*Authorizer, error) {
 	return &auth, nil
 }
 
-func (edb *EventDb) GetActiveAuthorizers() ([]Authorizer, error) {
+func (edb *EventDb) GetActiveAuthorizers(activeAuthorizerTimeLimitive time.Duration) ([]Authorizer, error) {
 	now := common.Now()
 	var authorizers []Authorizer
 	result := edb.Store.Get().
 		Model(&Authorizer{}).
-		Where("last_health_check > ?", common.ToTime(now).Add(-ActiveAuthorizerTimeLimit).Unix()).
+		Where("last_health_check > ?", common.ToTime(now).Add(-activeAuthorizerTimeLimitive).Unix()).
 		Find(&authorizers)
 	return authorizers, result.Error
 }

--- a/code/go/0chain.net/smartcontract/dbs/event/authorizer_test.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/authorizer_test.go
@@ -77,7 +77,7 @@ func TestAuthorizers(t *testing.T) {
 	_, err = authorizer_2.exists(eventDb)
 	require.NoError(t, err, "Error while checking if Authorizer exists in event Database")
 
-	activeAuthorizers, err := eventDb.GetActiveAuthorizers()
+	activeAuthorizers, err := eventDb.GetActiveAuthorizers(5 * time.Minute)
 	require.NoError(t, err, "Error while active Authorizer retrieval")
 	require.Len(t, activeAuthorizers, 2)
 

--- a/code/go/0chain.net/smartcontract/zcnsc/handler.go
+++ b/code/go/0chain.net/smartcontract/zcnsc/handler.go
@@ -4,7 +4,9 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"time"
 
+	"0chain.net/smartcontract"
 	"0chain.net/smartcontract/rest"
 
 	"github.com/0chain/common/core/currency"
@@ -50,7 +52,8 @@ func GetEndpoints(rh rest.RestHandlerI) []rest.Endpoint {
 func (zrh *ZcnRestHandler) getAuthorizerNodes(w http.ResponseWriter, r *http.Request) {
 	values := r.URL.Query()
 	active := values.Get("active")
-	edb := zrh.GetQueryStateContext().GetEventDB()
+	stateCtx := zrh.GetQueryStateContext()
+	edb := stateCtx.GetEventDB()
 	if edb == nil {
 		common.Respond(w, r, nil, common.NewErrInternal("no db connection"))
 		return
@@ -61,7 +64,19 @@ func (zrh *ZcnRestHandler) getAuthorizerNodes(w http.ResponseWriter, r *http.Req
 	authorizers := make([]event.Authorizer, 0)
 
 	if active == "true" {
-		authorizers, err = edb.GetActiveAuthorizers()
+		conf, err := GetGlobalNode(stateCtx)
+		if err != nil && err != util.ErrValueNotPresent {
+			const cantGetConfigErrMsg = "can't get config"
+			common.Respond(w, r, nil, smartcontract.NewErrNoResourceOrErrInternal(err, true, cantGetConfigErrMsg))
+			return
+		}
+
+		healthCheckPeriod := 60 * time.Minute // set default as 1 hour
+		if conf != nil {
+			healthCheckPeriod = conf.HealthCheckPeriod
+		}
+
+		authorizers, err = edb.GetActiveAuthorizers(healthCheckPeriod)
 	} else {
 		authorizers, err = edb.GetAuthorizers()
 	}


### PR DESCRIPTION
## Fixes
- Change authorizers to get health check period from config and use 60 minutes as default if not present.

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
