### PR TITLE
Fix rocksdb disk full

### DIFF
--- a/code/go/0chain.net/chaincore/block/block_state_change_entity.go
+++ b/code/go/0chain.net/chaincore/block/block_state_change_entity.go
@@ -28,6 +28,7 @@ func NewBlockStateChange(b *Block) (*StateChange, error) {
 	var changes []*util.NodeChange
 	bsc.Hash, changes, _, bsc.StartRoot = b.ClientState.GetChanges()
 	bsc.Nodes = make([]util.Node, len(changes))
+	bsc.DeadNodes = make([]util.Node, len(changes))
 	for idx, change := range changes {
 		bsc.Nodes[idx] = change.New
 		bsc.DeadNodes[idx] = change.Old

--- a/code/go/0chain.net/chaincore/block/block_state_change_entity.go
+++ b/code/go/0chain.net/chaincore/block/block_state_change_entity.go
@@ -30,6 +30,7 @@ func NewBlockStateChange(b *Block) (*StateChange, error) {
 	bsc.Nodes = make([]util.Node, len(changes))
 	for idx, change := range changes {
 		bsc.Nodes[idx] = change.New
+		bsc.DeadNodes[idx] = change.Old
 	}
 
 	if err := bsc.ComputeProperties(); err != nil {
@@ -86,14 +87,14 @@ func (sc *StateChange) GetChanges() []*util.NodeChange {
 	return changes
 }
 
-//MarshalJSON - implement Marshaler interface
+// MarshalJSON - implement Marshaler interface
 func (sc *StateChange) MarshalJSON() ([]byte, error) {
 	var data = make(map[string]interface{})
 	data["block"] = sc.Block
 	return sc.MarshalPartialStateJSON(data)
 }
 
-//UnmarshalJSON - implement Unmarshaler interface
+// UnmarshalJSON - implement Unmarshaler interface
 func (sc *StateChange) UnmarshalJSON(data []byte) error {
 	var obj map[string]interface{}
 	err := json.Unmarshal(data, &obj)

--- a/code/go/0chain.net/chaincore/block/block_state_change_entity.go
+++ b/code/go/0chain.net/chaincore/block/block_state_change_entity.go
@@ -29,6 +29,7 @@ func NewBlockStateChange(b *Block) (*StateChange, error) {
 	bsc.Hash, changes, _, bsc.StartRoot = b.ClientState.GetChanges()
 	bsc.Nodes = make([]util.Node, len(changes))
 	bsc.DeadNodes = make([]util.Node, len(changes))
+	logging.Logger.Debug("new block state change", zap.String("block", b.Hash), zap.Int("changes", len(changes)))
 	for idx, change := range changes {
 		bsc.Nodes[idx] = change.New
 		bsc.DeadNodes[idx] = change.Old

--- a/code/go/0chain.net/chaincore/block/entity.go
+++ b/code/go/0chain.net/chaincore/block/entity.go
@@ -1112,7 +1112,7 @@ func (b *Block) ApplyBlockStateChange(bsc *StateChange, c Chainer) error {
 		return state.ErrMalformedPartialState
 	}
 
-	err := clientState.MergeDB(bsc.GetNodeDB(), bsc.GetRoot().GetHashBytes())
+	err := clientState.MergeDB(bsc.GetNodeDB(), bsc.GetRoot().GetHashBytes(), bsc.GetDeadNodes())
 	if err != nil {
 		logging.Logger.Error("apply block state changes - error merging",
 			zap.Int64("round", b.Round), zap.String("block", b.Hash))

--- a/code/go/0chain.net/chaincore/chain/protocol_block.go
+++ b/code/go/0chain.net/chaincore/chain/protocol_block.go
@@ -382,6 +382,11 @@ func (c *Chain) finalizeBlock(ctx context.Context, fb *block.Block, bsh BlockSta
 				zap.String("block", fb.Hash),
 				zap.Error(er))
 		}
+
+		logging.Logger.Debug("finalize block - record dead nodes",
+			zap.Int64("round", fb.Round),
+			zap.String("block", fb.Hash),
+			zap.Int("num dead nodes", len(deletedNode)))
 		// do not return err, we don't want to see the dead nodes removing failure stop the finalizing process
 		return nil
 	})

--- a/code/go/0chain.net/chaincore/state/partial_state.go
+++ b/code/go/0chain.net/chaincore/state/partial_state.go
@@ -374,13 +374,15 @@ func (ps *PartialState) setMarshalFields(data map[string]interface{}) map[string
 	data["root"] = util.ToHex(ps.Hash)
 	data["version"] = ps.Version
 	nodes := make([][]byte, len(ps.Nodes))
-	deadNodes := make([][]byte, len(ps.DeadNodes))
+	deadNodes := make([][]byte, 0, len(ps.DeadNodes))
 	for idx, nd := range ps.Nodes {
 		nodes[idx] = nd.Encode()
 	}
 
-	for idx, nd := range ps.DeadNodes {
-		deadNodes[idx] = nd.Encode()
+	for _, nd := range ps.DeadNodes {
+		if nd != nil {
+			deadNodes = append(deadNodes, nd.Encode())
+		}
 	}
 	data["nodes"] = nodes
 	data["dead_nodes"] = deadNodes

--- a/code/go/0chain.net/chaincore/state/partial_state.go
+++ b/code/go/0chain.net/chaincore/state/partial_state.go
@@ -31,6 +31,7 @@ type PartialState struct {
 	Version   string      `json:"version"`
 	StartRoot util.Key    `json:"start"`
 	Nodes     []util.Node `json:"-" msgpack:"-"`
+	DeadNodes []util.Node `json:"-" msgpack:"-"`
 	mndb      *util.MemoryNodeDB
 	root      util.Node
 }
@@ -308,10 +309,16 @@ func (ps *PartialState) setMarshalFields(data map[string]interface{}) map[string
 	data["root"] = util.ToHex(ps.Hash)
 	data["version"] = ps.Version
 	nodes := make([][]byte, len(ps.Nodes))
+	deadNodes := make([][]byte, len(ps.DeadNodes))
 	for idx, nd := range ps.Nodes {
 		nodes[idx] = nd.Encode()
 	}
+
+	for idx, nd := range ps.DeadNodes {
+		deadNodes[idx] = nd.Encode()
+	}
 	data["nodes"] = nodes
+	data["dead_nodes"] = deadNodes
 	return data
 }
 
@@ -328,4 +335,8 @@ func (ps *PartialState) SaveState(ctx context.Context, stateDB util.NodeDB) erro
 // GetNodeDB returns the node db containing all the changes
 func (ps *PartialState) GetNodeDB() util.NodeDB {
 	return ps.mndb
+}
+
+func (ps *PartialState) GetDeadNodes() []util.Node {
+	return ps.DeadNodes
 }

--- a/code/go/0chain.net/go.mod
+++ b/code/go/0chain.net/go.mod
@@ -40,7 +40,7 @@ require (
 )
 
 require (
-	github.com/0chain/common v1.13.1-0.20240619040111-99779eb0e812
+	github.com/0chain/common v1.13.1-0.20240717061404-724fe8011a7c
 	github.com/0chain/gosdk v1.16.0
 	github.com/IBM/sarama v1.42.2
 	github.com/go-faker/faker/v4 v4.2.0

--- a/code/go/0chain.net/go.sum
+++ b/code/go/0chain.net/go.sum
@@ -38,6 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/0chain/common v1.13.1-0.20240619040111-99779eb0e812 h1:Vx8phSmTVzIjaG383IUyraMm1A6+68WcuNynOe6YJPA=
 github.com/0chain/common v1.13.1-0.20240619040111-99779eb0e812/go.mod h1:YQiHd2yA/gIo7BuHL3aW0oGzO+SIwhfsKMiUNprPISo=
+github.com/0chain/common v1.13.1-0.20240717061404-724fe8011a7c h1:dUne+gFXqRN/mEe/8NjPKzjXHCP+CrBRuKU/Xd9R+A4=
+github.com/0chain/common v1.13.1-0.20240717061404-724fe8011a7c/go.mod h1:YQiHd2yA/gIo7BuHL3aW0oGzO+SIwhfsKMiUNprPISo=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
 github.com/0chain/gosdk v1.16.0 h1:3CKuU9i9d+X2/htJOIyxNwviKG5H/lp+q8ogzCgnoQI=


### PR DESCRIPTION
## Fixes
- Fix rocksdb disk full issue. The more we sync state node from remote, the more nodes will be left in the rocksdb.  The process to clean up rocksdb dead nodes is like: mark deleted nodes that are collected when computing block state as dead nodes when finalize the block. We have another dead nodes clean worker that will remove those nodes from rocksdb peridocially. The problem is if we don't run the ComputeState for the block(where the deleted nodes are collected), instead we sync state changes from remote, which only sync new nodes. Then, when we finalize this block, we will see no delete nodes, therefore they will be left in the rocksdb forever. 

## Changes
Instead of synching the new added state nodes only, we sync the deleted nodes too, and when we apply the synced changes, we will add those deleted nodes to the client state. When finalize the block, those deleted nodes will be marked as dead nodes, then be clean up by the dead node worker. 

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- Common: - https://github.com/0chain/common/pull/24
