### PR TITLE
Fix miner stuck 

### DIFF
--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -1567,9 +1567,15 @@ func (c *Chain) addBlock(b *block.Block) *block.Block {
 		if eb != b {
 			c.MergeVerificationTickets(eb, b.GetVerificationTickets())
 			if b.IsStateComputed() {
-				eb.SetStateStatus(b.GetBlockState())
-				if b.GetStateStatus() == block.StateSuccessful {
+				if !eb.IsStateComputed() {
+					eb.SetStateStatus(b.GetBlockState())
 					eb.SetClientState(b.ClientState)
+				} else {
+					// eb state is also computed, overwrite it only if it's synced
+					if eb.GetStateStatus() == block.StateSynched {
+						eb.SetStateStatus(b.GetBlockState())
+						eb.SetClientState(b.ClientState)
+					}
 				}
 			}
 		}

--- a/code/go/0chain.net/chaincore/chain/entity.go
+++ b/code/go/0chain.net/chaincore/chain/entity.go
@@ -1568,6 +1568,9 @@ func (c *Chain) addBlock(b *block.Block) *block.Block {
 			c.MergeVerificationTickets(eb, b.GetVerificationTickets())
 			if b.IsStateComputed() {
 				eb.SetStateStatus(b.GetBlockState())
+				if b.GetStateStatus() == block.StateSuccessful {
+					eb.SetClientState(b.ClientState)
+				}
 			}
 		}
 		return eb

--- a/code/go/0chain.net/miner/chain.go
+++ b/code/go/0chain.net/miner/chain.go
@@ -235,7 +235,7 @@ func (mc *Chain) SetLatestFinalizedBlock(ctx context.Context, b *block.Block) {
 	mr := mc.CreateRound(r)
 	mr = mc.AddRound(mr).(*Round)
 	mc.SetRandomSeed(mr, b.GetRoundRandomSeed())
-	mc.AddRoundBlock(mr, b)
+	b = mc.AddRoundBlock(mr, b)
 	// mr.SetFinalized()
 	mr.Finalize(b)
 	mc.AddNotarizedBlock(mr, b)

--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -569,7 +569,7 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 			return nil, ErrRRSMismatch
 		}
 
-		mc.AddRoundBlock(r, b)
+		b = mc.AddRoundBlock(r, b)
 		if generationTries > 1 {
 			logging.Logger.Info("generate block - multiple tries",
 				zap.Int64("round", b.Round), zap.Int("tries", generationTries))
@@ -584,7 +584,7 @@ func (mc *Chain) generateRoundBlock(ctx context.Context, r *Round) (*block.Block
 		return nil, nil
 	}
 
-	mc.addToRoundVerification(r, b)
+	b = mc.addToRoundVerification(r, b)
 	r.AddProposedBlock(b)
 
 	go mc.SendBlock(ctx, b)
@@ -798,7 +798,7 @@ func (mc *Chain) updatePreviousBlockNotarization(ctx context.Context, b *block.B
 	return nil
 }
 
-func (mc *Chain) addToRoundVerification(mr *Round, b *block.Block) {
+func (mc *Chain) addToRoundVerification(mr *Round, b *block.Block) *block.Block {
 	logging.Logger.Info("adding block to verify",
 		zap.Int64("round", b.Round),
 		zap.String("block", b.Hash),
@@ -806,7 +806,9 @@ func (mc *Chain) addToRoundVerification(mr *Round, b *block.Block) {
 		zap.String("state_hash", util.ToHex(b.ClientStateHash)),
 		zap.Float64("weight", b.Weight()))
 	//mc.StartVerification(ctx, mr)
+	b = mc.AddRoundBlock(mr, b)
 	mr.AddBlockToVerify(b)
+	return b
 }
 
 func (mc *Chain) StartVerification(ctx context.Context, mr *Round) {
@@ -1001,7 +1003,7 @@ func (mc *Chain) CollectBlocksForVerification(ctx context.Context, r *Round) {
 			initiateVerification()
 		case b := <-r.GetBlocksToVerifyChannel():
 			r.AddProposedBlock(b)
-			mc.AddRoundBlock(r, b)
+			b = mc.AddRoundBlock(r, b)
 
 			if sendVerification {
 				// Is this better than the current best block


### PR DESCRIPTION
## Fixes
- There's a bug in local bocks storage. When add a block that has already in the local store, we will return the exist one and apply changes on it, but due to the bug, we are applying changes on the new block instance, so even we computed the block state successfully, the state in the local store would not be updated, therefore, when another thread fetchs the block, it will see its state as not computed yet, and the client state will be nil.
## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
