### PR TITLE
Do r-3 block finalization

### DIFF
--- a/code/go/0chain.net/chaincore/chain/protocol_round.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_round.go
@@ -326,9 +326,9 @@ func (c *Chain) finalizeRound(ctx context.Context, r round.RoundI) {
 			zap.String("lfb block", lfb.Hash))
 		for idx := range frchain {
 			fb := frchain[len(frchain)-1-idx]
-			if roundNumber-fb.Round < 3 {
-				// finalize the block only when it has at least 3 confirmation
-				logging.Logger.Debug("finalize round - block has less than 3 confirmation")
+			if roundNumber-fb.Round < 2 {
+				// finalize the block only when it has at least 2 confirmation
+				logging.Logger.Debug("finalize round - block has less than 2 confirmation")
 				continue
 			}
 

--- a/code/go/0chain.net/chaincore/chain/protocol_round.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_round.go
@@ -124,6 +124,11 @@ func (c *Chain) ComputeFinalizedBlock(ctx context.Context, lfbr int64, r round.R
 	if fb.Round == r.GetRoundNumber() {
 		return nil
 	}
+
+	if fb.Round <= lfbr {
+		return nil
+	}
+
 	return fb
 }
 


### PR DESCRIPTION
## Fixes

## Changes

- Change to finalize block when there at least 2 confirmats, i.e `r-3`. 

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
