### PR TITLE
Hotfix potential sharder missing blocks on restarting

### DIFF
--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -280,6 +280,28 @@ func (c *Chain) SetupEventDatabase() error {
 	return nil
 }
 
+// GetLatestFinalizedBlockFromDB gets the latest finalized block hash and round number from event db
+func (c *Chain) GetLatestFinalizedBlockFromDB() (string, int64, error) {
+	if c.EventDb == nil {
+		return "", 0, errors.New("event db is not initialized")
+	}
+
+	var roundHash = struct {
+		Round int64  `json:"round"`
+		Hash  string `json:"hash"`
+	}{}
+
+	err := c.EventDb.Store.Get().Model(&event.Block{}).
+		Select("round, hash").
+		Order("round desc").
+		Limit(1).Scan(&roundHash).Error
+	if err != nil {
+		return "", 0, err
+	}
+
+	return roundHash.Hash, roundHash.Round, nil
+}
+
 func (c *Chain) GetEventDb() *event.EventDb {
 	c.eventMutex.RLock()
 	defer c.eventMutex.RUnlock()

--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -505,8 +505,13 @@ func (sc *Chain) LoadLatestBlocksFromStore(ctx context.Context) (err error) {
 
 	if lfbRound == 0 {
 		// use genesis
+		logging.Logger.Debug("load_lfb - load from event db, use genesis block")
 		return nil
 	}
+
+	logging.Logger.Debug("load_lfb - load from event db",
+		zap.Int64("round", lfbRound),
+		zap.String("block", lfbHash))
 
 	bl, err := sc.loadLFBRoundAndBlocks(ctx, lfbHash, lfbRound)
 	if err != nil {


### PR DESCRIPTION
## Fixes

Sharder could miss blocks if the events is not processed successfully but MPT state is saved and the sharder is restarted. 

## Changes
- When starting the sharder, we check both the LFB round and hash on event db and state DB, use the info from event db if the round is older than the state DB one. All other case use the LFB info from state DB.

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
