### PR TITLE
Support sharder recover without blocks

### DIFF
--- a/code/go/0chain.net/sharder/chain.go
+++ b/code/go/0chain.net/sharder/chain.go
@@ -440,9 +440,6 @@ func (sc *Chain) loadLFBRoundAndBlocks(ctx context.Context, hash string, round i
 		if err != nil {
 			return nil, fmt.Errorf("load_lfb - could not load lfb block: %v", err)
 		}
-		// lfb = lfnb
-
-		// return nil, fmt.Errorf("load_lfb - could not load lfb block from store: %v", err)
 	}
 
 	logging.Logger.Debug("load_lfb, got block", zap.Int64("round", lfb.Round), zap.String("block", lfb.Hash))

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -447,13 +447,10 @@ func (edb *EventDb) managePartitions(round int64) error {
 func (edb *EventDb) movePartitions(round int64) {
 	if err := edb.movePartitionToSlowTableSpace(round, "transactions"); err != nil {
 		logging.Logger.Error("error moving partition", zap.Error(err))
-	} else {
-		logging.Logger.Debug("move transactions partitions success", zap.Int64("round", round))
 	}
+
 	if err := edb.movePartitionToSlowTableSpace(round, "blocks"); err != nil {
 		logging.Logger.Error("error moving partition", zap.Error(err))
-	} else {
-		logging.Logger.Debug("move blocks partitions success", zap.Int64("round", round))
 	}
 }
 

--- a/code/go/0chain.net/smartcontract/dbs/event/process.go
+++ b/code/go/0chain.net/smartcontract/dbs/event/process.go
@@ -447,9 +447,13 @@ func (edb *EventDb) managePartitions(round int64) error {
 func (edb *EventDb) movePartitions(round int64) {
 	if err := edb.movePartitionToSlowTableSpace(round, "transactions"); err != nil {
 		logging.Logger.Error("error moving partition", zap.Error(err))
+	} else {
+		logging.Logger.Debug("move transactions partitions success", zap.Int64("round", round))
 	}
 	if err := edb.movePartitionToSlowTableSpace(round, "blocks"); err != nil {
 		logging.Logger.Error("error moving partition", zap.Error(err))
+	} else {
+		logging.Logger.Debug("move blocks partitions success", zap.Int64("round", round))
 	}
 }
 


### PR DESCRIPTION
## Fixes

- Fetch block from remote when load lfb on starting of sharder so that sharder can recover from event db and mpt data.

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
