### PR TITLE
Read health check period from global node config

### DIFF
--- a/code/go/0chain.net/miner/worker.go
+++ b/code/go/0chain.net/miner/worker.go
@@ -222,8 +222,15 @@ func (mc *Chain) getPruneCountRoundStorage() func(storage round.RoundStorage) in
 }
 
 func (mc *Chain) MinerHealthCheck(ctx context.Context) {
-	// TODO: Move that to a unified config file.
-	const HEALTH_CHECK_TIMER = 5 * time.Minute // 5 Minute
+	gn, err := minersc.GetGlobalNode(mc.GetQueryStateContext())
+	if err != nil {
+		logging.Logger.Panic("miner health check - get global node failed", zap.Error(err))
+		return
+	}
+
+	logging.Logger.Debug("miner health check - start", zap.Any("period", gn.HealthCheckPeriod))
+	HEALTH_CHECK_TIMER := gn.HealthCheckPeriod
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/code/go/0chain.net/sharder/worker.go
+++ b/code/go/0chain.net/sharder/worker.go
@@ -395,8 +395,15 @@ func (sc *Chain) getPruneCountRoundStorage() func(storage round.RoundStorage) in
 }
 
 func (sc *Chain) SharderHealthCheck(ctx context.Context) {
-	// TODO: Move to a config file
-	const HEALTH_CHECK_TIMER = 5 * time.Minute // 5 Minute
+	gn, err := minersc.GetGlobalNode(sc.GetQueryStateContext())
+	if err != nil {
+		logging.Logger.Panic("sharder health check - get global node failed", zap.Error(err))
+		return
+	}
+
+	logging.Logger.Debug("sharder health check - start", zap.Any("period", gn.HealthCheckPeriod))
+	HEALTH_CHECK_TIMER := gn.HealthCheckPeriod
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/code/go/0chain.net/smartcontract/minersc/sc.go
+++ b/code/go/0chain.net/smartcontract/minersc/sc.go
@@ -161,3 +161,8 @@ func InitConfig(balances cstate.CommonStateContextI) error {
 
 	return nil
 }
+
+// GetGlobalNode returns the global node config
+func GetGlobalNode(balances cstate.CommonStateContextI) (*GlobalNode, error) {
+	return getGlobalNode(balances)
+}


### PR DESCRIPTION
## Fixes

Read health check period from global config, i.e minersc.health_check_period from sc.yaml. Change the period from previously 5m to 90m.

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
