### PR TITLE
Fix miner panic

### DIFF
--- a/code/go/0chain.net/miner/protocol_round.go
+++ b/code/go/0chain.net/miner/protocol_round.go
@@ -806,7 +806,7 @@ func (mc *Chain) addToRoundVerification(mr *Round, b *block.Block) *block.Block 
 		zap.String("state_hash", util.ToHex(b.ClientStateHash)),
 		zap.Float64("weight", b.Weight()))
 	//mc.StartVerification(ctx, mr)
-	b = mc.AddRoundBlock(mr, b)
+	b = mc.AddBlock(b)
 	mr.AddBlockToVerify(b)
 	return b
 }


### PR DESCRIPTION
Panic when we add block to round before the round has RRS, we should only add the lock to the local store only.

## Fixes

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
