### PR TITLE
fix: readme and run.sharder.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Start sharder first because miners need the genesis magic block. On the sharder 
 ../bin/start.b0sharder.sh
 ```
 
-Wait till the cassandra is started and the sharder is ready to listen to requests.
+Wait till the postgres is started and the sharder is ready to listen to requests.
 
 On the respective miner terminal, use
 
@@ -206,10 +206,10 @@ Redis used for transactions:
 ../bin/run.miner.sh redis_txns redis-cli
 ```
 
-4. Connecting to cassandra used in the sharder (you are within the appropriate sharder directories)
+4. Connecting to postgres used in the sharder (you are within the appropriate sharder directories)
 
 ```
-../bin/run.sharder.sh cassandra cqlsh
+../bin/run.sharder.sh postgres psql -U zchain_user -d events_db
 ```
 
 ## Restarting the nodes

--- a/docker.local/bin/run.sharder.sh
+++ b/docker.local/bin/run.sharder.sh
@@ -6,6 +6,8 @@ NODE_ID=$(echo "$NODE_DIR" | sed -e 's/.*\(.\)$/\1/')
 SERVICE=$1; shift
 CMD=$1; shift
 
+SHARD_NO="${NODE_DIR//[^0-9]/}"
+
 echo "$NODE_DIR: running $SERVICE $CMD $*"
 
-SHARDER=$SHARDER_ID docker-compose -p "$NODE_DIR" -f ../build.sharder/docker-compose.yml exec "$SERVICE" "$CMD" "$*"
+SHARDER=$SHARD_NO docker-compose -p "$NODE_DIR" -f ../build.sharder/docker-compose.yml exec $SERVICE $CMD $*


### PR DESCRIPTION
## Fixes
Fix in readme, Cassandra is no longer used in sharder. Use Postgres 

## Changes
psql command to access the postgres cli
## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
