### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/code/go/0chain.net/chaincore/node/node_pool_scorer.go
+++ b/code/go/0chain.net/chaincore/node/node_pool_scorer.go
@@ -96,13 +96,6 @@ func (n *Node) IsInTopWithNodes(nodeScores []*Score, topN int) (bool, []*Node) {
 	return inTop, nodes
 }
 
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 // GetTopNNodes - get the top n nodes from the sorted scores.
 func GetTopNNodes(scores []*Score, topN int) (nodes []*Node) {
 

--- a/code/go/0chain.net/smartcontract/minersc/models.go
+++ b/code/go/0chain.net/smartcontract/minersc/models.go
@@ -442,13 +442,6 @@ func (pn *PhaseNode) Decode(input []byte) error {
 // 	dkgmn.XPercent = gnb.XPercent
 // }
 
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 // The min_n is checked before the calculateTKN call, so, the n >= min_n.
 // The calculateTKN used to set initial T, K, and N.
 // func (dkgmn *DKGMinerNodes) calculateTKN(gn *GlobalNode, n int) {


### PR DESCRIPTION
## Fixes

Use the built-in max/min from the standard library in Go 1.21 to simplify the code.  https://pkg.go.dev/builtin@go1.21.0#max

## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [ ]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
