### PR TITLE
Fix zcnsc config validation

### DIFF
--- a/code/go/0chain.net/smartcontract/zcnsc/nodes.go
+++ b/code/go/0chain.net/smartcontract/zcnsc/nodes.go
@@ -200,8 +200,8 @@ func (gn *GlobalNode) Validate() error {
 		return common.NewError(Code, fmt.Sprintf("max delegate count (%v) is less than 0", gn.MaxDelegates))
 	case gn.HealthCheckPeriod <= 0:
 		return common.NewError(Code, fmt.Sprintf("health check period (%v) is less than 0", gn.HealthCheckPeriod))
-	case gn.MinLockAmount == 0:
-		return common.NewError(Code, fmt.Sprintf("min lock amount (%v) is equal to 0", gn.MinLockAmount))
+		// case gn.MinLockAmount == 0:
+		// 	return common.NewError(Code, fmt.Sprintf("min lock amount (%v) is equal to 0", gn.MinLockAmount))
 	}
 	return nil
 }

--- a/docker.local/config/sc.yaml
+++ b/docker.local/config/sc.yaml
@@ -226,6 +226,7 @@ smart_contracts:
     min_mint: 1
     min_burn: 1
     min_stake: 0
+    max_stake: 20000.0 # max stake can be set by a node (boundary for all nodes)
     min_stake_per_delegate : 1
     min_authorizers: 1
     percent_authorizers: 0.7


### PR DESCRIPTION
## Fixes

## Changes

- Add new config field `max_stake` to zcnsc to sc.yaml
- Comment out the `min_lock` config validation in zcnsc. 

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
