### PR TITLE
Fix incorrect comment for SetupMagicBlockMapEntity function

### DIFF
--- a/code/go/0chain.net/chaincore/block/magic_block_map_entity.go
+++ b/code/go/0chain.net/chaincore/block/magic_block_map_entity.go
@@ -111,7 +111,7 @@ func (mb *MagicBlockMap) Decode(input []byte) error {
 	return json.Unmarshal(input, mb)
 }
 
-/*SetupTxnSummaryEntity - setup the txn summary entity */
+/*SetupMagicBlockMapEntity - setup the magic block map entity */
 func SetupMagicBlockMapEntity(store datastore.Store) {
 	magicBlockMapEntityMetadata = datastore.MetadataProvider()
 	magicBlockMapEntityMetadata.Name = "magic_block_map"


### PR DESCRIPTION
## Fixes


The comment for the `SetupMagicBlockMapEntity` function was incorrectly labeled as "SetupTxnSummaryEntity" and described setting up a transaction summary entity, which was mismatched with the actual function purpose. 

This change corrects the comment to accurately reflect that the function sets up the magic block map entity.



## Changes

## Need to be mentioned in CHANGELOG.md?

## Tests
Tasks to complete before merging PR:
- [x]  Ensure system tests are passing. If not [Run them manually](https://github.com/0chain/0chain/actions/workflows/system_tests.yml) to check for any regressions :clipboard:
- [ ]  Do any new system tests need added to test this change? do any existing system tests need updated? If so create a PR at [0chain/system_test](https://github.com/0chain/system_test)
- [ ]  Merge your system tests PR to master AFTER merging this PR

## Associated PRs (Link as appropriate):
- blobber:
- gosdk:
- system_test:
- zboxcli:
- zwalletcli:
- Other: ...
