### PR TITLE
Fix demo sharder stuck

### DIFF
--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -455,18 +455,18 @@ func (c *Chain) BlockWorker(ctx context.Context) {
 					zap.String("block", b.Hash),
 					zap.String("prev block", b.PrevHash))
 
+				if err != ErrNoPreviousBlock && !ErrNoPreviousState.Is(err) {
+					continue
+				}
+
 				var pb *block.Block
-				if err == ErrNoPreviousBlock || ErrNoPreviousState.Is(err) {
-					pb, err = c.GetNotarizedBlock(ctx, b.PrevHash, b.Round-1)
-					if err != nil {
-						logging.Logger.Error("process block, previous block is nil",
-							zap.Int64("round", b.Round),
-							zap.String("block", b.Hash),
-							zap.String("prev block", b.PrevHash),
-							zap.Error(err))
-						continue
-					}
-				} else {
+				pb, err = c.GetNotarizedBlock(ctx, b.PrevHash, b.Round-1)
+				if err != nil {
+					logging.Logger.Error("process block, failed to fetch previous block",
+						zap.Int64("round", b.Round),
+						zap.String("block", b.Hash),
+						zap.String("prev block", b.PrevHash),
+						zap.Error(err))
 					continue
 				}
 

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -448,6 +448,18 @@ func (c *Chain) BlockWorker(ctx context.Context) {
 				continue
 			}
 
+			if b.Round != cr+1 {
+				if !syncing {
+					syncBlocksTimer.Reset(0)
+				}
+				logging.Logger.Debug("process block skip, not the next round",
+					zap.Int64("block round", b.Round),
+					zap.Int64("current round", cr),
+					zap.Int64("lfb", lfb.Round),
+					zap.Bool("syncing", syncing))
+				continue
+			}
+
 			if err := c.processBlock(ctx, b); err != nil {
 				logging.Logger.Error("process block failed",
 					zap.Error(err),

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -448,18 +448,6 @@ func (c *Chain) BlockWorker(ctx context.Context) {
 				continue
 			}
 
-			if b.Round != cr+1 {
-				if !syncing {
-					syncBlocksTimer.Reset(0)
-				}
-				logging.Logger.Debug("process block skip, not the next round",
-					zap.Int64("block round", b.Round),
-					zap.Int64("current round", cr),
-					zap.Int64("lfb", lfb.Round),
-					zap.Bool("syncing", syncing))
-				continue
-			}
-
 			if err := c.processBlock(ctx, b); err != nil {
 				logging.Logger.Error("process block failed",
 					zap.Error(err),

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -684,16 +684,24 @@ func (c *Chain) AddNotarizedBlock(ctx context.Context, r round.RoundI, b *block.
 		logging.Logger.Error("AddNotarizedBlock failed to compute state",
 			zap.Int64("round", b.Round),
 			zap.Error(err))
-		// if node.Self.IsSharder() {
 		return err
-		// }
 	}
 
-	c.SetCurrentRound(r.GetRoundNumber())
+	var (
+		rn         = r.GetRoundNumber()
+		cr         = c.GetCurrentRound()
+		moveToNext bool
+	)
+	if cr+1 == rn {
+		c.SetCurrentRound(r.GetRoundNumber())
+		if !node.Self.IsSharder() {
+			moveToNext = true
+		}
+	}
+
 	c.UpdateNodeState(b)
 
-	// TODO: notarization to move to next round
-	if !node.Self.IsSharder() {
+	if moveToNext {
 		c.notifyMoveToNextRound(r)
 	}
 


### PR DESCRIPTION
## Fixes
- Fix sharder stuck when current round only has a block that is not gona to be finalized, means the next block that the block worker try to process can't connect to the current round block. Finalization will stop due to the missed block in current round(the one that all others agreed and will finalize)
## Changes
- Fetch the missed block when detect it
- Set the processed block round as current round only when it's one round ahead of the previous one. This is to avoid skipping round setting, which could lead to potential missing blocks.

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
